### PR TITLE
Improve recognition heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All of these steps can be executed sequentially with `videocut pipeline input.mp
 
 When diarization is enabled, VideoCut scans the transcript for recognition cues
 such as "Director Doe you're recognized" or simply "You're recognized" when the
-chair has just mentioned a name.  The following speaker is automatically mapped
+chair has just mentioned a name.  Short lines that end with just "Director Name" or phrases like "yield the floor to Director Name" are also detected.  The following speaker is automatically mapped
 to that name and the results are written to `recognized_map.json`.  The
 `identify-recognized` command can be run manually if needed:
 

--- a/tests/test_speaker_mapping.py
+++ b/tests/test_speaker_mapping.py
@@ -71,6 +71,21 @@ def sample_recog_no_name(tmp_path):
     return diarized
 
 
+def sample_recog_extra(tmp_path):
+    diarized = tmp_path / "dia3.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "X", "text": "Director Lee"},
+            {"speaker": "A", "text": "hello"},
+            {"speaker": "X", "text": "I yield the floor to Ms. Kim"},
+            {"speaker": "B", "text": "thanks"},
+            {"speaker": "X", "text": "call on Mr. Park"},
+            {"speaker": "C", "text": "hi"},
+        ]
+    }))
+    return diarized
+
+
 def test_map_recognized_auto(tmp_path):
     diarized = sample_recog_data(tmp_path)
     ids = nicholson.map_recognized_auto(str(diarized))
@@ -88,6 +103,12 @@ def test_map_recognized_auto_context(tmp_path):
     diarized = sample_recog_no_name(tmp_path)
     ids = nicholson.map_recognized_auto(str(diarized))
     assert ids == {"Smith": "A", "Jones": "B"}
+
+
+def test_map_recognized_auto_extra(tmp_path):
+    diarized = sample_recog_extra(tmp_path)
+    ids = nicholson.map_recognized_auto(str(diarized))
+    assert ids == {"Lee": "A", "Kim": "B", "Park": "C"}
 
 
 def test_add_speaker_labels(tmp_path):

--- a/videocut/core/nicholson.py
+++ b/videocut/core/nicholson.py
@@ -156,6 +156,19 @@ _NAME_BEFORE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Short statement that is just a titled name
+_NAME_ONLY_RE = re.compile(
+    r"^(?:director|secretary|chair|treasurer|mr|ms|mrs|dr)\.?\s+(?P<name>[A-Za-z]+(?: [A-Za-z]+)*)[.,?]*$",
+    re.IGNORECASE,
+)
+
+# Yield or call on someone to speak
+_YIELD_RE = re.compile(
+    r"(?:yield|offer) (?:the )?floor to (?:director|secretary|chair|treasurer|mr|ms|mrs|dr)\.?\s*(?P<name>[A-Za-z]+(?: [A-Za-z]+)*)"
+    r"|call(?:ing)? on (?:director|secretary|chair|treasurer|mr|ms|mrs|dr)\.?\s*(?P<name2>[A-Za-z]+(?: [A-Za-z]+)*)",
+    re.IGNORECASE,
+)
+
 
 def map_recognized_auto(diarized_json: str) -> Dict[str, str]:
     """Infer recognized speakers directly from diarized text.
@@ -189,6 +202,14 @@ def map_recognized_auto(diarized_json: str) -> Dict[str, str]:
             matches = list(_NAME_BEFORE_RE.finditer(joined))
             if matches:
                 name = matches[-1].group("name").title()
+        else:
+            m2 = _NAME_ONLY_RE.match(text_l)
+            if m2:
+                name = m2.group("name").title()
+            else:
+                m3 = _YIELD_RE.search(text_l)
+                if m3:
+                    name = (m3.group("name") or m3.group("name2")).title()
         if not name:
             continue
         j = i + 1


### PR DESCRIPTION
## Summary
- broaden `map_recognized_auto` with `_NAME_ONLY_RE` and `_YIELD_RE`
- detect short name-only or yield statements
- document automatic speaker heuristics
- cover new patterns in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845047c6a8483219a62874a4559ff32