### PR TITLE
Fix Nicholson speaker return logic

### DIFF
--- a/auto_segment_nicholson.py
+++ b/auto_segment_nicholson.py
@@ -120,7 +120,6 @@ def find_nicholson_speaker(segments):
             if j < len(segments):
                 candidate = segments[j]["speaker"]
     return candidate
-    return None
 
 
 def main() -> None:

--- a/tests/test_auto_segment_nicholson.py
+++ b/tests/test_auto_segment_nicholson.py
@@ -1,0 +1,14 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from auto_segment_nicholson import find_nicholson_speaker
+
+
+def test_find_nicholson_speaker_none():
+    segments = [
+        {"speaker": "A", "text": "hello"},
+        {"speaker": "B", "text": "how are you"},
+        {"speaker": "A", "text": "thanks"},
+    ]
+    assert find_nicholson_speaker(segments) is None
+


### PR DESCRIPTION
## Summary
- remove unreachable `return None` in `find_nicholson_speaker`
- test that the function returns `None` when no candidate exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841212fcbb083218ccaae2868f8304f