### PR TITLE
Fix Typer compatibility with Python 3.12

### DIFF
--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -1,6 +1,7 @@
 """Typer-based command line interface for VideoCut."""
 from __future__ import annotations
 from pathlib import Path
+from typing import Optional
 import typer
 from .core import (
     transcription,
@@ -15,7 +16,7 @@ app = typer.Typer(help="VideoCut pipeline")
 
 
 @app.command()
-def transcribe(video: str = "input.mp4", diarize: bool = False, hf_token: str | None = None):
+def transcribe(video: str = "input.mp4", diarize: bool = False, hf_token: Optional[str] = None):
     """Run WhisperX transcription."""
     transcription.transcribe(video, hf_token, diarize)
 
@@ -71,7 +72,7 @@ def concatenate(clips_dir: str = "clips", out: str = "final_video.mp4"):
 def pipeline(
     video: str = "input.mp4",
     diarize: bool = False,
-    hf_token: str | None = None,
+    hf_token: Optional[str] = None,
     auto_nicholson: bool = True,
 ):
     """Run the full pipeline, auto-marking Nicholson by default."""


### PR DESCRIPTION
## Summary
- update CLI to use `Optional[str]` type hints
- update imports accordingly

## Testing
- `pip install -q -r no_transcribe_requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a9559b7c8321b613f1640012e54c