### PR TITLE
Implement chair detection and roll call mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,19 @@ videocut identify-speakers input.json phrase_map.json
 The resulting `speaker_map.json` can then be applied back to the transcript:
 
 ```bash
+
 videocut apply-speaker-labels input.json speaker_map.json --out labeled.json
+```
+
+### Chair identification and roll call
+
+When a meeting transcript includes a roll call vote, the speaker who announces
+"call the roll" is treated as the chair. Names read during the roll call are
+paired with the voices that respond "present" or "here" so diarization can be
+validated. The mapping of names to speaker labels can be extracted with:
+
+```bash
+videocut identify-chair input.json
 ```
 
 ### Example commands

--- a/specification.md
+++ b/specification.md
@@ -52,6 +52,14 @@ These utilities convert transcripts, identify clips, generate clips, and concate
 
 Functions for automatically determining which segments belong to Secretary Nicholson when diarization data is available. Heuristics group nearby segments, trim unrelated portions, and attach context lines before and after each segment. Results are saved as a list of objects with `start`, `end`, `text`, `pre`, and `post` keys.
 
+### Chair detection and roll call mapping
+
+The roll call portion of a meeting identifies the chair and validates speaker
+labels. When the transcript contains a phrase like "call the roll," the speaker
+issuing that line is considered the chair. Each name read during the roll call
+is paired with the responding speaker who says "present" or "here." This mapping
+is returned for downstream validation.
+
 ### Additional utilities
 
 - Insert `{START}`/`{END}` markers into `markup_with_markers.txt` for the segments in `segments_to_keep.json`.

--- a/tests/test_chair_rollcall.py
+++ b/tests/test_chair_rollcall.py
@@ -1,0 +1,30 @@
+import os, sys, json
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from videocut.core import chair
+
+
+def sample_roll_call(tmp_path):
+    diarized = tmp_path / "dia.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "A", "text": "welcome"},
+            {"speaker": "A", "text": "I will now call the roll"},
+            {"speaker": "A", "text": "Director Doe"},
+            {"speaker": "B", "text": "Present"},
+            {"speaker": "A", "text": "Director Roe"},
+            {"speaker": "C", "text": "Here"},
+        ]
+    }))
+    return diarized
+
+
+def test_identify_chair(tmp_path):
+    diarized = sample_roll_call(tmp_path)
+    assert chair.identify_chair(str(diarized)) == "A"
+
+
+def test_parse_roll_call(tmp_path):
+    diarized = sample_roll_call(tmp_path)
+    votes = chair.parse_roll_call(str(diarized))
+    assert votes == {"Doe": "B", "Roe": "C"}

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -12,6 +12,7 @@ from .core import (
     annotation,
     clip_transcripts,
     speaker_mapping,
+    chair,
 )
 
 app = typer.Typer(help="VideoCut pipeline")
@@ -103,6 +104,19 @@ def identify_recognized(
     ids = nicholson.map_recognized_auto(diarized_json)
     Path(out).write_text(json.dumps(ids, indent=2))
     print(f"✅  recognized map → {out}")
+
+
+@app.command()
+def identify_chair(
+    diarized_json: str,
+    out: str = "roll_call_map.json",
+):
+    """Detect the chair and parse roll call responses."""
+    chair_id = chair.identify_chair(diarized_json)
+    votes = chair.parse_roll_call(diarized_json)
+    Path(out).write_text(json.dumps(votes, indent=2))
+    print(f"🔍  chair is {chair_id}")
+    print(f"✅  roll call map → {out}")
 
 
 @app.command()

--- a/videocut/core/__init__.py
+++ b/videocut/core/__init__.py
@@ -8,6 +8,7 @@ from . import (
     annotation,
     clip_transcripts,
     speaker_mapping,
+    chair,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "video_editing",
     "nicholson",
     "speaker_mapping",
+    "chair",
 ]

--- a/videocut/core/chair.py
+++ b/videocut/core/chair.py
@@ -1,0 +1,59 @@
+import json
+import re
+from pathlib import Path
+from typing import Dict
+
+# Regex to detect a roll call announcement
+_ROLL_RE = re.compile(r"roll call|call the roll", re.IGNORECASE)
+# Regex to extract names announced during roll call
+_NAME_RE = re.compile(
+    r"(?:director|secretary|treasurer|chair(?:man)?|vice chair)\s+(?P<name>[A-Za-z]+(?: [A-Za-z]+)*)",
+    re.IGNORECASE,
+)
+_PRESENT_RE = re.compile(r"\b(present|here)\b", re.IGNORECASE)
+
+__all__ = ["identify_chair", "parse_roll_call"]
+
+def identify_chair(diarized_json: str) -> str:
+    """Return the diarized speaker ID who calls the roll."""
+    data = json.loads(Path(diarized_json).read_text())
+    for seg in data.get("segments", []):
+        if _ROLL_RE.search(seg.get("text", "")):
+            return seg.get("speaker")
+    raise RuntimeError("No roll call detected – unable to identify chair")
+
+
+def parse_roll_call(diarized_json: str) -> Dict[str, str]:
+    """Return mapping of names to diarized speaker IDs from the roll call."""
+    data = json.loads(Path(diarized_json).read_text())
+    segments = data.get("segments", [])
+    votes: Dict[str, str] = {}
+    chair_id = None
+    i = 0
+    # locate roll call
+    while i < len(segments):
+        if _ROLL_RE.search(segments[i].get("text", "")):
+            chair_id = segments[i].get("speaker")
+            i += 1
+            break
+        i += 1
+    if chair_id is None:
+        raise RuntimeError("No roll call found")
+    # parse name / response pairs
+    while i < len(segments):
+        text = segments[i].get("text", "")
+        m = _NAME_RE.search(text)
+        if m:
+            name = m.group("name").title()
+            j = i + 1
+            # skip chair's own segments
+            while j < len(segments) and segments[j].get("speaker") == chair_id:
+                j += 1
+            if j < len(segments) and _PRESENT_RE.search(segments[j].get("text", "")):
+                votes[name] = segments[j].get("speaker")
+            i = j
+            continue
+        elif _ROLL_RE.search(text):
+            break
+        i += 1
+    return votes


### PR DESCRIPTION
## Summary
- add `chair` module with chair/roll call helpers
- expose new module through package and CLI command
- document chair detection in README and specification
- add tests for chair detection and roll call parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451aa47f20832192db68ac884686fc