### PR TITLE
Improve Nicholson segment handling and add utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ HF_TOKEN=your_hf_token_here
 2. **Identify segments** – `videocut identify-segments input.json` generates
    `segments_to_keep.json` grouping Nicholson's remarks into coherent segments using recognized speaker IDs.
    The script also cross-checks with text heuristics and warns if the methods disagree.
+   A list of official board member names is provided in `board_members.txt` so replies
+   from non‑directors can be captured when extending Nicholson's segments.
+   Run `videocut apply-name-map` to replace `SPEAKER_xx` tokens in the JSON with
+   mapped names and `videocut prune-segments` to drop trivial clips.
 3. **Review and edit** – optionally run `videocut json-to-editable segments_to_keep.json` and modify the JSON to fine‑tune the clips.
 4. **Generate clips** – `videocut generate-clips input.mp4` cuts clips into a `clips/` directory.
 5. **Concatenate** – `videocut concatenate` stitches the clips together with white flashes.
@@ -113,6 +117,13 @@ videocut concatenate --clips_dir clips --out final.mp4
 videocut annotate-markup
 videocut clip-transcripts
 
+# Replace SPEAKER IDs with names and prune trivial segments
+videocut apply-name-map segments_to_keep.json recognized_map.json
+videocut prune-segments segments_to_keep.json
+
+# List recognized directors
+videocut recognized-directors recognized_map.json board_members.txt
+
 # Map speakers after transcription
 videocut map-speakers meeting.mp4 meeting.json --db speakers.json
 ```
@@ -122,5 +133,6 @@ videocut map-speakers meeting.mp4 meeting.json --db speakers.json
 - `videocut/cli.py` – Typer command line interface
 - `videocut/core/` – modular helpers (`transcription.py`, `segmentation.py`, `video_editing.py`, `nicholson.py`, `annotation.py`, `clip_transcripts.py`, `speaker_mapping.py`)
 - `videos/` – example data used for testing the pipeline
+- `board_members.txt` – official names used when matching directors
 
 WhisperX and FFmpeg must be installed separately.  Once those are available, the `videocut` command can automate cutting long meeting videos into polished clips.

--- a/board_members.txt
+++ b/board_members.txt
@@ -1,0 +1,15 @@
+Julien Bouquet
+Patrick O'Keefe
+Troy Whitmore
+Chris Nicholson
+Karen Benker
+Vince Buzek
+Michael Guzman
+Peggy Catlin
+Ian Harwick
+Kathleen Chandler
+Matt Larsen
+Lynn Guissinger
+Brett Paglieri
+Chris Gutschenritter
+JoyAnn Ruscha

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -138,6 +138,35 @@ def apply_speaker_labels(
 
 
 @app.command()
+def apply_name_map(
+    seg_json: str = "segments_to_keep.json",
+    map_json: str = "recognized_map.json",
+    out: Optional[str] = None,
+):
+    """Replace SPEAKER IDs in segments JSON with recognized names."""
+    nicholson.apply_name_map(seg_json, map_json, out)
+
+
+@app.command()
+def prune_segments_cmd(
+    seg_json: str = "segments_to_keep.json",
+    out: Optional[str] = None,
+):
+    """Remove trivial segments from the JSON list."""
+    nicholson.prune_segments(seg_json, out)
+
+
+@app.command()
+def recognized_directors(
+    recognized: str = "recognized_map.json",
+    board_file: str = "board_members.txt",
+    out: str = "recognized_directors.txt",
+):
+    """Generate recognized_directors.txt from recognition results."""
+    nicholson.generate_recognized_directors(recognized, board_file, out)
+
+
+@app.command()
 def generate_clips(
     video: str = typer.Argument("input.mp4", help="Source video"),
     segs: str = typer.Option("segments_to_keep.json", help="Segments JSON"),

--- a/videocut/core/nicholson.py
+++ b/videocut/core/nicholson.py
@@ -4,7 +4,8 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
+from difflib import get_close_matches
 
 from . import chair
 
@@ -45,6 +46,22 @@ TRAIL_SEC = 30
 PRE_SEC = 5
 MERGE_GAP_SEC = 45
 END_GAP_SEC = 30
+
+BOARD_FILE = Path(__file__).resolve().parents[1] / "board_members.txt"
+
+
+def load_board_names(path: str | None = None) -> set[str]:
+    """Return a set of official board member names in lowercase."""
+    fp = Path(path) if path else BOARD_FILE
+    if not fp.exists():
+        return set()
+    return {ln.strip().lower() for ln in fp.read_text().splitlines() if ln.strip()}
+
+
+def _is_board_member(name: str, board: set[str]) -> bool:
+    if not name:
+        return False
+    return bool(get_close_matches(name.lower(), list(board), n=1, cutoff=0.75))
 
 
 def map_nicholson_speaker(diarized_json: str) -> str:
@@ -328,17 +345,16 @@ def collect_pre(segs: List[dict], start: float) -> List[str]:
 
 
 def collect_post(segs: List[dict], end: float, next_start: float | None = None) -> List[str]:
+    """Return lines after *end* up to the next segment or trailing window."""
     window = end + TRAIL_SEC
-    out = []
-    for l in segs:
-        if l["start"] < end:
-            continue
-        if next_start is not None and l["start"] >= next_start:
-            break
-        if l["start"] > window:
-            break
-        out.append(l["line"])
-    return out
+    limit = next_start if next_start is not None else window
+    if limit > window:
+        limit = window
+    return [
+        l["line"]
+        for l in segs
+        if l["start"] >= end and l["start"] < limit
+    ]
 
 
 def trim_segment(start: float, end: float, markup: List[dict]) -> tuple[float, List[str]]:
@@ -401,6 +417,7 @@ def segment_nicholson(
     diarized_json: str,
     out_json: str = "segments_to_keep.json",
     recognized_map: str | None = None,
+    board_file: str | None = None,
 ) -> None:
     in_path = Path(diarized_json)
     out_path = Path(out_json)
@@ -409,11 +426,14 @@ def segment_nicholson(
     data = json.loads(in_path.read_text())
     segs = data["segments"]
     markup_lines = load_markup(markup_path)
+    board_names = load_board_names(board_file)
 
     recog_ids: List[str] | None = None
+    name_map: Dict[str, str] = {}
     if recognized_map and Path(recognized_map).exists():
         try:
             mapping = json.loads(Path(recognized_map).read_text())
+            name_map = {spk: info.get("name", "") for spk, info in mapping.items()}
             recog_ids = [
                 spk
                 for spk, info in mapping.items()
@@ -421,6 +441,7 @@ def segment_nicholson(
             ]
         except Exception:
             recog_ids = None
+            name_map = {}
 
     heur_id = find_nicholson_speaker(segs)
     if heur_id is None:
@@ -465,8 +486,8 @@ def segment_nicholson(
         end_time = float(segs[last_idx]["end"])
 
         j = last_idx + 1
-        prev_non_nich = None
         next_start = None
+        prev_spk = None
         while j < len(segs):
             seg = segs[j]
             seg_start = float(seg["start"])
@@ -474,14 +495,20 @@ def segment_nicholson(
             spk = seg.get("speaker")
             if spk in nicholson_ids:
                 break
+            name = name_map.get(spk, "")
+            is_director = _is_board_member(name, board_names)
             if should_end(seg.get("text", "")) or seg_start - float(segs[last_idx]["end"]) >= END_GAP_SEC:
                 end_time = seg_end
                 next_start = seg_start
                 break
-            if prev_non_nich is not None and spk != prev_non_nich:
+            if is_director:
                 next_start = seg_start
                 break
-            prev_non_nich = spk
+            if not board_names or not name_map:
+                if prev_spk is not None and spk != prev_spk:
+                    next_start = seg_start
+                    break
+                prev_spk = spk
             end_time = seg_end
             j += 1
         if j < len(segs):
@@ -507,6 +534,54 @@ def segment_nicholson(
     out_path.write_text(json.dumps(results, indent=2))
     print(f"✅  {len(results)} segments → {out_path}")
 
+
+def apply_name_map(seg_json: str, map_json: str, out_json: Optional[str] = None) -> None:
+    """Replace SPEAKER tokens in *seg_json* with names from *map_json*."""
+    segs = json.loads(Path(seg_json).read_text())
+    mapping = json.loads(Path(map_json).read_text())
+    repl = {k: v.get("name", k) for k, v in mapping.items()}
+    for seg in segs:
+        for key in ["text", "pre", "post"]:
+            lines = seg.get(key, [])
+            new_lines = []
+            for line in lines:
+                for spk, name in repl.items():
+                    line = line.replace(spk, name)
+                new_lines.append(line)
+            seg[key] = new_lines
+    Path(out_json or seg_json).write_text(json.dumps(segs, indent=2))
+    print(f"✅  names applied → {out_json or seg_json}")
+
+
+def prune_segments(seg_json: str, out_json: Optional[str] = None) -> None:
+    """Remove trivial segments with very few words."""
+    segs = json.loads(Path(seg_json).read_text())
+    kept = []
+    for seg in segs:
+        words = " ".join(seg.get("text", [])).split()
+        if len(words) >= 4:
+            kept.append(seg)
+    Path(out_json or seg_json).write_text(json.dumps(kept, indent=2))
+    print(f"✅  {len(kept)} segment(s) kept → {out_json or seg_json}")
+
+
+def generate_recognized_directors(
+    recognized_map: str,
+    board_file: str = str(BOARD_FILE),
+    out_file: str = "recognized_directors.txt",
+) -> None:
+    """Write recognized directors matched against the official board list."""
+    board = load_board_names(board_file)
+    mapping = json.loads(Path(recognized_map).read_text())
+    found = []
+    for info in mapping.values():
+        name = info.get("name", "")
+        match = get_close_matches(name.lower(), list(board), n=1, cutoff=0.75)
+        if match:
+            found.append(match[0])
+    Path(out_file).write_text("\n".join(sorted(set(found))) + "\n")
+    print(f"✅  recognized directors → {out_file}")
+
 __all__ = [
     "map_nicholson_speaker",
     "map_speaker_by_phrases",
@@ -517,6 +592,9 @@ __all__ = [
     "identify_segments",
     "find_nicholson_speaker",
     "segment_nicholson",
+    "apply_name_map",
+    "prune_segments",
+    "generate_recognized_directors",
     "start_score",
     "end_score",
     "should_start",


### PR DESCRIPTION
## Summary
- support listing board members
- update Nicholson segmentation to capture non-director replies
- fix collection of post-context lines
- helper to apply recognized names to segments and prune trivial clips
- CLI commands for name mapping, pruning and recognized director list
- document new utilities in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b20c05dc832188eb74958c7a2c6c