### PR TITLE
Improve Nicholson segment handling and add utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ HF_TOKEN=your_hf_token_here
 2. **Identify segments** – `videocut identify-segments input.json` generates
    `segments_to_keep.json` grouping Nicholson's remarks into coherent segments using recognized speaker IDs.
    The script also cross-checks with text heuristics and warns if the methods disagree.
+   A list of official board member names in `board_members.txt` lets the tool
+   include staff answers when Nicholson asks a question.  Speaker IDs are now
+   replaced with recognized names automatically and `videocut prune-segments`
+   can drop trivial clips.
 3. **Review and edit** – optionally run `videocut json-to-editable segments_to_keep.json` and modify the JSON to fine‑tune the clips.
 4. **Generate clips** – `videocut generate-clips input.mp4` cuts clips into a `clips/` directory.
 5. **Concatenate** – `videocut concatenate` stitches the clips together with white flashes.
@@ -113,6 +117,12 @@ videocut concatenate --clips_dir clips --out final.mp4
 videocut annotate-markup
 videocut clip-transcripts
 
+# Prune trivial segments
+videocut prune-segments segments_to_keep.json
+
+# List recognized directors
+videocut recognized-directors recognized_map.json board_members.txt
+
 # Map speakers after transcription
 videocut map-speakers meeting.mp4 meeting.json --db speakers.json
 ```
@@ -122,5 +132,6 @@ videocut map-speakers meeting.mp4 meeting.json --db speakers.json
 - `videocut/cli.py` – Typer command line interface
 - `videocut/core/` – modular helpers (`transcription.py`, `segmentation.py`, `video_editing.py`, `nicholson.py`, `annotation.py`, `clip_transcripts.py`, `speaker_mapping.py`)
 - `videos/` – example data used for testing the pipeline
+- `board_members.txt` – official names used when matching directors
 
 WhisperX and FFmpeg must be installed separately.  Once those are available, the `videocut` command can automate cutting long meeting videos into polished clips.

--- a/board_members.txt
+++ b/board_members.txt
@@ -1,0 +1,15 @@
+Julien Bouquet
+Patrick O'Keefe
+Troy Whitmore
+Chris Nicholson
+Karen Benker
+Vince Buzek
+Michael Guzman
+Peggy Catlin
+Ian Harwick
+Kathleen Chandler
+Matt Larsen
+Lynn Guissinger
+Brett Paglieri
+Chris Gutschenritter
+JoyAnn Ruscha

--- a/tests/test_pipeline_recognition.py
+++ b/tests/test_pipeline_recognition.py
@@ -28,9 +28,9 @@ def test_pipeline_recognition(tmp_path, monkeypatch):
 
     called = {}
 
-    def fake_identify(jf, rec, out):
+    def fake_identify(*args):
         called["identify"] = True
-        pathlib.Path(out).write_text("[]")
+        pathlib.Path(args[2]).write_text("[]")
 
     monkeypatch.setattr(nicholson_mod, "identify_segments", fake_identify)
 

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -82,9 +82,10 @@ def identify_segments_cmd(
     json_file: str,
     recognized: str = "recognized_map.json",
     out: str = "segments_to_keep.json",
+    board_file: str = "board_members.txt",
 ):
     """Detect Nicholson segments using recognized speaker IDs."""
-    nicholson.identify_segments(json_file, recognized, out)
+    nicholson.identify_segments(json_file, recognized, out, board_file)
 
 
 @app.command()
@@ -138,6 +139,35 @@ def apply_speaker_labels(
 
 
 @app.command()
+def apply_name_map(
+    seg_json: str = "segments_to_keep.json",
+    map_json: str = "recognized_map.json",
+    out: Optional[str] = None,
+):
+    """Replace SPEAKER IDs in segments JSON with recognized names."""
+    nicholson.apply_name_map(seg_json, map_json, out)
+
+
+@app.command()
+def prune_segments_cmd(
+    seg_json: str = "segments_to_keep.json",
+    out: Optional[str] = None,
+):
+    """Remove trivial segments from the JSON list."""
+    nicholson.prune_segments(seg_json, out)
+
+
+@app.command()
+def recognized_directors(
+    recognized: str = "recognized_map.json",
+    board_file: str = "board_members.txt",
+    out: str = "recognized_directors.txt",
+):
+    """Generate recognized_directors.txt from recognition results."""
+    nicholson.generate_recognized_directors(recognized, board_file, out)
+
+
+@app.command()
 def generate_clips(
     video: str = typer.Argument("input.mp4", help="Source video"),
     segs: str = typer.Option("segments_to_keep.json", help="Segments JSON"),
@@ -180,7 +210,10 @@ def pipeline(
 
     if auto_nicholson:
         nicholson.identify_segments(
-            json_file, "recognized_map.json", "segments_to_keep.json"
+            json_file,
+            "recognized_map.json",
+            "segments_to_keep.json",
+            "board_members.txt",
         )
     else:
         segmentation.json_to_editable(json_file, "segments_edit.json", "markup_guide.txt")


### PR DESCRIPTION
## Summary
- support listing board members
- update Nicholson segmentation to capture non-director replies
- fix collection of post-context lines
- helper to apply recognized names to segments and prune trivial clips
- CLI commands for name mapping, pruning and recognized director list
- document new utilities in README

------
https://chatgpt.com/codex/tasks/task_e_6845b20c05dc832188eb74958c7a2c6c