### PR TITLE
Improve recognition heuristics for chair cues

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,33 @@ HF_TOKEN=your_hf_token_here
 
 All of these steps can be executed sequentially with `videocut pipeline input.mp4 --diarize --hf_token $HF_TOKEN` which auto‑marks Nicholson by default.
 
+### Automatic speaker identification
+
+When diarization is enabled, VideoCut scans the transcript for recognition cues
+such as "Director Doe you're recognized" or simply "You're recognized" when the
+chair has just mentioned a name.  The following speaker is automatically mapped
+to that name and the results are written to `recognized_map.json`.  The
+`identify-recognized` command can be run manually if needed:
+
+```bash
+videocut identify-recognized input.json
+```
+
+The pipeline command performs this detection automatically and prints a warning
+if no recognition cues are found.
+
+For multiple people you can supply a phrase map to `identify-speakers`:
+
+```bash
+videocut identify-speakers input.json phrase_map.json
+```
+
+The resulting `speaker_map.json` can then be applied back to the transcript:
+
+```bash
+videocut apply-speaker-labels input.json speaker_map.json --out labeled.json
+```
+
 ### Example commands
 
 ```bash

--- a/tests/test_pipeline_recognition.py
+++ b/tests/test_pipeline_recognition.py
@@ -1,0 +1,59 @@
+import os, sys, json
+import pathlib
+import importlib.util
+
+_cli_path = pathlib.Path(__file__).resolve().parents[1] / "videocut" / "cli.py"
+_spec = importlib.util.spec_from_file_location("videocut.cli", _cli_path)
+videocut_cli = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = videocut_cli
+_spec.loader.exec_module(videocut_cli)
+
+import videocut.core.transcription as transcribe_mod
+import videocut.core.nicholson as nicholson_mod
+import videocut.core.video_editing as video_editing
+
+
+def test_pipeline_recognition(tmp_path, monkeypatch):
+    json_file = tmp_path / "input.json"
+
+    def fake_transcribe(video, hf_token, diarize):
+        json_file.write_text(json.dumps({
+            "segments": [
+                {"speaker": "A", "text": "director doe you're recognized"},
+                {"speaker": "B", "text": "hi"},
+            ]
+        }))
+
+    monkeypatch.setattr(transcribe_mod, "transcribe", fake_transcribe)
+
+    called = {}
+
+    def fake_auto_mark(jf, out):
+        called["auto_mark"] = True
+        pathlib.Path(out).write_text("[]")
+
+    monkeypatch.setattr(nicholson_mod, "auto_mark_nicholson", fake_auto_mark)
+
+    def fake_generate(video, segs, out_dir):
+        called["clips"] = True
+
+    monkeypatch.setattr(video_editing, "generate_clips", fake_generate)
+    monkeypatch.setattr(video_editing, "concatenate_clips", lambda a, b: called.setdefault("concat", True))
+
+    def fake_map(jf):
+        called["map"] = jf
+        return {"Doe": "B"}
+
+    monkeypatch.setattr(nicholson_mod, "map_recognized_auto", fake_map)
+
+    monkeypatch.chdir(tmp_path)
+
+    videocut_cli.pipeline(
+        video="input.mp4",
+        diarize=True,
+        hf_token="tok",
+        auto_nicholson=True,
+    )
+
+    assert called.get("map")
+    assert json.loads(pathlib.Path("recognized_map.json").read_text()) == {"Doe": "B"}

--- a/tests/test_speaker_mapping.py
+++ b/tests/test_speaker_mapping.py
@@ -1,0 +1,112 @@
+import os, sys, json
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pathlib
+import importlib.util
+import videocut.core.nicholson as nicholson
+
+_cli_path = pathlib.Path(__file__).resolve().parents[1] / "videocut" / "cli.py"
+_spec = importlib.util.spec_from_file_location("videocut.cli", _cli_path)
+videocut_cli = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = videocut_cli
+_spec.loader.exec_module(videocut_cli)
+
+
+def sample_data(tmp_path):
+    diarized = tmp_path / "dia.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "A", "text": "hello secretary nicholson"},
+            {"speaker": "B", "text": "other"},
+            {"speaker": "B", "text": "mr doe reports"},
+            {"speaker": "A", "text": "thanks"},
+        ]
+    }))
+    mapping = tmp_path / "map.json"
+    mapping.write_text(json.dumps({
+        "Nicholson": ["secretary nicholson"],
+        "Doe": ["mr doe"],
+    }))
+    return diarized, mapping
+
+
+def test_map_speaker_by_phrases(tmp_path):
+    diarized, mapping = sample_data(tmp_path)
+    result = nicholson.map_speaker_by_phrases(str(diarized), json.loads(mapping.read_text()))
+    assert result == {"Nicholson": "A", "Doe": "B"}
+
+
+def test_identify_speakers_cli(tmp_path):
+    diarized, mapping = sample_data(tmp_path)
+    out = tmp_path / "ids.json"
+    videocut_cli.identify_speakers(diarized_json=str(diarized), mapping=str(mapping), out=str(out))
+    assert json.loads(out.read_text()) == {"Nicholson": "A", "Doe": "B"}
+
+
+def sample_recog_data(tmp_path):
+    diarized = tmp_path / "dia.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "A", "text": "director doe you're recognized"},
+            {"speaker": "B", "text": "hello"},
+            {"speaker": "A", "text": "director roe you're recognized"},
+            {"speaker": "C", "text": "thanks"},
+        ]
+    }))
+    return diarized
+
+
+def sample_recog_no_name(tmp_path):
+    diarized = tmp_path / "dia2.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "X", "text": "director smith."},
+            {"speaker": "X", "text": "you're recognized"},
+            {"speaker": "A", "text": "thanks"},
+            {"speaker": "X", "text": "Director Jones"},
+            {"speaker": "X", "text": "you are recognized"},
+            {"speaker": "B", "text": "hello"},
+        ]
+    }))
+    return diarized
+
+
+def test_map_recognized_auto(tmp_path):
+    diarized = sample_recog_data(tmp_path)
+    ids = nicholson.map_recognized_auto(str(diarized))
+    assert ids == {"Doe": "B", "Roe": "C"}
+
+
+def test_identify_recognized_cli(tmp_path):
+    diarized = sample_recog_data(tmp_path)
+    out = tmp_path / "rec.json.out"
+    videocut_cli.identify_recognized(diarized_json=str(diarized), out=str(out))
+    assert json.loads(out.read_text()) == {"Doe": "B", "Roe": "C"}
+
+
+def test_map_recognized_auto_context(tmp_path):
+    diarized = sample_recog_no_name(tmp_path)
+    ids = nicholson.map_recognized_auto(str(diarized))
+    assert ids == {"Smith": "A", "Jones": "B"}
+
+
+def test_add_speaker_labels(tmp_path):
+    diarized, mapping = sample_data(tmp_path)
+    ids = {"Nicholson": "A", "Doe": "B"}
+    out = tmp_path / "lab.json"
+    nicholson.add_speaker_labels(str(diarized), ids, str(out))
+    data = json.loads(out.read_text())
+    labels = [seg.get("label") for seg in data["segments"]]
+    assert labels == ["Nicholson", "Doe", "Doe", "Nicholson"]
+
+
+def test_apply_speaker_labels_cli(tmp_path):
+    diarized, _ = sample_data(tmp_path)
+    ids = {"Nicholson": "A", "Doe": "B"}
+    map_file = tmp_path / "ids.json"
+    map_file.write_text(json.dumps(ids))
+    out = tmp_path / "lab_cli.json"
+    videocut_cli.apply_speaker_labels(diarized_json=str(diarized), map_json=str(map_file), out=str(out))
+    data = json.loads(out.read_text())
+    assert data["segments"][0]["label"] == "Nicholson"
+    assert data["segments"][1]["label"] == "Doe"

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Optional
+import json
 import typer
 from .core import (
     transcription,
@@ -67,6 +68,41 @@ def auto_mark_nicholson(json_file: str, out: str = "segments_to_keep.json"):
 
 
 @app.command()
+def identify_speakers(
+    diarized_json: str,
+    mapping: str,
+    out: str = "speaker_map.json",
+):
+    """Map named people to diarized speaker IDs based on key phrases."""
+    phrase_map = json.loads(Path(mapping).read_text())
+    ids = nicholson.map_speaker_by_phrases(diarized_json, phrase_map)
+    Path(out).write_text(json.dumps(ids, indent=2))
+    print(f"✅  speaker map → {out}")
+
+
+@app.command()
+def identify_recognized(
+    diarized_json: str,
+    out: str = "recognized_map.json",
+):
+    """Automatically map recognized names to speaker IDs."""
+    ids = nicholson.map_recognized_auto(diarized_json)
+    Path(out).write_text(json.dumps(ids, indent=2))
+    print(f"✅  recognized map → {out}")
+
+
+@app.command()
+def apply_speaker_labels(
+    diarized_json: str,
+    map_json: str,
+    out: str = "labeled.json",
+):
+    """Write a copy of diarized_json with speaker names in a 'label' field."""
+    mapping = json.loads(Path(map_json).read_text())
+    nicholson.add_speaker_labels(diarized_json, mapping, out)
+
+
+@app.command()
 def generate_clips(
     video: str = typer.Argument("input.mp4", help="Source video"),
     segs: str = typer.Option("segments_to_keep.json", help="Segments JSON"),
@@ -90,6 +126,15 @@ def pipeline(
     """Run the full pipeline, auto-marking Nicholson by default."""
     transcription.transcribe(video, hf_token, diarize)
     json_file = f"{Path(video).stem}.json"
+
+    if diarize:
+        try:
+            ids = nicholson.map_recognized_auto(json_file)
+            Path("recognized_map.json").write_text(json.dumps(ids, indent=2))
+            print("✅  recognized map → recognized_map.json")
+        except Exception as exc:
+            print(f"⚠️  automatic recognition failed: {exc}")
+
     if auto_nicholson:
         nicholson.auto_mark_nicholson(json_file, "segments_to_keep.json")
     else:

--- a/videocut/core/nicholson.py
+++ b/videocut/core/nicholson.py
@@ -41,6 +41,227 @@ def map_nicholson_speaker(diarized_json: str) -> str:
     return best
 
 
+def map_speaker_by_phrases(diarized_json: str, phrase_map: Dict[str, List[str]]) -> Dict[str, str]:
+    """Return WhisperX speaker IDs for each name in *phrase_map*.
+
+    The *phrase_map* argument maps a display name to one or more key phrases
+    uniquely spoken by that person. Each speaker ID is chosen by counting which
+    diarized speaker label says the most of that person's phrases, following the
+    same strategy as :func:`map_nicholson_speaker`.
+    """
+
+    data = json.loads(Path(diarized_json).read_text())
+    segments = data["segments"]
+    result: Dict[str, str] = {}
+
+    for name, phrases in phrase_map.items():
+        counts: Dict[str, int] = {}
+        phr_lower = [p.lower() for p in phrases]
+        for seg in segments:
+            spk = seg.get("speaker")
+            if not spk:
+                continue
+            text_l = seg.get("text", "").lower()
+            if any(p in text_l for p in phr_lower):
+                counts[spk] = counts.get(spk, 0) + 1
+        if not counts:
+            raise RuntimeError(
+                f"Phrases for {name} not found – update key phrases or re-check diarization."
+            )
+        best = max(counts, key=counts.get)
+        print(f"🔍  Identified {name} as {best} (matches={counts[best]})")
+        result[name] = best
+
+    return result
+
+
+def map_recognized_speakers(
+    diarized_json: str,
+    chair_id: str,
+    recognition_map: Dict[str, List[str]],
+) -> Dict[str, str]:
+    """Return speaker IDs for names the chair recognizes.
+
+    Each entry in *recognition_map* maps a person's name to phrases that appear
+    in the chair's dialog when they are recognized. The diarized speaker who
+    talks next after such a phrase is counted as that person, and the speaker ID
+    with the most counts for each name is returned.
+    """
+
+    data = json.loads(Path(diarized_json).read_text())
+    segments = data["segments"]
+    counts: Dict[str, Dict[str, int]] = {name: {} for name in recognition_map}
+
+    for i, seg in enumerate(segments):
+        if seg.get("speaker") != chair_id:
+            continue
+        text_l = seg.get("text", "").lower()
+        for name, phrases in recognition_map.items():
+            if any(p.lower() in text_l for p in phrases):
+                j = i + 1
+                while j < len(segments) and segments[j].get("speaker") == chair_id:
+                    j += 1
+                if j < len(segments):
+                    spk = segments[j].get("speaker")
+                    sub = counts[name]
+                    sub[spk] = sub.get(spk, 0) + 1
+                break
+
+    result: Dict[str, str] = {}
+    for name, spk_counts in counts.items():
+        if not spk_counts:
+            raise RuntimeError(
+                f"Recognition phrases for {name} not found – update key phrases or re-check diarization."
+            )
+        best = max(spk_counts, key=spk_counts.get)
+        print(f"🔍  Recognized {name} as {best} (matches={spk_counts[best]})")
+        result[name] = best
+
+    return result
+
+
+_AUTO_RECOG_RE = re.compile(
+    r"(?i:(?:director|secretary|chair|treasurer|mr|ms|mrs))\.?\s*(?P<name>[a-zA-Z]+(?: [a-zA-Z]+)*)\s+(?:you(?:'re| are)|is) recognized",
+)
+
+# "You're recognized" without a name
+_RECOG_SIMPLE_RE = re.compile(r"you(?:'re| are) recognized", re.IGNORECASE)
+
+# Name mentioned before a recognition cue
+_NAME_BEFORE_RE = re.compile(
+    r"(?i:(?:director|secretary|chair|treasurer|mr|ms|mrs))\.?\s+(?P<name>[A-Za-z]+(?: [A-Za-z]+)?)\b",
+)
+
+# Chair mentions without a recognition phrase
+_NAME_MENTION_RE = _NAME_BEFORE_RE
+
+
+def map_recognized_auto(diarized_json: str) -> Dict[str, str]:
+    """Infer recognized speakers directly from diarized text.
+
+    The function searches for phrases such as "director Doe you're recognized".
+    The next speaker after the phrase is counted as the recognized person. The
+    most frequent speaker ID for each detected name is returned.
+    """
+
+    data = json.loads(Path(diarized_json).read_text())
+    segments = data["segments"]
+
+    chair_counts: Dict[str, int] = {}
+    for seg in segments:
+        spk = seg.get("speaker")
+        if not spk:
+            continue
+        text = seg.get("text", "")
+        if _RECOG_SIMPLE_RE.search(text) or _NAME_MENTION_RE.search(text):
+            chair_counts[spk] = chair_counts.get(spk, 0) + 1
+
+    if not chair_counts:
+        raise RuntimeError("Unable to detect chair from transcript")
+
+    chair_id = max(chair_counts, key=chair_counts.get)
+
+    counts: Dict[str, Dict[str, int]] = {}
+
+    for i, seg in enumerate(segments):
+        if seg.get("speaker") != chair_id:
+            continue
+
+        text = seg.get("text", "")
+        name = None
+
+        m = _AUTO_RECOG_RE.search(text)
+        if m:
+            name = m.group("name").title()
+        elif _RECOG_SIMPLE_RE.search(text):
+            back_text = []
+            j = i - 1
+            while j >= 0 and len(back_text) < 3 and segments[j].get("speaker") == chair_id:
+                back_text.insert(0, segments[j].get("text", ""))
+                j -= 1
+            joined = " ".join(back_text)
+            matches = list(_NAME_MENTION_RE.finditer(joined))
+            if matches:
+                raw = matches[-1].group("name")
+                parts = raw.split()
+                if (
+                    raw[0].isalpha()
+                    and len(raw) > 1
+                    and parts[0].lower() not in {"on", "at", "any", "the"}
+                    and not (
+                        len(parts) > 1 and parts[1].lower() in {"and", "as", "is", "would", "the", "or"}
+                    )
+                ):
+                    if len(parts) == 2 and not parts[1][0].isupper():
+                        pass
+                    else:
+                        name = raw.title()
+        else:
+            m2 = _NAME_MENTION_RE.search(text)
+            if m2:
+                raw = m2.group("name")
+                parts = raw.split()
+                if (
+                    raw[0].isalpha()
+                    and len(raw) > 1
+                    and parts[0].lower() not in {"on", "at", "any", "the"}
+                    and not (
+                        len(parts) > 1 and parts[1].lower() in {"and", "as", "is", "would", "the", "or"}
+                    )
+                ):
+                    if len(parts) == 2 and not parts[1][0].isupper():
+                        pass
+                    else:
+                        name = raw.title()
+
+        if not name:
+            continue
+
+        j = i + 1
+        while j < len(segments) and segments[j].get("speaker") == chair_id:
+            j += 1
+        if j < len(segments):
+            spk = segments[j].get("speaker")
+            if spk:
+                sub = counts.setdefault(name, {})
+                sub[spk] = sub.get(spk, 0) + 1
+
+    if not counts:
+        raise RuntimeError("No recognition cues found – unable to map speakers.")
+
+    result: Dict[str, str] = {}
+    for name, spk_counts in counts.items():
+        best = max(spk_counts, key=spk_counts.get)
+        print(f"🔍  Recognized {name} as {best} (matches={spk_counts[best]})")
+        result[name] = best
+
+    return result
+
+
+def add_speaker_labels(
+    diarized_json: str,
+    id_map: Dict[str, str],
+    out_json: str = "labeled.json",
+) -> None:
+    """Write a copy of *diarized_json* with name labels added.
+
+    The *id_map* argument maps display names to WhisperX speaker IDs. Each
+    segment whose ``speaker`` matches an ID gets a ``label`` field with the
+    corresponding name.
+    """
+
+    data = json.loads(Path(diarized_json).read_text())
+    segments = data["segments"]
+    inv = {v: k for k, v in id_map.items()}
+    for seg in segments:
+        spk = seg.get("speaker")
+        name = inv.get(spk)
+        if name:
+            seg["label"] = name
+    Path(out_json).write_text(json.dumps(data, indent=2))
+    print(f"✅  labels added → {out_json}")
+
+
 def auto_segments_for_speaker(diarized_json: str, speaker_id: str, out_json: str = "segments_to_keep.json") -> None:
     """Dump every segment spoken by *speaker_id* into JSON."""
     data = json.loads(Path(diarized_json).read_text())
@@ -199,6 +420,10 @@ def segment_nicholson(diarized_json: str, out_json: str = "segments_to_keep.json
 
 __all__ = [
     "map_nicholson_speaker",
+    "map_speaker_by_phrases",
+    "map_recognized_speakers",
+    "map_recognized_auto",
+    "add_speaker_labels",
     "auto_segments_for_speaker",
     "auto_mark_nicholson",
     "find_nicholson_speaker",


### PR DESCRIPTION
## Summary
- refine `_NAME_*` regex to avoid mis-matching phrases
- infer chair automatically and scan their segments for mentions
- filter spurious names when mapping recognized speakers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68435eb3fe288321b89038ddb75bd6e8