### PR TITLE
Fix recognized speaker mapping orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All of these steps can be executed sequentially with `videocut pipeline input.mp
 When diarization is enabled, VideoCut scans the transcript for recognition cues
 such as "Director Doe you're recognized" or simply "You're recognized" when the
 chair has just mentioned a name.  Short lines that end with just "Director Name" or phrases like "yield the floor to Director Name" are also detected.  The following speaker is automatically mapped
-to that name and the results are written to `recognized_map.json`.  The
+to a name and the results are written to `recognized_map.json`, mapping each diarized speaker ID to its most likely name and any alternatives.  The
 `identify-recognized` command can be run manually if needed:
 
 ```bash

--- a/tests/test_pipeline_recognition.py
+++ b/tests/test_pipeline_recognition.py
@@ -42,7 +42,7 @@ def test_pipeline_recognition(tmp_path, monkeypatch):
 
     def fake_map(jf):
         called["map"] = jf
-        return {"Doe": "B"}
+        return {"B": {"name": "Doe", "alternatives": []}}
 
     monkeypatch.setattr(nicholson_mod, "map_recognized_auto", fake_map)
 
@@ -56,4 +56,6 @@ def test_pipeline_recognition(tmp_path, monkeypatch):
     )
 
     assert called.get("map")
-    assert json.loads(pathlib.Path("recognized_map.json").read_text()) == {"Doe": "B"}
+    assert json.loads(pathlib.Path("recognized_map.json").read_text()) == {
+        "B": {"name": "Doe", "alternatives": []}
+    }

--- a/tests/test_speaker_mapping.py
+++ b/tests/test_speaker_mapping.py
@@ -89,26 +89,39 @@ def sample_recog_extra(tmp_path):
 def test_map_recognized_auto(tmp_path):
     diarized = sample_recog_data(tmp_path)
     ids = nicholson.map_recognized_auto(str(diarized))
-    assert ids == {"Doe": "B", "Roe": "C"}
+    assert ids == {
+        "B": {"name": "Doe", "alternatives": []},
+        "C": {"name": "Roe", "alternatives": []},
+    }
 
 
 def test_identify_recognized_cli(tmp_path):
     diarized = sample_recog_data(tmp_path)
     out = tmp_path / "rec.json.out"
     videocut_cli.identify_recognized(diarized_json=str(diarized), out=str(out))
-    assert json.loads(out.read_text()) == {"Doe": "B", "Roe": "C"}
+    assert json.loads(out.read_text()) == {
+        "B": {"name": "Doe", "alternatives": []},
+        "C": {"name": "Roe", "alternatives": []},
+    }
 
 
 def test_map_recognized_auto_context(tmp_path):
     diarized = sample_recog_no_name(tmp_path)
     ids = nicholson.map_recognized_auto(str(diarized))
-    assert ids == {"Smith": "A", "Jones": "B"}
+    assert ids == {
+        "A": {"name": "Smith", "alternatives": []},
+        "B": {"name": "Jones", "alternatives": []},
+    }
 
 
 def test_map_recognized_auto_extra(tmp_path):
     diarized = sample_recog_extra(tmp_path)
     ids = nicholson.map_recognized_auto(str(diarized))
-    assert ids == {"Lee": "A", "Kim": "B", "Park": "C"}
+    assert ids == {
+        "A": {"name": "Lee", "alternatives": []},
+        "B": {"name": "Kim", "alternatives": []},
+        "C": {"name": "Park", "alternatives": []},
+    }
 
 
 def test_add_speaker_labels(tmp_path):


### PR DESCRIPTION
## Summary
- map recognized speakers per diarized ID in nicholson helper
- adapt CLI usage description
- update tests for new mapping structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684517aa7ee48321a5d0208845b71205