### PR TITLE
Add fields to editable JSON

### DIFF
--- a/scripts/auto_mark_nicholson_step.py
+++ b/scripts/auto_mark_nicholson_step.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Step 4: auto-identify Nicholson segments from WhisperX JSON."""
+import argparse
+from clip_utils import auto_mark_nicholson
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Auto-identify Nicholson segments from JSON")
+    p.add_argument("json", help="WhisperX diarization JSON file")
+    p.add_argument("--out", default="segments_to_keep.json", help="Output JSON file")
+    args = p.parse_args()
+    auto_mark_nicholson(args.json, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/concatenate_clips_step.py
+++ b/scripts/concatenate_clips_step.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Step 6: concatenate clips into a final video."""
+import argparse
+from clip_utils import concatenate_clips
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Concatenate clips into final video")
+    p.add_argument("--clips_dir", default="clips", help="Directory with clip files")
+    p.add_argument("--out", default="final_video.mp4", help="Output video file")
+    args = p.parse_args()
+    concatenate_clips(args.clips_dir, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_marked_step.py
+++ b/scripts/extract_marked_step.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Step 3: parse markup_guide.txt to JSON segments."""
+import argparse
+from clip_utils import extract_marked
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Parse markup_guide.txt to JSON segments")
+    p.add_argument("--markup", default="markup_guide.txt", help="Markup file")
+    p.add_argument("--out", default="segments_to_keep.json", help="Output JSON file")
+    args = p.parse_args()
+    extract_marked(args.markup, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_clips_step.py
+++ b/scripts/generate_clips_step.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Step 5: cut clips from segments_to_keep.json."""
+import argparse
+from clip_utils import generate_clips
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Generate video clips from JSON segments")
+    p.add_argument("--input", default="input.mp4", help="Input video file")
+    p.add_argument("--json", default="segments_to_keep.json", help="Segments JSON file")
+    p.add_argument("--out_dir", default="clips", help="Output directory")
+    args = p.parse_args()
+    generate_clips(args.input, args.json, args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/identify_clips_json_step.py
+++ b/scripts/identify_clips_json_step.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Step 3 alternative: parse ``segments_edit.json`` to ``segments_to_keep.json``."""
+import argparse
+from clip_utils import identify_clips_json
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Parse editable JSON to clip segments")
+    p.add_argument("--json", default="segments_edit.json", help="Editable JSON file")
+    p.add_argument("--out", default="segments_to_keep.json", help="Output JSON")
+    args = p.parse_args()
+    identify_clips_json(args.json, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/identify_clips_step.py
+++ b/scripts/identify_clips_step.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Step 3: convert ``input.tsv`` (edited spreadsheet) to ``segments_to_keep.json``.
+
+Run :mod:`json_to_tsv_step` first to generate the TSV from the transcription
+JSON, mark rows to keep, then run this script.
+"""
+import argparse
+from clip_utils import identify_clips
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Parse TSV to JSON segments")
+    p.add_argument("--tsv", default="input.tsv", help="TSV file")
+    p.add_argument("--out", default="segments_to_keep.json", help="Output JSON file")
+    args = p.parse_args()
+    identify_clips(args.tsv, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/json_to_editable_step.py
+++ b/scripts/json_to_editable_step.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Step 2 alternative: convert WhisperX JSON into ``segments_edit.json``.
+
+Each entry includes ``Timestamp``/``content``/``pre``/``post`` fields and a
+numeric ``id`` along with ``start``/``end``/``speaker`` and ``keep`` flag.
+"""
+import argparse
+from clip_utils import json_to_editable
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Create editable JSON from WhisperX output")
+    p.add_argument("json", help="Input JSON file from WhisperX")
+    p.add_argument("--out", default="segments_edit.json", help="Output editable JSON")
+    args = p.parse_args()
+    json_to_editable(args.json, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/json_to_tsv_step.py
+++ b/scripts/json_to_tsv_step.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Step 2: convert WhisperX JSON to TSV with an empty ``keep`` column."""
+import argparse
+from clip_utils import json_to_tsv
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Create editable TSV from WhisperX JSON")
+    p.add_argument("json", help="Input JSON file from WhisperX")
+    p.add_argument("--out", default="input.tsv", help="Output TSV file")
+    args = p.parse_args()
+    json_to_tsv(args.json, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Orchestrate the video-cutting pipeline.
+
+Steps:
+1. :mod:`transcribe_step` – run WhisperX.
+2. :mod:`json_to_tsv_step` or :mod:`json_to_editable_step` – prepare TSV or
+   JSON for manual editing.
+3. :mod:`identify_clips_step`, :mod:`identify_clips_json_step` or
+   :mod:`extract_marked_step` – create ``segments_to_keep.json``.
+4. :mod:`auto_mark_nicholson_step` – optional auto-detection via diarization.
+5. :mod:`generate_clips_step` – cut clips.
+6. :mod:`concatenate_clips_step` – join clips together.
+"""
+import argparse
+import os
+from transcribe import transcribe
+from clip_utils import (
+    json_to_tsv,
+    json_to_editable,
+    identify_clips,
+    identify_clips_json,
+    extract_marked,
+    auto_mark_nicholson,
+    generate_clips,
+    concatenate_clips,
+)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser("run_pipeline")
+    p.add_argument("--input", default="input.mp4", help="Input video file")
+    p.add_argument("--hf_token", default=os.getenv("HF_TOKEN"), help="Hugging Face token")
+    p.add_argument("--diarize", action="store_true", help="Use speaker diarization")
+    p.add_argument("--tsv", default="input.tsv", help="TSV file for identify_clips")
+    p.add_argument("--json", default=None, help="WhisperX JSON for conversion steps")
+    p.add_argument("--segments", default="segments_to_keep.json", help="JSON segments file")
+    p.add_argument("--clips_dir", default="clips", help="Output clips directory")
+    p.add_argument("--final", default="final_video.mp4", help="Final video filename")
+
+    p.add_argument("--transcribe", action="store_true", help="Run WhisperX transcription")
+    p.add_argument("--json_to_tsv", action="store_true", help="Convert JSON → TSV")
+    p.add_argument(
+        "--json_to_editable",
+        action="store_true",
+        help="Create editable JSON with Timestamp/content/pre/post fields",
+    )
+    p.add_argument("--identify_clips", action="store_true", help="Parse TSV to JSON")
+    p.add_argument("--identify_clips_json", action="store_true", help="Parse editable JSON to segments")
+    p.add_argument("--extract_marked", action="store_true", help="Parse markup guide to JSON")
+    p.add_argument("--auto_mark_nicholson", action="store_true", help="Auto-mark Nicholson segments")
+    p.add_argument("--generate_clips", action="store_true", help="Cut clips from segments JSON")
+    p.add_argument("--concatenate", action="store_true", help="Join clips into final video")
+    p.add_argument("--all", action="store_true", help="Run all steps in order")
+
+    args = p.parse_args()
+
+    def run(cond, func, *f_args):
+        if cond:
+            func(*f_args)
+
+    run(args.transcribe or args.all, transcribe, args.input, args.hf_token, args.diarize)
+    run(args.json_to_tsv or args.all, json_to_tsv, args.json or f"{os.path.splitext(args.input)[0]}.json", args.tsv)
+    run(args.json_to_editable or args.all, json_to_editable, args.json or f"{os.path.splitext(args.input)[0]}.json", "segments_edit.json")
+    run(args.identify_clips or args.all, identify_clips, args.tsv, args.segments)
+    run(args.identify_clips_json or args.all, identify_clips_json, "segments_edit.json", args.segments)
+    run(args.extract_marked or args.all, extract_marked, "markup_guide.txt", args.segments)
+    run(args.auto_mark_nicholson, auto_mark_nicholson, f"{os.path.splitext(args.input)[0]}.json", args.segments)
+    run(args.generate_clips or args.all, generate_clips, args.input, args.segments, args.clips_dir)
+    run(args.concatenate or args.all, concatenate_clips, args.clips_dir, args.final)
+
+    if not any([
+        args.transcribe,
+        args.json_to_tsv,
+        args.json_to_editable,
+        args.identify_clips,
+        args.identify_clips_json,
+        args.extract_marked,
+        args.auto_mark_nicholson,
+        args.generate_clips,
+        args.concatenate,
+        args.all,
+    ]):
+        p.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/transcribe_step.py
+++ b/scripts/transcribe_step.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Step 1: run WhisperX transcription."""
+import argparse
+import os
+from transcribe import transcribe
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Run WhisperX transcription")
+    p.add_argument("--input", default="input.mp4", help="Input video file")
+    p.add_argument("--hf_token", default=os.getenv("HF_TOKEN"), help="Hugging Face token")
+    p.add_argument("--diarize", action="store_true", help="Use speaker diarization")
+    args = p.parse_args()
+    transcribe(args.input, args.hf_token, args.diarize)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand `json_to_editable` so segments include `Timestamp`, `content`, `pre`, `post` and numeric `id`
- document new fields in `json_to_editable_step.py`
- update pipeline wrapper option description

## Testing
- `python3 -m py_compile scripts/*.py clip_utils.py transcribe.py`

------
https://chatgpt.com/codex/tasks/task_e_68408533910c83218fd1666457404d17