### PR TITLE
Fix CLI import error and restore transcribe command

### DIFF
--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -17,6 +17,7 @@ app = typer.Typer(help="VideoCut pipeline")
 @app.command()
 def transcribe(video: str = "input.mp4", diarize: bool = False, hf_token: str | None = None):
     """Run WhisperX transcription."""
+    transcription.transcribe(video, hf_token, diarize)
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- remove empty `videocut/cli` package so `videocut.cli` resolves to the CLI module
- restore `transcribe` command to invoke transcription

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a84281488321b539fa350cf85f7e