### PR TITLE
Remove TSV workflow references

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ HF_TOKEN=your_hf_token_here
 ## Workflow
 
 1. **Transcribe** – `scripts/transcribe_step.py` runs WhisperX and produces `markup_guide.txt` and the original JSON file.
-2. **Prepare for editing** – use `scripts/json_to_tsv_step.py` to create `input.tsv` or `scripts/json_to_editable_step.py` for `segments_edit.json`.
-3. **Identify clips** – after marking segments to keep, run one of
-   `scripts/identify_clips_step.py`, `scripts/identify_clips_json_step.py` or
+2. **Prepare for editing** – use `scripts/json_to_editable_step.py` to create `segments_edit.json`.
+3. **Identify clips** – after marking segments to keep, run
+   `scripts/identify_clips_json_step.py` or
    `scripts/extract_marked_step.py` to create `segments_to_keep.json`.
 4. **Auto-select Nicholson segments (optional)** – `scripts/auto_mark_nicholson_step.py` examines a diarized JSON file and builds the JSON list for you.
 5. **Generate clips** – `scripts/generate_clips_step.py` cuts clips from the input video into a `clips/` directory.
@@ -43,12 +43,12 @@ All of these steps can be executed sequentially with `scripts/run_pipeline.py --
 # Transcription with diarization
 python3 scripts/transcribe_step.py --input meeting.mp4 --diarize --hf_token $HF_TOKEN
 
-# Convert JSON to TSV for spreadsheet editing
-python3 scripts/json_to_tsv_step.py meeting.json --out input.tsv
-# (edit input.tsv to mark rows to keep)
+# Create an editable JSON
+python3 scripts/json_to_editable_step.py meeting.json --out segments_edit.json
+# (edit segments_edit.json to mark segments to keep)
 
 # Generate the list of segments
-python3 scripts/identify_clips_step.py --tsv input.tsv
+python3 scripts/identify_clips_json_step.py --json segments_edit.json
 
 # Cut clips and assemble the final video
 python3 scripts/generate_clips_step.py --input meeting.mp4 --json segments_to_keep.json

--- a/videocut/cli/steps/run_pipeline.py
+++ b/videocut/cli/steps/run_pipeline.py
@@ -3,9 +3,8 @@
 
 Steps:
 1. :mod:`videocut.cli.steps.transcribe_step` – run WhisperX.
-2. :mod:`videocut.cli.steps.json_to_tsv_step` or :mod:`videocut.cli.steps.json_to_editable_step` – prepare TSV or
-   JSON for manual editing.
-3. :mod:`videocut.cli.steps.identify_clips_step`, :mod:`videocut.cli.steps.identify_clips_json_step` or
+2. :mod:`videocut.cli.steps.json_to_editable_step` – prepare JSON for manual editing.
+3. :mod:`videocut.cli.steps.identify_clips_json_step` or
    :mod:`videocut.cli.steps.extract_marked_step` – create ``segments_to_keep.json``.
 4. :mod:`videocut.cli.steps.auto_mark_nicholson_step` – optional auto-detection via diarization.
 5. :mod:`videocut.cli.steps.generate_clips_step` – cut clips.
@@ -15,7 +14,6 @@ import argparse
 import os
 from videocut.core.transcribe import transcribe
 from videocut.core.clip_utils import (
-    json_to_tsv,
     json_to_editable,
     identify_clips_json,
     extract_marked,


### PR DESCRIPTION
## Summary
- drop json_to_tsv workflow from README
- update pipeline docs and imports to exclude json_to_tsv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841323e2dfc83218e408b9e7f2b77b4