### PR TITLE
docs: clarify purpose of minimal requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+If you already have transcripts and want to skip WhisperX's heavy install,
+install only the lightweight dependencies instead:
+
+```bash
+pip install -r no_transcribe_requirements.txt
+```
+
 Verify the CLI loads properly:
 
 ```bash


### PR DESCRIPTION
## Summary
- mention `no_transcribe_requirements.txt` in README so users can skip WhisperX install

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a7576e7c8321b225d6174d465bf3