### PR TITLE
Ignore Python warnings in transcription

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,7 +17,7 @@ def test_transcribe_creates_markup(tmp_path, monkeypatch):
 
     calls = {}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, env=None):
         calls["cmd"] = cmd
         json_out.write_text(json.dumps({"segments": [{"start": 0, "end": 1, "text": "hi"}]}))
         return SimpleNamespace(returncode=0)
@@ -39,7 +39,7 @@ def test_generate_clips_invokes_ffmpeg(tmp_path, monkeypatch):
 
     calls = {"run": [], "build": []}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, env=None):
         calls["run"].append(cmd)
         Path(cmd[-1]).write_text("tmp")
 

--- a/videocut/core/transcription.py
+++ b/videocut/core/transcription.py
@@ -4,6 +4,7 @@ import json
 import platform
 import subprocess
 import sys
+import os
 from pathlib import Path
 from dotenv import load_dotenv
 
@@ -39,7 +40,9 @@ def transcribe(
         cmd += ["--diarize", "--hf_token", hf_token]
 
     print("🧠  WhisperX …")
-    subprocess.run(cmd, check=True)
+    env = os.environ.copy()
+    env.setdefault("PYTHONWARNINGS", "ignore")
+    subprocess.run(cmd, check=True, env=env)
     if not Path(out_json).exists():
         sys.exit(f"❌  Expected {out_json} not produced")
 


### PR DESCRIPTION
## Summary
- prevent display of local paths during transcription by ignoring warnings
- adjust tests for new subprocess signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684378afd10883219c20e6f8b03141d7