### PR TITLE
Enhance Nicholson segment checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ HF_TOKEN=your_hf_token_here
 
 1. **Transcribe with diarization** – `videocut transcribe input.mp4 --diarize --hf_token $HF_TOKEN` runs WhisperX and produces `markup_guide.txt` and `input.json` with speaker labels.
    Provide `--speaker-db speakers.json` to map diarized IDs to real names.
-2. **Auto-mark Nicholson** – `videocut auto-mark-nicholson input.json` generates
-   `segments_to_keep.json` grouping Nicholson's remarks into coherent segments.
+2. **Identify segments** – `videocut identify-segments input.json` generates
+   `segments_to_keep.json` grouping Nicholson's remarks into coherent segments using recognized speaker IDs.
+   The script also cross-checks with text heuristics and warns if the methods disagree.
 3. **Review and edit** – optionally run `videocut json-to-editable segments_to_keep.json` and modify the JSON to fine‑tune the clips.
 4. **Generate clips** – `videocut generate-clips input.mp4` cuts clips into a `clips/` directory.
 5. **Concatenate** – `videocut concatenate` stitches the clips together with white flashes.
@@ -56,8 +57,7 @@ All of these steps can be executed sequentially with `videocut pipeline input.mp
 
 When diarization is enabled, VideoCut scans the transcript for recognition cues
 such as "Director Doe you're recognized" or simply "You're recognized" when the
-chair has just mentioned a name.  Short lines that end with just "Director Name" or phrases like "yield the floor to Director Name" are also detected.  The following speaker is automatically mapped
-to a name and the results are written to `recognized_map.json`, mapping each diarized speaker ID to its most likely name and any alternatives.  The
+chair has just mentioned a name. Short lines that end with just "Director Name" or phrases like "yield the floor to Director Name" are also detected. The chair is identified from the roll call first, then these cues map each diarized speaker ID to its most likely name with any alternatives. Results are written to `recognized_map.json`.
 `identify-recognized` command can be run manually if needed:
 
 ```bash
@@ -100,8 +100,8 @@ videocut build-speaker-db samples/ --out speakers.json
 # Transcription with diarization
 videocut transcribe meeting.mp4 --diarize --hf_token $HF_TOKEN --speaker-db speakers.json
 
-# Auto-mark Nicholson segments into grouped clips
-videocut auto-mark-nicholson meeting.json
+# Identify Nicholson segments into grouped clips
+videocut identify-segments meeting.json
 
 # (Optional) tweak the segments
 videocut json-to-editable segments_to_keep.json --out segments_edit.json

--- a/annotate_segments.py
+++ b/annotate_segments.py
@@ -24,7 +24,7 @@ _TS_RE = re.compile(r"^\s*\[(?P<start>\d+\.?\d*)[–-](?P<end>\d+\.?\d*)\]")
 
 def load_segments(json_path: Path) -> list[dict]:
     if not json_path.exists():
-        sys.exit(f"❌  '{json_path}' not found. Run auto-mark-nicholson first.")
+        sys.exit(f"❌  '{json_path}' not found. Run identify-segments first.")
     raw = json.loads(json_path.read_text())
     if isinstance(raw, dict) and "segments" in raw:
         raw = raw["segments"]

--- a/specification.md
+++ b/specification.md
@@ -11,7 +11,7 @@ VideoCut implements a video-editing pipeline driven by transcript data. The work
 High-level workflow:
 
 1. **Transcribe with diarization** – produce a speaker-labeled JSON transcript and `markup_guide.txt`.
-2. **Auto-mark Nicholson** – create `segments_to_keep.json` selecting Secretary Nicholson's speech. The JSON can be manually edited or converted to an editable format after this step.
+2. **Identify segments** – create `segments_to_keep.json` selecting Secretary Nicholson's speech. The script cross-checks heuristics against recognized speakers and warns if they disagree. The JSON can be manually edited or converted to an editable format after this step.
 3. **Generate clips** – cut clips with fade-in/out.
 4. **Concatenate** – join clips together with white flashes in between.
 5. **Optional utilities** – annotate markup with `{START}`/`{END}` markers and generate a transcript summary of long clips.
@@ -44,7 +44,7 @@ These utilities convert transcripts, identify clips, generate clips, and concate
 - **TSV → JSON** – read rows where the `keep` column is truthy and output a list of `{start, end}` objects.
 - **editable JSON → JSON** – save segments whose `keep` flag is truthy into the same `{start, end}` structure.
 - **markup guide → JSON** – parse `markup_guide.txt` looking for `{START}` and `{END}` markers and dump the corresponding segments.
-- **Nicholson helpers** – map the speaker label for Secretary Nicholson, dump all of that speaker's segments, and provide a convenience function to auto-mark Nicholson segments.
+- **Nicholson helpers** – map the speaker label for Secretary Nicholson, dump all of that speaker's segments, and provide a convenience function to identify Nicholson segments automatically.
 - **Clip generation** – for each segment in the JSON file, extract the portion, re-encode it with fade-in/out, and pad to 1280×720 at 30fps.
 - **Concatenation** – concatenate the clip files, inserting a white flash (`0.5` seconds) between them and joining audio/video streams.
 
@@ -75,7 +75,7 @@ Each script wraps one of the core functions, exposing a single command-line step
 2. Convert the JSON transcript to `segments_edit.json`.
 3. Parse the editable JSON and produce `segments_to_keep.json`.
 4. Extract `{START}`/`{END}` markers from `markup_guide.txt`.
-5. Auto-mark Nicholson segments from a diarized JSON file.
+5. Identify Nicholson segments from a diarized JSON file.
 6. Cut clips to a directory using the JSON segments.
 7. Assemble the clips into the final video.
 8. Generate transcript summaries for each clip.
@@ -86,7 +86,7 @@ Each script wraps one of the core functions, exposing a single command-line step
 
 ## 5. Monolithic Wrappers
 
-A single command-line interface can run the entire pipeline with flags to enable or disable each step. The default behavior is to auto‑mark Nicholson segments immediately after transcription, producing `segments_to_keep.json`. Manual editing of this file can be done before generating clips, and the auto‑mark step can be skipped via a flag.
+A single command-line interface can run the entire pipeline with flags to enable or disable each step. The default behavior is to identify Nicholson segments immediately after transcription, producing `segments_to_keep.json`. Manual editing of this file can be done before generating clips, and the segment identification step can be skipped via a flag.
 
 ---
 

--- a/tests/test_auto_segment_nicholson.py
+++ b/tests/test_auto_segment_nicholson.py
@@ -41,3 +41,23 @@ def test_scoring_helpers():
     assert start_score("I have Secretary Nicholson") >= 0.8
     assert end_score("Thank you, Director") >= 0.6
 
+
+def test_segment_nicholson_agreement(tmp_path, capsys):
+    diarized = tmp_path / "dia_agree.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"start": 0, "end": 1, "speaker": "A", "text": "secretary nicholson"},
+            {"start": 1, "end": 2, "speaker": "B", "text": "other"},
+            {"start": 2, "end": 3, "speaker": "A", "text": "continue"},
+        ]
+    }))
+    rec_map = tmp_path / "rec.json"
+    rec_map.write_text(json.dumps({"A": {"name": "Nicholson", "alternatives": []}}))
+    out = tmp_path / "keep.json"
+
+    nicholson.segment_nicholson(str(diarized), str(out), recognized_map=str(rec_map))
+
+    out_text = capsys.readouterr().out
+    assert "agree" in out_text
+    segs = json.loads(out.read_text())
+    assert segs

--- a/tests/test_pipeline_recognition.py
+++ b/tests/test_pipeline_recognition.py
@@ -28,11 +28,11 @@ def test_pipeline_recognition(tmp_path, monkeypatch):
 
     called = {}
 
-    def fake_auto_mark(jf, out):
-        called["auto_mark"] = True
+    def fake_identify(jf, rec, out):
+        called["identify"] = True
         pathlib.Path(out).write_text("[]")
 
-    monkeypatch.setattr(nicholson_mod, "auto_mark_nicholson", fake_auto_mark)
+    monkeypatch.setattr(nicholson_mod, "identify_segments", fake_identify)
 
     def fake_generate(video, segs, out_dir):
         called["clips"] = True

--- a/tests/test_segmentation_utils.py
+++ b/tests/test_segmentation_utils.py
@@ -53,7 +53,7 @@ def test_extract_marked(tmp_path, capsys):
     assert "✅" in capsys.readouterr().out
 
 
-def test_auto_mark_nicholson(tmp_path, capsys):
+def test_identify_segments(tmp_path, capsys):
     diarized = tmp_path / "dia.json"
     diarized.write_text(json.dumps({
         "segments": [
@@ -64,7 +64,7 @@ def test_auto_mark_nicholson(tmp_path, capsys):
     }))
     out = tmp_path / "keep.json"
 
-    nicholson.auto_mark_nicholson(str(diarized), str(out))
+    nicholson.identify_segments(str(diarized), out_json=str(out))
 
     segs = json.loads(out.read_text())
     assert len(segs) == 1
@@ -91,7 +91,7 @@ def test_cli_commands(tmp_path):
     assert out2.exists()
 
     out3 = tmp_path / "keep3.json"
-    videocut_cli.auto_mark_nicholson(json_file=str(diarized), out=str(out3))
+    videocut_cli.identify_segments_cmd(json_file=str(diarized), out=str(out3))
     assert out3.exists()
 
 

--- a/tests/test_speaker_mapping.py
+++ b/tests/test_speaker_mapping.py
@@ -47,6 +47,11 @@ def sample_recog_data(tmp_path):
     diarized = tmp_path / "dia.json"
     diarized.write_text(json.dumps({
         "segments": [
+            {"speaker": "X", "text": "call the roll"},
+            {"speaker": "X", "text": "Director Doe"},
+            {"speaker": "B", "text": "Present"},
+            {"speaker": "X", "text": "Director Roe"},
+            {"speaker": "C", "text": "Here"},
             {"speaker": "A", "text": "director doe you're recognized"},
             {"speaker": "B", "text": "hello"},
             {"speaker": "A", "text": "director roe you're recognized"},
@@ -60,6 +65,13 @@ def sample_recog_no_name(tmp_path):
     diarized = tmp_path / "dia2.json"
     diarized.write_text(json.dumps({
         "segments": [
+            {"speaker": "X", "text": "call the roll"},
+            {"speaker": "X", "text": "Director Smith"},
+            {"speaker": "A", "text": "Present"},
+            {"speaker": "X", "text": "Director Jones"},
+            {"speaker": "B", "text": "Here"},
+            {"speaker": "X", "text": "Let us proceed"},
+            {"speaker": "X", "text": "Continuing"},
             {"speaker": "X", "text": "director smith."},
             {"speaker": "X", "text": "you're recognized"},
             {"speaker": "A", "text": "thanks"},
@@ -75,6 +87,13 @@ def sample_recog_extra(tmp_path):
     diarized = tmp_path / "dia3.json"
     diarized.write_text(json.dumps({
         "segments": [
+            {"speaker": "X", "text": "call the roll"},
+            {"speaker": "X", "text": "Director Lee"},
+            {"speaker": "A", "text": "Present"},
+            {"speaker": "X", "text": "Ms. Kim"},
+            {"speaker": "B", "text": "Here"},
+            {"speaker": "X", "text": "Mr. Park"},
+            {"speaker": "C", "text": "Present"},
             {"speaker": "X", "text": "Director Lee"},
             {"speaker": "A", "text": "hello"},
             {"speaker": "X", "text": "I yield the floor to Ms. Kim"},

--- a/videocut/core/annotation.py
+++ b/videocut/core/annotation.py
@@ -16,7 +16,7 @@ _TS_RE = re.compile(r"^\s*\[(?P<start>\d+\.?\d*)[–-](?P<end>\d+\.?\d*)\]")
 def load_segments(json_path: Path) -> list[dict]:
     """Load and sort clip segments from a JSON file."""
     if not json_path.exists():
-        sys.exit(f"❌  '{json_path}' not found. Run auto-mark-nicholson first.")
+        sys.exit(f"❌  '{json_path}' not found. Run identify-segments first.")
     raw = json.loads(json_path.read_text())
     if isinstance(raw, dict) and "segments" in raw:
         raw = raw["segments"]


### PR DESCRIPTION
## Summary
- cross-check Nicholson IDs from recognition map vs heuristics
- update documentation for identify-segments
- add regression test for ID agreement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68451f6266208321a0142ce39a123b61