### PR TITLE
Add SRT annotation command

### DIFF
--- a/videocut/__init__.py
+++ b/videocut/__init__.py
@@ -7,6 +7,7 @@ from .core import (
     nicholson,
     annotation,
     clip_transcripts,
+    srt_markers,
     speaker_mapping,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "segmentation",
     "video_editing",
     "nicholson",
+    "srt_markers",
     "speaker_mapping",
 ]

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -11,6 +11,7 @@ from .core import (
     nicholson,
     annotation,
     clip_transcripts,
+    srt_markers,
     speaker_mapping,
     chair,
 )
@@ -64,6 +65,35 @@ def annotate_markup(markup_file: str = "markup_guide.txt", seg_json: str = "segm
 @app.command()
 def clip_transcripts_cmd(markup_file: str = "markup_guide.txt", seg_json: str = "segments_to_keep.json", out_file: str = "clip_transcripts.txt"):
     clip_transcripts.clip_transcripts(markup_file, seg_json, out_file)
+
+@app.command()
+def annotate_srt(
+    srt_file: str,
+    seg_json: str = "segments_to_keep.json",
+    name_map: str = "recognized_map.json",
+    out_file: str = "May_Board_Meeting_processed.srt",
+):
+    """Write ``out_file`` with =START/=END markers and mapped labels."""
+    srt_markers.annotate_srt(srt_file, seg_json, name_map, out_file)
+
+
+@app.command()
+def srt_to_segments(srt_file: str, out: str = "segments_from_srt.json"):
+    """Extract segment list from an annotated SRT file."""
+    segs = srt_markers.segments_from_srt(srt_file)
+    Path(out).write_text(json.dumps(segs, indent=2))
+    print(f"✅  {len(segs)} segment(s) → {out}")
+
+
+@app.command()
+def clips_from_srt(
+    video: str = typer.Argument("input.mp4", help="Source video"),
+    srt_file: str = typer.Argument("processed.srt", help="SRT with markers"),
+    out_dir: str = typer.Option("clips", help="Output directory for clips"),
+):
+    """Generate clips directly from an annotated SRT."""
+    segs = srt_markers.segments_from_srt(srt_file)
+    video_editing.generate_clips_from_segments(video, segs, out_dir)
 
 
 @app.command()

--- a/videocut/core/srt_markers.py
+++ b/videocut/core/srt_markers.py
@@ -1,0 +1,140 @@
+"""Utilities for inserting segment markers into SRT files."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def _parse_time(ts: str) -> float:
+    h, m, rest = ts.split(":")
+    s, ms = rest.split(",")
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000
+
+
+def _format_time(t: float) -> str:
+    h = int(t // 3600)
+    m = int((t % 3600) // 60)
+    s = int(t % 60)
+    ms = int(round((t - int(t)) * 1000))
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+class _SrtEntry(dict):
+    start: float
+    end: float
+    lines: list[str]
+
+
+def _load_srt(path: Path) -> list[_SrtEntry]:
+    entries: list[_SrtEntry] = []
+    lines = path.read_text().splitlines()
+    i = 0
+    while i < len(lines):
+        if not lines[i].strip():
+            i += 1
+            continue
+        number = lines[i].strip()
+        i += 1
+        if i >= len(lines):
+            break
+        ts_line = lines[i].strip()
+        i += 1
+        if "-->" not in ts_line:
+            break
+        start_str, end_str = [p.strip() for p in ts_line.split("-->")]
+        start, end = _parse_time(start_str), _parse_time(end_str)
+        text_lines: list[str] = []
+        while i < len(lines) and lines[i].strip():
+            text_lines.append(lines[i])
+            i += 1
+        entries.append({"number": number, "start": start, "end": end, "lines": text_lines})
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+    return entries
+
+
+def _find_entry(entries: list[_SrtEntry], t: float) -> int:
+    for idx, e in enumerate(entries):
+        if e["start"] <= t <= e["end"]:
+            return idx
+    for idx, e in enumerate(entries):
+        if t < e["start"]:
+            return idx
+    return len(entries) - 1
+
+
+_SPEAKER_RE = re.compile(r"^\[(SPEAKER_\d+)\]:\s*")
+
+
+def annotate_srt(
+    srt_file: str,
+    seg_json: str = "segments_to_keep.json",
+    name_map: str = "recognized_map.json",
+    out_file: str = "processed.srt",
+) -> None:
+    """Insert ``=START-n=``/``=END-n=`` markers and map speaker labels."""
+    entries = _load_srt(Path(srt_file))
+    segs = json.loads(Path(seg_json).read_text())
+    mapping = {}
+    if Path(name_map).exists():
+        raw = json.loads(Path(name_map).read_text())
+        mapping = {k: v.get("name", k) for k, v in raw.items() if isinstance(v, dict)}
+
+    before: dict[int, list[str]] = {}
+    after: dict[int, list[str]] = {}
+    for i, seg in enumerate(sorted(segs, key=lambda s: s["start"]), 1):
+        s_idx = _find_entry(entries, float(seg["start"]))
+        e_idx = _find_entry(entries, float(seg["end"]))
+        before.setdefault(s_idx, []).append(f"=START-{i}=")
+        after.setdefault(e_idx, []).append(f"=END-{i}=")
+
+    for e in entries:
+        new_lines = []
+        for line in e["lines"]:
+            m = _SPEAKER_RE.match(line)
+            if m:
+                sp = m.group(1)
+                name = mapping.get(sp, sp)
+                line = _SPEAKER_RE.sub(f"{name}: ", line)
+            new_lines.append(line)
+        e["lines"] = new_lines
+
+    out_lines: list[str] = []
+    for idx, e in enumerate(entries):
+        out_lines.append(str(e["number"]))
+        out_lines.append(f"{_format_time(e['start'])} --> {_format_time(e['end'])}")
+        for m in before.get(idx, []):
+            out_lines.append(m)
+        out_lines.extend(e["lines"])
+        for m in after.get(idx, []):
+            out_lines.append(m)
+        out_lines.append("")
+
+    Path(out_file).write_text("\n".join(out_lines))
+    print(f"✅  wrote {out_file}")
+
+
+_START_RE = re.compile(r"=START-(\d+)=")
+_END_RE = re.compile(r"=END-(\d+)=")
+
+
+def segments_from_srt(srt_file: str) -> list[dict]:
+    """Return ``[{start, end}, ...]`` parsed from marker lines in *srt_file*."""
+    entries = _load_srt(Path(srt_file))
+    starts: dict[int, float] = {}
+    segments: list[dict] = []
+    for e in entries:
+        for line in e["lines"]:
+            m = _START_RE.match(line.strip())
+            if m:
+                starts[int(m.group(1))] = e["start"]
+            m = _END_RE.match(line.strip())
+            if m:
+                idx = int(m.group(1))
+                start = starts.pop(idx, e["start"])
+                segments.append({"start": start, "end": e["end"]})
+    return sorted(segments, key=lambda s: s["start"])
+
+
+__all__ = ["annotate_srt", "segments_from_srt"]

--- a/videos/May_Board_Meeting/May_Board_Meeting_processed.srt
+++ b/videos/May_Board_Meeting/May_Board_Meeting_processed.srt
@@ -1,0 +1,7537 @@
+1
+00:00:00,031 --> 00:00:02,534
+SPEAKER_10: Comments, feel free to come up to the podium.
+
+2
+00:00:06,018 --> 00:00:08,381
+SPEAKER_10: Seeing none, were there any emailed comments, Mr. Carroll?
+
+3
+00:00:08,561 --> 00:00:09,262
+Larsen: There were a number.
+
+4
+00:00:09,302 --> 00:00:12,466
+Larsen: I am not going to go through all 46 and read the names.
+
+5
+00:00:12,666 --> 00:00:19,575
+Larsen: However, you received 36 letters with respect to Northwest Rail and the IGA conversation that you held earlier today.
+
+6
+00:00:19,615 --> 00:00:24,341
+Larsen: Five letters with respect to the ETOD policy you will consider later this evening.
+
+7
+00:00:24,861 --> 00:00:29,667
+Larsen: Three letters with respect to Title VI policy or the program update.
+
+8
+00:00:29,917 --> 00:00:42,896
+Larsen: You all will consider later this evening, one regarding the National Women's Soccer League proposed stadium that was discussed earlier here in person, and one regarding paratransit AOD program modifications.
+
+9
+00:00:43,497 --> 00:00:45,961
+Larsen: All will be appended to the transcript of this meeting.
+
+10
+00:00:46,421 --> 00:00:59,080
+Larsen: And just as a reminder to directors, a majority of these written public comments were submitted to the RTD.directors email group, which you all have access to and can see in real time.
+
+11
+00:00:59,819 --> 00:01:00,740
+SPEAKER_10: Thank you, Mr. Krull.
+
+12
+00:01:01,060 --> 00:01:05,105
+SPEAKER_10: With no other participants in the queue, we will now close public participation at this time.
+
+13
+00:01:06,346 --> 00:01:09,009
+SPEAKER_10: Moving on to our next item, external entities report.
+
+14
+00:01:09,290 --> 00:01:12,533
+SPEAKER_10: We have no external entity reports this month.
+
+15
+00:01:14,035 --> 00:01:16,137
+SPEAKER_10: Moving on to our next item, discussion items.
+
+16
+00:01:16,518 --> 00:01:23,245
+SPEAKER_10: We have one discussion item on the agenda this evening, which is a holdover from last week's operation safety and security committee meeting.
+
+17
+00:01:24,102 --> 00:01:27,008
+SPEAKER_10: It is the access on demand program modifications.
+
+18
+00:01:27,710 --> 00:01:33,583
+SPEAKER_10: I would like to offer the floor to GM CEO Deborah Johnson for some opening remarks before introducing Ms.
+
+19
+00:01:33,924 --> 00:01:34,405
+SPEAKER_10: Vallejo's.
+
+20
+00:01:35,808 --> 00:01:37,331
+SPEAKER_16: Thank you very much, Mr. Chair.
+
+21
+00:01:37,832 --> 00:01:42,583
+SPEAKER_16: Good afternoon or evening, board members, Deborah Johnson, general manager and chief executive officer.
+
+22
+00:01:43,238 --> 00:01:51,572
+SPEAKER_16: I am joined by Aaron Valleos, who serves as the Acting Assistant or Deputy Assistant General Manager of Bus Operations.
+
+23
+00:01:52,033 --> 00:02:05,196
+SPEAKER_16: And as indicated in your remarks, we are here referencing the previous agendized topic at the Operations Safety and Security Committee that we did not get to and wanted to have this conversation.
+
+24
+00:02:05,176 --> 00:02:34,879
+SPEAKER_16: with you all this evening, the intent of this presentation is to ground all board members in our paratransit programs, but more specifically, what we are seeking from this body is some guidance relative to access on demand, which is a supplemental premium service as relates to paratransit services, not the American with Disabilities Act of 1990, Complementary Paratransit Services.
+
+25
+00:02:34,859 --> 00:02:40,708
+SPEAKER_16: And in doing so, this conversation will help us guide our path forward.
+
+26
+00:02:41,750 --> 00:02:51,966
+SPEAKER_16: Specifically, I think what's notable for everybody to understand that the current paratransit contracts that we have for access on demand do sunset at the end of December.
+
+27
+00:02:52,547 --> 00:02:57,795
+SPEAKER_16: We have had conversations relative to modifications and absence of having some guidance
+
+28
+00:02:57,775 --> 00:03:09,491
+SPEAKER_16: We run the risk of not having any type of services and hence why it's so imperative is that we adhere to open and fair competition in order to do a solicitation relative to services.
+
+29
+00:03:09,571 --> 00:03:17,522
+SPEAKER_16: We have to have some guidance relative to the specifications that would be included in a solicitation for a request for proposal.
+
+30
+00:03:18,043 --> 00:03:25,673
+SPEAKER_16: So this is not for you to make a decision relative to where we are but provide guidance because what we anticipate doing with said guidance
+
+31
+00:03:25,653 --> 00:03:30,938
+SPEAKER_16: and bringing forward these scenarios after meeting with some board members, i.e.
+
+32
+00:03:32,039 --> 00:03:47,432
+SPEAKER_16: Chair Ruscha and Director Chandler, that are both on the Operation Safety and Security Committee, is to seek that direction so we can then go out to the customer segments and garner a better understanding.
+
+33
+00:03:47,472 --> 00:03:54,158
+SPEAKER_16: While we've heard comments here, we have taken part in a myriad of different public participation engagements
+
+34
+00:03:54,138 --> 00:04:07,755
+SPEAKER_16: and want to ensure that we are being good fiscal stewards, but also ensuring that we are providing the independence and ability for all aspects of our population to be able to travel and move about to and fro.
+
+35
+00:04:07,815 --> 00:04:11,099
+SPEAKER_16: So with that being said, I will yield the floor to Ms.
+
+36
+00:04:11,179 --> 00:04:13,842
+SPEAKER_16: Filaios to commence with the presentation.
+
+37
+00:04:13,902 --> 00:04:17,526
+SPEAKER_16: If we could have board office staff pull that up, that would be appreciated.
+
+38
+00:04:17,727 --> 00:04:18,087
+SPEAKER_16: Thank you.
+
+39
+00:04:36,950 --> 00:04:38,712
+SPEAKER_20: been a while since I've used these microphones.
+
+40
+00:04:39,333 --> 00:04:40,155
+SPEAKER_20: Good evening, everyone.
+
+41
+00:04:40,415 --> 00:04:48,126
+SPEAKER_20: As GMCEO Johnson said, I'm Erin Vallejoz, the acting deputy assistant general manager for bus operations.
+
+42
+00:04:48,707 --> 00:04:52,171
+SPEAKER_20: And we are just going to go over just kind of a quick overview.
+
+43
+00:04:52,231 --> 00:04:56,798
+SPEAKER_20: I think it's a lot of information that you've already seen, so we won't spend too much time on that.
+
+44
+00:04:57,118 --> 00:05:00,443
+SPEAKER_20: Just kind of hit on what the initial recommendation was that we made.
+
+45
+00:05:00,423 --> 00:05:08,458
+SPEAKER_20: talk about some revised recommendations and then again kind of open it up for discussion to kind of get an idea of some direction.
+
+46
+00:05:08,692 --> 00:05:08,912
+SPEAKER_10: Ms.
+
+47
+00:05:08,952 --> 00:05:12,037
+SPEAKER_10: Faleos before, could you speak a little closer to the microphone?
+
+48
+00:05:12,057 --> 00:05:12,799
+SPEAKER_20: Yes, I can.
+
+49
+00:05:12,819 --> 00:05:13,400
+SPEAKER_10: Thank you so much.
+
+50
+00:05:13,440 --> 00:05:14,281
+SPEAKER_20: Of course.
+
+51
+00:05:14,301 --> 00:05:26,481
+SPEAKER_20: Okay, so just to kind of highlight on this again as GM CEO Johnson said, Accessor Ride and Access on Demand are the two programs that we have.
+
+52
+00:05:26,681 --> 00:05:33,332
+SPEAKER_20: Accessor Ride is RTD's federally required ADA complimentary paratransit service.
+
+53
+00:05:33,312 --> 00:05:36,420
+SPEAKER_20: It does supplement our fixed route services.
+
+54
+00:05:36,480 --> 00:05:49,212
+SPEAKER_20: There is a fair payment required for these services and customers must meet the criteria set forth by the Americans with Disabilities Act of 1990 to be eligible.
+
+55
+00:05:49,192 --> 00:05:55,840
+SPEAKER_20: This is provided with all RTD branded access ride vehicles that are all 100 percent accessible.
+
+56
+00:05:56,781 --> 00:06:01,547
+SPEAKER_20: Then access on demand is our supplemental premium paratransit service.
+
+57
+00:06:02,308 --> 00:06:06,093
+SPEAKER_20: It is a curb-to-curb taxi and ride share service.
+
+58
+00:06:06,794 --> 00:06:18,608
+SPEAKER_20: It is available to current paratransit customers, so they must meet those eligibility criteria to qualify for access ride to then use access on demand.
+
+59
+00:06:18,588 --> 00:06:24,947
+SPEAKER_20: And as it stands today, RTD pays the first $25 of the trip and the remaining portion is paid by the customer.
+
+60
+00:06:25,830 --> 00:06:29,661
+SPEAKER_20: And again, ability today to take 60 total trips.
+
+61
+00:06:30,502 --> 00:06:32,826
+SPEAKER_20: So just some quick operating statistics.
+
+62
+00:06:32,966 --> 00:06:40,839
+SPEAKER_20: The annual operating cost in 2024 for excessive ride was just over 53 million and the customer trips were just over 500,000.
+
+63
+00:06:40,979 --> 00:06:50,434
+SPEAKER_20: And again, these are RTD owned vehicles and the contractors that operate this service have over 500 drivers mechanics and other staff.
+
+64
+00:06:50,414 --> 00:06:55,968
+SPEAKER_20: And then access on demand slash year it was about just over 15 3 million for the budget.
+
+65
+00:06:58,174 --> 00:07:03,327
+SPEAKER_20: Just over 685,000 trips and these are all provided by third party vehicles.
+
+66
+00:07:05,180 --> 00:07:11,508
+SPEAKER_20: So again, as we touched on, you must be eligible for access ride to also use access on demand.
+
+67
+00:07:12,790 --> 00:07:22,222
+SPEAKER_20: There is a process that customers must go through that determines if a customer has a disabling condition that would prevent them from using a regular fixed route service.
+
+68
+00:07:23,203 --> 00:07:30,192
+SPEAKER_20: There's an application process, a medical verification process, and then an in-person assessment that customers must complete.
+
+69
+00:07:30,172 --> 00:07:34,719
+SPEAKER_20: And there are a couple of different types of eligibility that a customer could receive.
+
+70
+00:07:34,899 --> 00:07:40,448
+SPEAKER_20: Unconditional means you can have access to the full service for up to four years.
+
+71
+00:07:40,988 --> 00:07:46,797
+SPEAKER_20: Temporary, you might have a condition that's going to improve recovering from surgery or something along those lines.
+
+72
+00:07:47,398 --> 00:07:53,708
+SPEAKER_20: And then conditional would be when there was something maybe you're sensitive to extreme hot or extreme cold.
+
+73
+00:07:54,208 --> 00:07:57,934
+SPEAKER_20: So you would be able to use it at those times, but not the full year.
+
+74
+00:07:59,686 --> 00:08:05,693
+SPEAKER_20: Okay, and as we have touched on, this is something that you've probably seen as well.
+
+75
+00:08:06,473 --> 00:08:10,638
+SPEAKER_20: We are continuing to see an increase in access on demand usage.
+
+76
+00:08:11,179 --> 00:08:18,246
+SPEAKER_20: This is through 2024, but we continue to see that access on demand trend line going up into the start of this year.
+
+77
+00:08:18,266 --> 00:08:27,837
+SPEAKER_20: And access ride, when you look at the trend line, while it is staying a little bit more stable, we are still seeing an increase in usage there as well.
+
+78
+00:08:30,010 --> 00:08:38,685
+SPEAKER_20: And as we've talked about, average monthly trips per customer, the majority of customers are falling into the category of taking up to 50 trips.
+
+79
+00:08:39,346 --> 00:08:43,333
+SPEAKER_20: That is about 90% of the customers when we lasted the analysis.
+
+80
+00:08:43,854 --> 00:08:49,183
+SPEAKER_20: And about 10% of the customers, again, fall into that 51 to 60 category.
+
+81
+00:08:51,155 --> 00:08:56,401
+SPEAKER_20: So now I'm going to just remind everyone of what our initial recommendations were back in 2024.
+
+82
+00:08:56,562 --> 00:09:02,409
+SPEAKER_20: As it stands today again quickly, there's a zero dollar base customer fare.
+
+83
+00:09:02,449 --> 00:09:04,511
+SPEAKER_20: The trip cap is 60 per month.
+
+84
+00:09:05,072 --> 00:09:07,215
+SPEAKER_20: Subsidy is up to $25 per trip.
+
+85
+00:09:08,596 --> 00:09:13,382
+SPEAKER_20: It is available within the entire district and it is available 24 seven.
+
+86
+00:09:13,362 --> 00:09:28,024
+SPEAKER_20: Back when we came to you in November of 2024, we had proposed making changes, and this involved having a $4.50 based customer fare, which would be $2.25 for our live eligible customers.
+
+87
+00:09:28,605 --> 00:09:31,149
+SPEAKER_20: We proposed a trip cap of 40 per month.
+
+88
+00:09:32,531 --> 00:09:40,703
+SPEAKER_20: The subsidy would go to $20 per trip, and then it was proposed to mirror both the current service area and the service hours.
+
+89
+00:09:42,320 --> 00:09:50,960
+SPEAKER_20: With this recommendation, there were going to be cost savings that the district would realize, and that was going to be about 5.8 million dollars.
+
+90
+00:09:52,323 --> 00:10:00,362
+SPEAKER_20: So instead of the projected yearly spend being a little bit over 15 million, we would go down to about 9.4.
+
+91
+00:10:04,105 --> 00:10:11,537
+SPEAKER_20: Okay, and as a result of some of the feedback and comments that we've heard, we did put together two additional revised scenarios.
+
+92
+00:10:11,657 --> 00:10:15,103
+SPEAKER_20: So scenario one is what I'm going to touch on first.
+
+93
+00:10:15,323 --> 00:10:19,650
+SPEAKER_20: So this has to do with an increased trip cap approach.
+
+94
+00:10:19,630 --> 00:10:27,746
+SPEAKER_20: So what we were proposing in this scenario is increasing the trip cap to 50 per month from the original 40 that was proposed.
+
+95
+00:10:28,548 --> 00:10:35,682
+SPEAKER_20: We are proposing as this is again as we've said a premium supplemental service a fair of $6.50 per trip.
+
+96
+00:10:35,662 --> 00:10:40,271
+SPEAKER_20: which would be $3.25 for our live customers.
+
+97
+00:10:41,373 --> 00:10:43,718
+SPEAKER_20: Then the remainder of the proposal does remain the same.
+
+98
+00:10:43,878 --> 00:10:55,662
+SPEAKER_20: We were still proposing a subsidy per trip of $20, and we are proposing mirroring the current service area and service hours as that of our accessoride program.
+
+99
+00:10:56,468 --> 00:11:11,347
+SPEAKER_20: With this program, we did see actually a little bit of the yearly impact would be a cost savings of about $6.1 million, bringing our total spend to about a little over $9.1.
+
+100
+00:11:13,150 --> 00:11:22,662
+SPEAKER_20: With the 50 trips, that does allow for customers to still have, given there's about 20 weekdays in a month,
+
+101
+00:11:22,642 --> 00:11:29,698
+SPEAKER_20: That does allow for customers to still travel to work, but then does allow for some ancillary trips throughout the month.
+
+102
+00:11:32,125 --> 00:11:38,693
+SPEAKER_20: And then another scenario that we had put together is the tiered approach that we have discussed.
+
+103
+00:11:39,354 --> 00:11:46,863
+SPEAKER_20: With this approach, we would still maintain a trip cap of up to 60 trips per month, which matches what we have currently.
+
+104
+00:11:47,824 --> 00:11:53,070
+SPEAKER_20: There would be a $4.50 based customer fare for up to 30 trips.
+
+105
+00:11:53,050 --> 00:11:59,309
+SPEAKER_20: $5.50 for 31 to 50 and $6.50 for 51 to 60.
+
+106
+00:11:59,951 --> 00:12:03,381
+SPEAKER_20: And the remainder of the recommendation would remain the same.
+
+107
+00:12:04,762 --> 00:12:23,804
+SPEAKER_20: With this program, as some people have noted, due to kind of the program structure and some of the manual aspects that exist with monitoring today, there would be an increase in staff oversight that would result in additional staff headcount.
+
+108
+00:12:23,824 --> 00:12:29,470
+SPEAKER_20: Again, that had been noted, but as it stands today, the program does require quite a bit of manual intervention.
+
+109
+00:12:30,496 --> 00:12:38,554
+SPEAKER_20: There is also, as someone mentioned, the customers would need to be keeping a little bit closer track of their trips, and that could lead to confusion.
+
+110
+00:12:38,594 --> 00:12:45,490
+SPEAKER_20: It is something a customer would have to be regularly thinking, where am I at for the month?
+
+111
+00:12:45,510 --> 00:12:49,078
+SPEAKER_20: Have I hit that 30 trips so they know what to expect for their costs?
+
+112
+00:12:50,898 --> 00:12:55,828
+SPEAKER_20: With this program, we would see some reductions of just over $5 million.
+
+113
+00:12:55,908 --> 00:13:00,297
+SPEAKER_20: So it is a little bit less than some of the other recommendations that we've put forth.
+
+114
+00:13:00,838 --> 00:13:06,669
+SPEAKER_20: And it would bring our projected yearly spend to about $10.28 million a year.
+
+115
+00:13:10,497 --> 00:13:11,218
+SPEAKER_20: And actually,
+
+116
+00:13:12,025 --> 00:13:22,662
+SPEAKER_20: So proposed next steps we are here as GM CEO Johnson has said to just kind of garner everyone's feedback and get some guidance on a path forward.
+
+117
+00:13:23,203 --> 00:13:30,034
+SPEAKER_20: The intent is to do outreach and engagement in June based on some of that guidance and engage with the community.
+
+118
+00:13:30,014 --> 00:13:40,690
+SPEAKER_20: We would be coming back for board consideration in July with an actual recommended action to the committee and then provided the committee advanced it at the board meeting.
+
+119
+00:13:40,730 --> 00:13:46,319
+SPEAKER_20: And we would begin implementation in August with full implementation in October.
+
+120
+00:13:48,141 --> 00:13:50,144
+SPEAKER_20: And with that, I will open it up.
+
+121
+00:13:51,246 --> 00:13:51,667
+SPEAKER_10: Perfect.
+
+122
+00:13:52,167 --> 00:13:53,890
+SPEAKER_10: Thank you very much for your presentation, Ms.
+
+123
+00:13:53,950 --> 00:13:54,391
+SPEAKER_10: Vallejoz.
+
+124
+00:13:55,332 --> 00:13:57,455
+SPEAKER_10: OK, I'm going to open it up for directors.
+
+125
+00:13:57,796 --> 00:13:58,637
+SPEAKER_10: Second Vice Chair Whitmore.
+
+126
+00:13:59,765 --> 00:14:04,551
+Whitmore: Thank you for the presentation and the ease of absorbing the proposed changes.
+
+127
+00:14:05,433 --> 00:14:17,930
+Whitmore: Erin, looking at the second proposal, the tiered approach, one of our commenters talked about the complications of keeping up with number of trips.
+
+128
+00:14:18,671 --> 00:14:24,118
+Whitmore: Is that something that the new staff would be able to be
+
+129
+00:14:24,098 --> 00:14:49,870
+Whitmore: Clearinghouse if you will tour you have one call to RTD instead of calling a taxi and a lift and an Uber That seems to be the most difficult part of that I'm just curious if you think our staff would be handling that in a way that would be handy for our customers It's definitely something I think we could assist with but I do think there would still be some burden on the customer for having some of that responsibility and
+
+130
+00:14:50,356 --> 00:14:55,925
+SPEAKER_20: Again, as I mentioned, as it stands today, there is just a very manual aspect of the program.
+
+131
+00:14:56,466 --> 00:15:04,859
+SPEAKER_20: And so while we're always looking at things to improve, I do think there would still be some responsibility that would live with the customer.
+
+132
+00:15:07,082 --> 00:15:07,723
+SPEAKER_09: Thank you.
+
+133
+00:15:09,526 --> 00:15:09,986
+Catlin: Thank you.
+
+134
+00:15:10,127 --> 00:15:16,273
+Catlin: And thank you for a very clear presentation, although I have one question of clarification.
+
+135
+00:15:16,633 --> 00:15:19,376
+Catlin: You talk about mirroring the existing service area.
+
+136
+00:15:20,657 --> 00:15:35,652
+Catlin: One of the things that appealed to me about this service was that, um, I don't think that the customers were restricted to the three quarter mile within a fixed route.
+
+137
+00:15:36,391 --> 00:15:38,353
+Catlin: Would that change with this?
+
+138
+00:15:38,373 --> 00:15:43,198
+Catlin: Any of these proposals or would it still be over the entire RTD service area?
+
+139
+00:15:44,199 --> 00:15:53,249
+SPEAKER_20: As the pro the proposals are presented, we are proposing mirroring the three quarter of a mile boundary that exists today for our accessory customers.
+
+140
+00:15:56,793 --> 00:15:57,373
+Catlin: Okay, that.
+
+141
+00:15:59,976 --> 00:16:03,299
+Catlin: That presents some problems for me, but we can talk about that later.
+
+142
+00:16:03,339 --> 00:16:03,900
+Catlin: Thank you.
+
+143
+00:16:06,142 --> 00:16:07,204
+=START-1=
+SPEAKER_10: Secretary Nicholson.
+
+144
+00:16:09,247 --> 00:16:10,669
+Nicholson: Thank you very much.
+
+145
+00:16:11,731 --> 00:16:18,081
+Nicholson: I think I first want to echo and perhaps be a little bit more direct about what Director Catlin said.
+
+146
+00:16:20,164 --> 00:16:25,613
+Nicholson: We have bus routes in this system that don't qualify for the ADA service, but they're bus routes anyway.
+
+147
+00:16:26,674 --> 00:16:29,719
+Nicholson: There are commuter routes and I
+
+148
+00:16:29,699 --> 00:16:38,215
+Nicholson: would not vote personally for a change that would cut off the people who live within three quarters of a mile of those routes.
+
+149
+00:16:38,275 --> 00:16:44,687
+Nicholson: So at least for me, you guys want to get this through, you're going to need to change that because it's just a matter of basic equity.
+
+150
+00:16:44,727 --> 00:16:46,290
+Nicholson: Otherwise, Peggy has like
+
+151
+00:16:46,962 --> 00:16:50,689
+Nicholson: two places in our district that get service and that's just not reasonable.
+
+152
+00:16:50,709 --> 00:16:53,836
+Nicholson: There are a lot of older folks that live up in those areas.
+
+153
+00:16:54,818 --> 00:17:02,052
+Nicholson: I think the second issue that I have with what's being proposed is that the needs of
+
+154
+00:17:02,673 --> 00:17:11,729
+Nicholson: you know, not call it rural, but mountainous Jefferson County when it comes to AOD are very different than the needs of central Denver.
+
+155
+00:17:12,530 --> 00:17:22,487
+Nicholson: The trips I can get to most places that I need to go, you know, in terms of grocery stores, medical, et cetera, in a $15 Uber.
+
+156
+00:17:22,467 --> 00:17:31,493
+Nicholson: You know, I don't think there's anywhere that you can get to for 15 bucks in Peggy's district or yours exactly.
+
+157
+00:17:31,513 --> 00:17:33,017
+Nicholson: And so.
+
+158
+00:17:33,638 --> 00:17:38,545
+Nicholson: But creating a system where the trip cap is 40 bucks doesn't work for me.
+
+159
+00:17:38,665 --> 00:17:44,074
+Nicholson: Creating a trip cap where it's 15 bucks doesn't work for the people in her district.
+
+160
+00:17:44,154 --> 00:17:55,811
+Nicholson: It strikes me that the right approach would be to have different levels of financial cap and different levels of trip cap to go along with them and let people pick.
+
+161
+00:17:55,931 --> 00:17:57,874
+Nicholson: You want 60 trips at
+
+162
+00:17:58,090 --> 00:17:59,212
+Nicholson: $15 per.
+
+163
+00:17:59,673 --> 00:17:59,914
+Nicholson: Great.
+
+164
+00:17:59,974 --> 00:18:02,539
+Nicholson: You want 50 trips at $20 per.
+
+165
+00:18:02,679 --> 00:18:02,900
+Nicholson: Great.
+
+166
+00:18:02,960 --> 00:18:05,906
+Nicholson: You want 40 trips at $30 per.
+
+167
+00:18:06,266 --> 00:18:06,507
+Nicholson: Great.
+
+168
+00:18:06,567 --> 00:18:07,669
+Nicholson: Depends on where you live.
+
+169
+00:18:07,689 --> 00:18:09,633
+Nicholson: Depends on the types of trips you're going to be taking.
+
+170
+00:18:09,693 --> 00:18:19,693
+Nicholson: But making people all fit into one size is either going to leave her people paying $20 for every single trip that they take.
+
+171
+00:18:19,673 --> 00:18:28,772
+Nicholson: or it's going to put people in my district in a reduced number of rides because very few trips are going to cost $20 or $25.
+
+172
+00:18:29,032 --> 00:18:31,076
+Nicholson: So those are my two pieces of feedback.
+
+173
+00:18:31,096 --> 00:18:31,397
+Nicholson: Thank you.
+
+174
+00:18:33,581 --> 00:18:34,363
+SPEAKER_09: Thank you, Secretary.
+
+175
+00:18:35,165 --> 00:18:35,826
+SPEAKER_09: Director Ruscha.
+
+176
+00:18:40,480 --> 00:18:41,161
+Paglieri: Thank you, Mr. Chair.
+=END-1=
+
+177
+00:18:42,322 --> 00:18:46,726
+Paglieri: So I just wanted to offer a bit of context.
+
+178
+00:18:46,887 --> 00:18:51,792
+Paglieri: And the general manager, please interrupt me if I'm framing this wrong.
+
+179
+00:18:52,172 --> 00:18:58,459
+Paglieri: But the conversation that we're having tonight is a framework of a potential path forward.
+
+180
+00:18:59,139 --> 00:19:05,526
+Paglieri: And because of our OSS meeting went so long,
+
+181
+00:19:05,506 --> 00:19:12,034
+Paglieri: we weren't able to get to through the discussion and that also I think impacted our ability to have some interim discussions.
+
+182
+00:19:12,074 --> 00:19:35,344
+Paglieri: So I just want folks to you know keep keep an open mind to what staff is saying and definitely share that feedback because we're on a timeline but also just recognize that well and please if I'm saying the strong introduction but what is being presented is a concept framework and so we want so we'll get more feedback and then of course staff is going to be working very closely
+
+183
+00:19:35,662 --> 00:19:43,093
+Paglieri: with our existing customers and advocacy organizations to make further refinements and give us some more stuff to look at.
+
+184
+00:19:43,154 --> 00:19:50,285
+Paglieri: So I hope I didn't speak out of turn, but I just wanted to offer that for context.
+
+185
+00:19:51,026 --> 00:20:03,525
+Paglieri: And I'm also listening and taking notes and I know staff is, so I would just urge if anyone has thoughts one way or another, please share them tonight since we are also on
+
+186
+00:20:03,809 --> 00:20:07,758
+Paglieri: timeline with our existing partners and those contracts as well.
+
+187
+00:20:07,798 --> 00:20:08,159
+Paglieri: Thank you.
+
+188
+00:20:09,281 --> 00:20:09,923
+Guissinger: Thank you, Director.
+
+189
+00:20:10,724 --> 00:20:11,406
+Guissinger: Director Larson.
+
+190
+00:20:15,054 --> 00:20:15,495
+Larsen: Thank you.
+
+191
+00:20:15,595 --> 00:20:17,940
+Larsen: I just have a question for Ms.
+
+192
+00:20:17,980 --> 00:20:18,441
+Larsen: Vallejos.
+
+193
+00:20:19,744 --> 00:20:23,252
+Larsen: So I saw I seen one of those slot these slides that it says there's
+
+194
+00:20:23,536 --> 00:20:32,065
+Larsen: In December of 2024, there were about 2,900 total active customers of access on demand.
+
+195
+00:20:33,127 --> 00:20:38,292
+Larsen: So there were 2,900 people, roughly, who used it in all of December.
+
+196
+00:20:39,073 --> 00:20:39,574
+Larsen: Is that right?
+
+197
+00:20:40,915 --> 00:20:43,518
+SPEAKER_20: I know that would be for the year, I believe.
+
+198
+00:20:44,599 --> 00:20:45,280
+Larsen: Let me just.
+
+199
+00:20:45,420 --> 00:20:45,941
+Larsen: OK.
+
+200
+00:20:45,961 --> 00:20:50,946
+Larsen: So 2,900 people used this service for the whole year.
+
+201
+00:20:51,227 --> 00:20:51,687
+Larsen: That's it.
+
+202
+00:20:52,578 --> 00:21:05,271
+Larsen: And so I guess what I'm trying to just understand is, if we were going to spend, say, $10 million or $15 million on 2,900 people,
+
+203
+00:21:05,740 --> 00:21:10,807
+Larsen: What do we think the equivalent is for just our regular riders?
+
+204
+00:21:11,107 --> 00:21:12,048
+Larsen: Do we have any guess?
+
+205
+00:21:12,669 --> 00:21:15,032
+Larsen: I mean, I know people have different ridership.
+
+206
+00:21:15,072 --> 00:21:29,430
+Larsen: If we have a million customers a year and it's the majority of our budget, I'm just trying to get a sense of how the per-person spend for a regular rider compares to the per-person spend for access on demand.
+
+207
+00:21:31,713 --> 00:21:33,756
+SPEAKER_20: Go ahead, Deborah.
+
+208
+00:21:35,542 --> 00:21:39,048
+SPEAKER_16: So if I can, Mr. Chair, and thank you, Director Larsen, for the question.
+
+209
+00:21:39,309 --> 00:21:41,753
+SPEAKER_16: I would not want us to conjecture and speculate.
+
+210
+00:21:41,814 --> 00:21:43,617
+SPEAKER_16: We could double back and give you those numbers.
+
+211
+00:21:44,519 --> 00:21:50,249
+SPEAKER_16: As we talk about, you use the term regular writer, you're talking about those that are using fixed route service.
+
+212
+00:21:50,269 --> 00:21:53,415
+SPEAKER_16: I just want to be clear and intentional with the language we're using going forward.
+
+213
+00:21:53,395 --> 00:22:02,188
+SPEAKER_16: So we need to assess that because it's a different level of service because with fixed route bus, we're not providing curb to curb service.
+
+214
+00:22:02,528 --> 00:22:06,454
+SPEAKER_16: And so we can double back and share that information with the board.
+
+215
+00:22:07,395 --> 00:22:11,521
+SPEAKER_16: But I think it wouldn't be fruitful for us to guesstimate because this is critically important.
+
+216
+00:22:11,882 --> 00:22:17,390
+SPEAKER_16: But as we come back and we have some guidance, we could provide that detailed information, if you will.
+
+217
+00:22:17,790 --> 00:22:18,131
+SPEAKER_16: Thank you.
+
+218
+00:22:20,113 --> 00:22:21,175
+SPEAKER_16: Thank you.
+
+219
+00:22:22,505 --> 00:22:24,588
+SPEAKER_10: Any other directors comments?
+
+220
+00:22:24,608 --> 00:22:25,409
+SPEAKER_09: Yeah, director Guzman.
+
+221
+00:22:26,351 --> 00:22:33,882
+Guzman: So I am concerned with the aligning with the ADA for the service area.
+
+222
+00:22:36,365 --> 00:22:40,311
+Guzman: District C is fairly blessed with
+
+223
+00:22:40,713 --> 00:22:49,686
+Guzman: multiple forms of transit and fixed route, where this is not a particular problem, but it is an issue in the suburban areas of the region.
+
+224
+00:22:50,127 --> 00:23:03,767
+Guzman: And it is highly concerning that we would restrict it so much where people would be left off of the system that live within a quarter mile of a commuter bus and still not be able to access this.
+
+225
+00:23:06,262 --> 00:23:18,596
+Guzman: I also think that as we proceed into the future after the demographers presentation to the finance and planning committee, a big concern will be our aging population in the region.
+
+226
+00:23:19,478 --> 00:23:24,624
+Guzman: And it's a, you know, somebody said that this is a drop in the bucket for our budget.
+
+227
+00:23:25,845 --> 00:23:36,117
+Guzman: Maybe right now, but eventually this is going to catch up with us, which is why we're having this conversation and access on demand and folks that are able to
+
+228
+00:23:36,451 --> 00:23:50,934
+Guzman: or out of need, utilize this system, need to be considered as humans first and how we serve them, which is our mission, right?
+
+229
+00:23:50,954 --> 00:23:52,637
+Guzman: They need connection as well.
+
+230
+00:23:53,107 --> 00:24:06,549
+Guzman: and not every one of them will be able to jump from a, jump, roll, walk, shuffle to a fixed route form of transportation to get them to their destinations.
+
+231
+00:24:07,511 --> 00:24:14,081
+Guzman: I have a question about the time on this, right?
+
+232
+00:24:14,542 --> 00:24:19,350
+Guzman: If it's mirroring regular service provision for the whole region,
+
+233
+00:24:20,579 --> 00:24:28,370
+Guzman: It kind of makes sense, but I would still be concerned for the reasons that emergencies don't happen on RTD schedule.
+
+234
+00:24:29,371 --> 00:24:38,384
+Guzman: And so somebody who already has a specific need for this type of transportation usage might need to go to the doctor.
+
+235
+00:24:38,924 --> 00:24:41,608
+Guzman: And what do they do if they're unable to drive?
+
+236
+00:24:42,128 --> 00:24:52,688
+Guzman: And regular bus service is not something that they can use because the buses aren't running a two o'clock in the morning emergency room visit is not unheard of and not uncommon in anybody's life.
+
+237
+00:24:53,249 --> 00:24:56,014
+Guzman: And yet what do we do to take care of those that are most vulnerable.
+
+238
+00:24:57,397 --> 00:25:00,643
+Guzman: So for me, I would really want to see some clarity around
+
+239
+00:25:01,028 --> 00:25:02,050
+Guzman: those two areas.
+
+240
+00:25:03,191 --> 00:25:08,700
+Guzman: I am frankly less concerned about minimal difference of cost savings.
+
+241
+00:25:09,621 --> 00:25:12,145
+Guzman: I mean, we're talking $5 million.
+
+242
+00:25:12,185 --> 00:25:18,295
+Guzman: That's not really the top priority for me on that part.
+
+243
+00:25:18,680 --> 00:25:43,557
+Guzman: right now it will eventually get there because this will likely continue to grow but I do want to make sure that we are basing ourselves in reality to serve the taxpayers needs and this is a need right this is not a desire as some of the other services we want to grow and create are this one is an actual need and so I want to be clear in my language on that and why I'm
+
+244
+00:25:44,566 --> 00:25:46,914
+Guzman: depositing these comments within that framework.
+
+245
+00:25:47,255 --> 00:25:48,479
+Guzman: So that would be my feedback.
+
+246
+00:25:48,499 --> 00:25:52,994
+Guzman: I'd like to see something a little bit different on those two things, the service area and the time for service.
+
+247
+00:25:53,175 --> 00:25:53,476
+Guzman: Thank you.
+
+248
+00:25:54,058 --> 00:25:54,760
+Guzman: Thank you, Director.
+
+249
+00:25:55,443 --> 00:25:56,145
+Guzman: Director Harwick.
+
+250
+00:25:57,138 --> 00:25:59,422
+Harwick: Well, thank you, Director Guzman.
+
+251
+00:25:59,442 --> 00:26:01,746
+Harwick: I'm just going to pretty much replicate everything you just said.
+
+252
+00:26:01,766 --> 00:26:11,162
+Harwick: I represent Arvada, and Arvada is actually the fastest growing aging population.
+
+253
+00:26:11,362 --> 00:26:12,564
+Harwick: However, I said that.
+
+254
+00:26:12,645 --> 00:26:13,506
+Harwick: I'm not sure I said it right.
+
+255
+00:26:14,167 --> 00:26:19,637
+Harwick: And a lot of our service is not in the areas where we have those aging people.
+
+256
+00:26:20,198 --> 00:26:22,842
+Harwick: So I'd really like to see
+
+257
+00:26:23,395 --> 00:26:25,438
+Harwick: just the boundary kept the same.
+
+258
+00:26:25,558 --> 00:26:30,484
+Harwick: I'm also really again with director Guzman keeping it as a full 24 seven.
+
+259
+00:26:30,504 --> 00:26:46,905
+Harwick: I just like I have a friend in a wheelchair and I just think about her trying like if she didn't live where she lived if she lived where I live she would have such a difficult time getting you know around her community and I won't just
+
+260
+00:26:47,408 --> 00:26:52,899
+Harwick: especially like if the service is outside of that time period, it's just precluding her life.
+
+261
+00:26:52,959 --> 00:27:04,101
+Harwick: And I know we don't all have these, the same abilities when we're riding the bus, but for a person with disability that's blind or in a wheelchair, I think that we can sort of extend them the grace that they deserve.
+
+262
+00:27:05,009 --> 00:27:07,453
+Harwick: I also would like to see the cap stay at 60.
+
+263
+00:27:07,613 --> 00:27:20,816
+Harwick: I think that, again, I know that it's a, you know, less than 10% of the population go above the 50 rides, but I think it's still like that's, we're giving them access to a free and full life.
+
+264
+00:27:21,878 --> 00:27:30,072
+Harwick: And I think if we are gonna go with the 650, I think that that to me is fine, but I also think that it would be imperative that we really,
+
+265
+00:27:30,052 --> 00:27:57,561
+Harwick: put out the live program and let let those writers know That there is another option like there's always with someone the other day she Lives about three miles away from where she works and you know She can afford it, but just barely and she didn't know about the live program So I think that there's we're missing an opportunity there specifically with these With these writers so and then my last one is just a request is it possible to get a map of
+
+266
+00:27:57,541 --> 00:28:12,317
+Harwick: like sort of like a density map of where AOD is like highly being used to sort of go with that, like thinking about, you know, West Jefferson County versus central Denver, just kind of see what that looks like.
+
+267
+00:28:12,417 --> 00:28:19,605
+Harwick: Obviously we want to anonymize the data, but I think it's sort of just would be interesting for us to know where the sort of hotspots of usage are.
+
+268
+00:28:19,645 --> 00:28:20,906
+Harwick: Thank you.
+
+269
+00:28:20,946 --> 00:28:21,667
+SPEAKER_09: Thank you, Director Harwick.
+
+270
+00:28:21,867 --> 00:28:22,028
+SPEAKER_09: Ms.
+
+271
+00:28:22,048 --> 00:28:22,468
+Harwick: Johnson.
+
+272
+00:28:23,478 --> 00:28:41,897
+SPEAKER_16: Yes, Director Harwick, if I understood you correctly, because I'm taking copious notes here, you are in support for all intents and purposes of what I hear, the modification of scenario one, keeping it at 60 trips with 650 and then one information relative to what the current usage is from a geographic vantage point.
+
+273
+00:28:42,397 --> 00:28:43,178
+SPEAKER_16: Okay, thank you.
+
+274
+00:28:44,439 --> 00:28:45,060
+Harwick: Thank you.
+
+275
+00:28:45,080 --> 00:28:49,144
+Harwick: Yeah, but I also want to keep the service areas the same as they are today.
+
+276
+00:28:49,664 --> 00:28:51,967
+SPEAKER_10: Yeah.
+
+277
+00:28:51,987 --> 00:28:52,287
+SPEAKER_10: Excellent.
+
+278
+00:28:53,549 --> 00:28:55,493
+=START-2=
+SPEAKER_10: Director Nicholson, then Director Ruscha.
+
+279
+00:28:57,036 --> 00:29:00,702
+Nicholson: Yeah, just a quick follow-up onto that.
+
+280
+00:29:01,684 --> 00:29:09,058
+Nicholson: When it comes to go to Director Ruscha, my brain, I lost my train of thought for a second, so.
+
+281
+00:29:10,341 --> 00:29:11,102
+SPEAKER_10: Alright, Director Ruscha.
+
+282
+00:29:15,908 --> 00:29:17,110
+Paglieri: Thank you for the red rover.
+=END-2=
+
+283
+00:29:17,171 --> 00:29:17,972
+Paglieri: I wasn't prepared.
+
+284
+00:29:17,992 --> 00:29:18,874
+Paglieri: I went back to my notes.
+
+285
+00:29:19,375 --> 00:29:19,796
+Paglieri: Okay.
+
+286
+00:29:19,816 --> 00:29:34,305
+Paglieri: So, um, anyway, I, um, so I, some of this, um, feedback I did share with staff and I, um, I don't want to be repetitive, but I also just want to be really transparent with my, my colleagues, uh, because we haven't had this public conversation yet.
+
+287
+00:29:34,758 --> 00:29:52,084
+Paglieri: And just high level, some of the things that I had shared was, you know, first of all, we don't want to put one proposal out before the community and get feedback like the one that we've had out for several months and then come back with something else that looks like less than what we originally proposed.
+
+288
+00:29:52,185 --> 00:29:55,129
+Paglieri: And so one of the pain points that I had was just the idea of
+
+289
+00:29:55,430 --> 00:29:59,337
+Paglieri: going up to 650 for the initial fare because that's not what we originally put out there.
+
+290
+00:29:59,678 --> 00:30:10,558
+Paglieri: So one of the things that I urge is that if we put an offer on the table, so to speak, we don't take it back.
+
+291
+00:30:10,958 --> 00:30:12,601
+Paglieri: That's kind of our baseline now.
+
+292
+00:30:13,363 --> 00:30:18,552
+Paglieri: And another piece of feedback I had is that where something is not
+
+293
+00:30:20,337 --> 00:30:32,897
+Paglieri: For every change we make, which essentially results in a reduction of a service of some kind or an increase in price, we really have to justify that line by line.
+
+294
+00:30:33,277 --> 00:30:41,731
+Paglieri: So for example, if we decide that we are going to strictly align with service hours, then we have to justify it.
+
+295
+00:30:41,891 --> 00:30:43,233
+Paglieri: It doesn't cost us any more money.
+
+296
+00:30:43,393 --> 00:30:44,415
+Paglieri: It's not going to save us a penny.
+
+297
+00:30:44,856 --> 00:30:48,201
+Paglieri: If somebody, you know, uses on demand,
+
+298
+00:30:49,008 --> 00:30:53,458
+Paglieri: 15 or 20 minutes or an hour before fixed drought starts.
+
+299
+00:30:55,102 --> 00:31:00,013
+Paglieri: Likewise, it's not costing us that I could see a lot of money, if any.
+
+300
+00:31:00,415 --> 00:31:04,880
+Paglieri: for us to offer service outside of our general service area.
+
+301
+00:31:05,961 --> 00:31:08,864
+Paglieri: I know that was flagged in the peer review.
+
+302
+00:31:09,184 --> 00:31:28,164
+Paglieri: So I, because this idea has been on the table for so many months, I also want to caution us about the service area idea because if we restrict the service, that means there are people who currently are using AOD and they're going to lose it.
+
+303
+00:31:28,885 --> 00:31:29,325
+Paglieri: So
+
+304
+00:31:30,267 --> 00:31:40,961
+Paglieri: I, um, so that was just, I mean, that was just the, the kind of like high level, like, um, theme that I had in, in the feedback.
+
+305
+00:31:41,602 --> 00:31:54,840
+Paglieri: Um, and also, you know, I'm going back to the, uh, initial like a fair, um, we also want to be really careful about what we think.
+
+306
+00:31:55,192 --> 00:31:58,378
+Paglieri: is inexpensive because it's really relative.
+
+307
+00:31:58,418 --> 00:32:17,892
+Paglieri: So for some folks using the service and they have like a fixed income or very limited income, if we even do you know 450 which would be parity with excess ride and I think I could accept that but like say we go up to 650 or we do this tiered system
+
+308
+00:32:18,445 --> 00:32:26,853
+Paglieri: then for some folks, they are not going to be able to write or they're going to be choosing, do I get to the doctor or do I buy food for tonight?
+
+309
+00:32:27,013 --> 00:32:30,717
+Paglieri: So I just wanted to put that out there.
+
+310
+00:32:31,117 --> 00:32:40,907
+Paglieri: And finally, well, actually, I'll stop there.
+
+311
+00:32:40,927 --> 00:32:48,334
+Paglieri: I concurred with what a lot of other directors said in terms of keeping the program as is as much as we can.
+
+312
+00:32:49,023 --> 00:33:01,228
+Paglieri: I think that, but I also just want to commend staff, you know, because we are at a much different place than where we were several months ago.
+
+313
+00:33:01,869 --> 00:33:03,673
+Paglieri: This is a totally different conversation.
+
+314
+00:33:04,396 --> 00:33:05,957
+Paglieri: really slashing this program.
+
+315
+00:33:06,738 --> 00:33:12,203
+Paglieri: And staff did a lot of work and we spent several months, we almost voted on this a few months ago.
+
+316
+00:33:12,243 --> 00:33:21,110
+Paglieri: And they listened to us as directors and they listened to community because as you know, we've had hundreds of public comments over several months on this.
+
+317
+00:33:21,751 --> 00:33:29,618
+Paglieri: And they said, okay, we can take a timeout, we can reassess, we can get some different data, we can, you know, kind of present a new paradigm.
+
+318
+00:33:29,638 --> 00:33:33,441
+Paglieri: So again, what's before us today is a sketch of ideas, the feedback is good.
+
+319
+00:33:33,691 --> 00:33:38,728
+Paglieri: But I really do want to commend staff for listening and working with us in partnership.
+
+320
+00:33:38,748 --> 00:33:39,671
+Paglieri: So thank you.
+
+321
+00:33:39,691 --> 00:33:41,076
+Paglieri: And thank you.
+
+322
+00:33:42,280 --> 00:33:43,143
+Guissinger: Thank you, Director Ruscha.
+
+323
+00:33:43,323 --> 00:33:44,046
+=START-3=
+Guissinger: Director Nicholson.
+
+324
+00:33:45,431 --> 00:33:46,755
+Nicholson: Thank you.
+
+325
+00:33:48,119 --> 00:34:02,977
+Nicholson: Is there any step during enrollment of AAR and AOD where we ask people if they are enrolled in the live program and ask them, hey, we're taking 14 other pieces of documentation from you.
+
+326
+00:34:02,997 --> 00:34:06,982
+Nicholson: I mean, AAR is remarkably complicated to sign up for.
+
+327
+00:34:07,723 --> 00:34:13,911
+Nicholson: Is there any part of that process where we try to enroll them in the live program as well?
+
+328
+00:34:13,951 --> 00:34:15,072
+Nicholson: And then I have a quick follow up.
+
+329
+00:34:19,844 --> 00:34:22,427
+SPEAKER_20: I will have to find out about that as part of the process.
+
+330
+00:34:22,828 --> 00:34:27,734
+SPEAKER_20: Um, and we will confirm if that is, you know, how that is handled as, as part of the process.
+
+331
+00:34:28,855 --> 00:34:29,075
+Nicholson: Yeah.
+
+332
+00:34:29,155 --> 00:34:39,448
+Nicholson: So, yeah, as a, as a first thing I would say that since we're going to be updating this to offer the, the live discount and, and not make it free, uh, it should be required as part of the process.
+
+333
+00:34:39,508 --> 00:34:47,978
+Nicholson: If you're going through to sign up for AOD or AAR, some point in that process to set, to ask someone to affirm that they are either already signed up or,
+
+334
+00:34:48,228 --> 00:34:52,593
+Nicholson: haven't signed up or whatever, and then give them the opportunity to make it super easy.
+
+335
+00:34:52,653 --> 00:34:59,220
+Nicholson: Because we only have 15,000 people signed up for live right now, and we have 180 something thousand boardings every day.
+
+336
+00:34:59,340 --> 00:35:05,888
+Nicholson: And I think only about half the people in AOD are currently signed up for, or AAR currently signed up for live.
+
+337
+00:35:05,908 --> 00:35:08,291
+Nicholson: So definitely something I'd like to see there.
+
+338
+00:35:08,331 --> 00:35:17,661
+Nicholson: The second thing, I want to echo what Director Ruscha said about the effect on people who
+
+339
+00:35:18,215 --> 00:35:34,300
+Nicholson: are low income to having these fares, but I want to take it from the other side, which is if you don't have a lot of money and you need to get around to a lot of places, then 40 trips maybe, or whatever the number ends up being, not nearly enough in a way that someone who makes more money
+
+340
+00:35:34,280 --> 00:35:37,643
+Nicholson: can probably have some discretionary to be like, oh, I've run out of trips.
+
+341
+00:35:37,723 --> 00:35:40,966
+Nicholson: I can afford to take an extra three or five or whatever.
+
+342
+00:35:40,986 --> 00:35:45,110
+Nicholson: So I'm not sure that that needs to be fit into the policy here.
+
+343
+00:35:45,170 --> 00:35:47,712
+Nicholson: I'm wary about trying to do too much too quickly.
+
+344
+00:35:48,033 --> 00:35:58,522
+Nicholson: But I do think we need to get a report from you after, I don't know, six months a year that looks at how many trips are people on live using?
+
+345
+00:35:58,763 --> 00:35:59,744
+Nicholson: Are they maxing out?
+
+346
+00:36:00,184 --> 00:36:02,346
+Nicholson: Or are we seeing sort of the same curve?
+
+347
+00:36:02,326 --> 00:36:15,021
+Nicholson: from live users as we do from regular users right now, and that might inform us to take action a year from now to try to offer the right service for people who need it.
+
+348
+00:36:15,062 --> 00:36:17,104
+Nicholson: Some live people make decent incomes.
+
+349
+00:36:17,284 --> 00:36:24,653
+Nicholson: Some of them are literally broke, and we need to recognize that those two groups of people have very different lived experiences.
+
+350
+00:36:25,374 --> 00:36:26,215
+SPEAKER_10: Thank you, Secretary.
+
+351
+00:36:26,315 --> 00:36:26,475
+SPEAKER_10: Ms.
+
+352
+00:36:26,515 --> 00:36:26,856
+SPEAKER_10: Johnson?
+
+353
+00:36:27,236 --> 00:36:30,240
+SPEAKER_16: Yes, thank you very much, Director Nicholson.
+=END-3=
+
+354
+00:36:30,372 --> 00:36:33,095
+SPEAKER_16: Mr. Chair, thank you, Director Nicholson, for the comments.
+
+355
+00:36:33,555 --> 00:36:50,174
+SPEAKER_16: And what I will say in reference to your request, it appeared to be a directive, but I would just offer this up to you that once we collectively agree upon the path forward in this Board acts, we can then assess what might be most prudent, because at this point in time, we don't know what we don't know.
+
+356
+00:36:50,194 --> 00:36:55,980
+SPEAKER_16: And relative to what you just asked, I can't commit to that without knowing what we intend to do.
+
+357
+00:36:56,140 --> 00:36:57,882
+SPEAKER_16: So I just had to say that for the record.
+
+358
+00:36:58,081 --> 00:36:59,102
+SPEAKER_16: because it seemed as if Ms.
+
+359
+00:36:59,162 --> 00:37:02,767
+SPEAKER_16: Baleos was giving direction, and I don't think that's appropriate at this juncture.
+
+360
+00:37:03,067 --> 00:37:03,527
+SPEAKER_10: Thank you.
+
+361
+00:37:05,009 --> 00:37:05,330
+SPEAKER_10: Thank you.
+
+362
+00:37:05,350 --> 00:37:05,410
+SPEAKER_10: Ms.
+
+363
+00:37:05,430 --> 00:37:06,010
+SPEAKER_10: Director Larson.
+
+364
+00:37:07,752 --> 00:37:08,193
+SPEAKER_10: Thank you.
+
+365
+00:37:08,213 --> 00:37:14,761
+Larsen: I was just kind of doing some stuff on my calculator.
+
+366
+00:37:14,881 --> 00:37:25,253
+Larsen: And so if we only have 3,000 people who use excess on demand, I mean, it seems like the disabled population
+
+367
+00:37:25,570 --> 00:37:31,456
+Larsen: You know, it might be 300,000 people in Denver or something, you know, much, much larger.
+
+368
+00:37:32,937 --> 00:37:39,504
+Larsen: Do we, how do, how confident are we of our projection that it'll stay at around, I mean, or, or however much we think it'll increase?
+
+369
+00:37:39,524 --> 00:37:51,055
+Larsen: I mean, what do we think the total number of active users might become and why won't it become, you know, several, many multiples more than 3,000 or so?
+
+370
+00:37:56,671 --> 00:38:05,481
+SPEAKER_16: First, if I may, just for everyone's identification, you probably have heard this over the course of several months in the public comment discussions.
+
+371
+00:38:06,182 --> 00:38:21,379
+SPEAKER_16: When we talk about access on demand, currently as it's configured, recognizing that we're using private entities, transportation network companies in particular, not all of the vehicles are outfitted to be wheelchair accessible.
+
+372
+00:38:21,646 --> 00:38:29,435
+SPEAKER_16: So that's a critical element when we're talking about the population because there's different disabilities that individuals have.
+
+373
+00:38:29,515 --> 00:38:36,404
+SPEAKER_16: Some may have cognitive, somebody may be using a mobility device, which can't be accommodated going forward.
+
+374
+00:38:36,424 --> 00:38:39,347
+SPEAKER_16: So I just wanted to provide that context prior to Ms.
+
+375
+00:38:39,367 --> 00:38:44,233
+SPEAKER_16: Vallejo's answering the question because that has not been factored into this conversation this evening.
+
+376
+00:38:44,253 --> 00:38:45,655
+SPEAKER_16: And I believe it's a germane point.
+
+377
+00:38:47,677 --> 00:38:48,278
+SPEAKER_16: Thank you, Director.
+
+378
+00:38:48,781 --> 00:38:53,165
+SPEAKER_20: And I don't think I need to add anything that was really exactly what I was going to say.
+
+379
+00:38:53,225 --> 00:38:58,851
+SPEAKER_20: Not everyone is able to use the access on demand service that is eligible for excessive ride.
+
+380
+00:38:59,251 --> 00:39:00,633
+SPEAKER_20: Other is a difference there.
+
+381
+00:39:01,293 --> 00:39:02,214
+Larsen: Can I just follow up?
+
+382
+00:39:02,234 --> 00:39:09,161
+Larsen: But I mean, surely many more people than 3000 in the metro area would be eligible though.
+
+383
+00:39:10,682 --> 00:39:15,447
+SPEAKER_20: Well, and again, we have continued continue to see substantial growth.
+
+384
+00:39:15,865 --> 00:39:20,290
+SPEAKER_20: in the number of customers that are beginning to use the service.
+
+385
+00:39:20,751 --> 00:39:27,620
+SPEAKER_20: Again, the trips that we are seeing continue to grow even into this year, so we are seeing quite significant growth still.
+
+386
+00:39:30,763 --> 00:39:31,084
+SPEAKER_10: Thank you.
+
+387
+00:39:31,264 --> 00:39:31,584
+SPEAKER_10: Thank you.
+
+388
+00:39:32,385 --> 00:39:32,686
+SPEAKER_10: Thank you.
+
+389
+00:39:33,927 --> 00:39:35,389
+SPEAKER_10: Any further questions, comments?
+
+390
+00:39:37,632 --> 00:39:37,812
+SPEAKER_10: Ms.
+
+391
+00:39:37,872 --> 00:39:38,613
+SPEAKER_10: Johnson and Ms.
+
+392
+00:39:38,633 --> 00:39:40,636
+SPEAKER_10: Vallejoz, thank you very much for the presentation.
+
+393
+00:39:40,676 --> 00:39:42,959
+SPEAKER_10: I hope this was helpful feedback for going forward.
+
+394
+00:39:43,419 --> 00:39:44,100
+SPEAKER_10: So thank you.
+
+395
+00:39:44,722 --> 00:39:45,824
+SPEAKER_16: Yes, thank you, Mr. Chair.
+
+396
+00:39:45,864 --> 00:39:48,708
+SPEAKER_16: This was in the sense that we do have some guidance now.
+
+397
+00:39:48,748 --> 00:39:51,733
+SPEAKER_16: We know what we need to do as we do further outreach.
+
+398
+00:39:51,773 --> 00:39:54,156
+SPEAKER_16: So thank you all very much for the opportunity.
+
+399
+00:39:54,677 --> 00:40:04,352
+SPEAKER_16: And when we come back in July with a recommended action, hopefully we can all rally around that, recognizing the public comments that we heard in the direction in which you provide it.
+
+400
+00:40:04,372 --> 00:40:04,732
+SPEAKER_16: Thank you.
+
+401
+00:40:05,013 --> 00:40:05,313
+Guzman: Thank you.
+
+402
+00:40:05,814 --> 00:40:06,395
+Guzman: Director Guzman.
+
+403
+00:40:06,795 --> 00:40:10,181
+Guzman: Will that recommended action be going through operation safety and security?
+
+404
+00:40:11,923 --> 00:40:12,063
+SPEAKER_10: Ms.
+
+405
+00:40:12,103 --> 00:40:12,484
+SPEAKER_10: Johnson.
+
+406
+00:40:12,785 --> 00:40:14,751
+SPEAKER_16: Yes, thank you very much, Mr. Chair.
+
+407
+00:40:14,811 --> 00:40:17,318
+SPEAKER_16: And thank you, Director Guzman.
+
+408
+00:40:17,599 --> 00:40:19,706
+SPEAKER_16: I apologize for the question.
+
+409
+00:40:20,006 --> 00:40:22,614
+SPEAKER_16: Most definitely we will go through the committee procedure.
+
+410
+00:40:22,634 --> 00:40:25,282
+SPEAKER_16: The only reason why this didn't happen because it's time sensitive.
+
+411
+00:40:25,703 --> 00:40:26,305
+SPEAKER_16: So thank you.
+
+412
+00:40:26,977 --> 00:40:27,678
+SPEAKER_10: Thank you very much.
+
+413
+00:40:28,899 --> 00:40:29,220
+SPEAKER_10: All right.
+
+414
+00:40:29,300 --> 00:40:30,381
+SPEAKER_10: Well, thank you again, Ms.
+
+415
+00:40:30,421 --> 00:40:30,862
+SPEAKER_10: Filaios.
+
+416
+00:40:31,823 --> 00:40:32,104
+SPEAKER_10: All right.
+
+417
+00:40:32,384 --> 00:40:32,925
+SPEAKER_10: Moving on.
+
+418
+00:40:32,985 --> 00:40:35,268
+SPEAKER_10: Thank you, directors, for the questions and conversations.
+
+419
+00:40:35,568 --> 00:40:41,716
+SPEAKER_10: We're going to be moving to our committee reports, not, not to be the, the time police or anything.
+
+420
+00:40:41,756 --> 00:40:45,201
+SPEAKER_10: We are at 8 31 PM and we've been going at this since 3 30.
+
+421
+00:40:45,761 --> 00:40:49,486
+SPEAKER_10: If committee reports could be less than a minute, that'd be greatly appreciated.
+
+422
+00:40:50,107 --> 00:40:52,270
+SPEAKER_10: Audit committee chair music.
+
+423
+00:40:52,290 --> 00:40:53,271
+SPEAKER_10: What would you like to share?
+
+424
+00:40:54,213 --> 00:40:55,014
+Whitmore: Thank you, Mr. Chair.
+
+425
+00:40:55,054 --> 00:40:56,676
+Whitmore: We did not meet in April or May.
+
+426
+00:40:56,716 --> 00:40:58,518
+Whitmore: Our next meeting is June 12, 2025.
+
+427
+00:40:59,098 --> 00:41:00,200
+Whitmore: That concludes my report.
+
+428
+00:41:00,580 --> 00:41:01,281
+SPEAKER_10: Thank you.
+
+429
+00:41:01,301 --> 00:41:01,981
+SPEAKER_10: Thank you very much.
+
+430
+00:41:03,944 --> 00:41:06,386
+SPEAKER_10: Finance and Planning Committee Report, Committee Chair Guzman.
+
+431
+00:41:06,807 --> 00:41:07,467
+Guzman: Thank you, Mr. Chair.
+
+432
+00:41:08,669 --> 00:41:16,217
+Guzman: The Finance and Planning Committee met Tuesday, May 13th, discussed a handful of items, received a report from our state demographer, which was really awesome.
+
+433
+00:41:16,958 --> 00:41:23,545
+Guzman: Directors are reminded to email the board office if you had any follow-up questions or things specific to your sub-district so we can send that all at once.
+
+434
+00:41:23,660 --> 00:41:25,122
+Guzman: to receive an answer to the whole board.
+
+435
+00:41:25,823 --> 00:41:34,014
+Guzman: Received an update from DOTI for the East Colfax BRT and three items came out of committee, which will be before us tonight.
+
+436
+00:41:35,776 --> 00:41:47,071
+Guzman: Just want to thank the committee for all of the hard work and the next meeting for the finance and planning committee is scheduled for Tuesday, June 10th at 5.30 PM.
+
+437
+00:41:47,212 --> 00:41:47,592
+Guzman: Thank you.
+
+438
+00:41:48,652 --> 00:41:49,316
+SPEAKER_10: Thank you, Director.
+
+439
+00:41:50,504 --> 00:41:55,135
+SPEAKER_10: Committee Chair Ruscio or Committee Chair Harwick, what would you like to share for OSS?
+
+440
+00:41:56,110 --> 00:41:56,711
+Paglieri: I'll take it, sir.
+
+441
+00:41:57,653 --> 00:41:57,973
+Paglieri: Thank you.
+
+442
+00:41:58,033 --> 00:42:00,798
+Paglieri: So we met remotely on Wednesday, May 14th.
+
+443
+00:42:01,640 --> 00:42:04,204
+Paglieri: We gaveled in at 5.34 p.m.
+
+444
+00:42:04,405 --> 00:42:06,829
+Paglieri: and wrapped up at 9.44 p.m.
+
+445
+00:42:07,490 --> 00:42:09,714
+Paglieri: We had extensive public comments.
+
+446
+00:42:09,874 --> 00:42:12,219
+Paglieri: The most I've ever seen at any OSS meeting.
+
+447
+00:42:13,240 --> 00:42:13,781
+Paglieri: That was great.
+
+448
+00:42:13,881 --> 00:42:15,104
+Paglieri: Come visit us anytime.
+
+449
+00:42:16,166 --> 00:42:20,413
+Paglieri: It's always nice to know that people are listening to our podcast and by that I mean our YouTube channel.
+
+450
+00:42:20,393 --> 00:42:43,279
+Paglieri: But two major items that went on the consent calendar for tonight's meeting is the 2025-2028 Title VI program update, just ensuring that we stay in compliance with federal law, civil rights protections, and meet the needs of our customers, as well as the Allied Universal Security Services Contract Extension.
+
+451
+00:42:43,259 --> 00:42:48,224
+Paglieri: FNP authorized a budget transfer, which had no financial impact.
+
+452
+00:42:48,344 --> 00:42:50,247
+Paglieri: It was just moving from one department to another.
+
+453
+00:42:50,287 --> 00:42:58,996
+Paglieri: And then we filed that up with a vote to extend that contract for another year with the cost of up to just a little over 22 million.
+
+454
+00:42:59,777 --> 00:43:03,240
+Paglieri: And we did have four discussion items, two of which were heard.
+
+455
+00:43:04,282 --> 00:43:08,406
+Paglieri: So we had the Vision Zero update from GM CEO Johnson.
+
+456
+00:43:08,842 --> 00:43:13,869
+Paglieri: As you might recall, we passed a Vision Zero resolution last year, and so that planning process is underway.
+
+457
+00:43:14,690 --> 00:43:16,932
+Paglieri: We had a customer communications update.
+
+458
+00:43:17,653 --> 00:43:28,167
+Paglieri: Stuart Summers led an excellent presentation, discussing how we handle communications, some tech updates, customer service aspects.
+
+459
+00:43:28,147 --> 00:43:31,492
+Paglieri: real-time information and service alerts and things like that.
+
+460
+00:43:32,253 --> 00:43:39,585
+Paglieri: Unfortunately, we did hit our four-hour mark before we could finish our agenda items, and even though the nuggets weren't playing, folks wanted to go, and we were tired.
+
+461
+00:43:40,186 --> 00:43:51,403
+Paglieri: So we moved the on-demand item to the nice meeting, which we just heard, and then we'll be hearing Paratransit Legacy Customer Protection's proposal next month.
+
+462
+00:43:51,383 --> 00:44:03,481
+Paglieri: So for those of you who have been tracking what we're doing with paratransit, I strongly encourage you to come visit us at OSSX month and weigh in so we get your feedback before we come back with something more final.
+
+463
+00:44:04,383 --> 00:44:13,016
+Paglieri: Our next meeting is Wednesday, June 11th at 5.30, same time, same place, online or on the phone.
+
+464
+00:44:13,797 --> 00:44:14,097
+Paglieri: Thank you.
+
+465
+00:44:14,558 --> 00:44:15,940
+SPEAKER_10: Thank you, committee chair.
+
+466
+00:44:16,375 --> 00:44:19,039
+SPEAKER_10: Uh, now to for performance committee chair Guzman.
+
+467
+00:44:19,460 --> 00:44:20,060
+SPEAKER_10: I get it.
+
+468
+00:44:20,721 --> 00:44:21,623
+Guzman: Thank you, Mr. Chair.
+
+469
+00:44:22,043 --> 00:44:23,886
+Guzman: Performance committee met Monday, May 12th, 2025.
+
+470
+00:44:23,926 --> 00:44:39,649
+Guzman: Uh, I, I, the, the committee chair presented a draft proposal that I had worked on previously with vice chair Gucci and Ritter for the 2025 general manager, CEO performance assessment form and process that needed to be updated to seek input from the committee and other directors.
+
+471
+00:44:39,629 --> 00:44:52,120
+Guzman: to find a way forward for the rest of the year based on the current 2025 general manager CO short term goals and the respective adjustments made to the scoring points based on our votes in January.
+
+472
+00:44:52,640 --> 00:44:54,002
+Guzman: I've received some feedback.
+
+473
+00:44:54,183 --> 00:44:57,449
+Guzman: I continue to invite directors to submit the feedback.
+
+474
+00:44:57,489 --> 00:44:59,432
+Guzman: If you have not reviewed that meeting, please do so.
+
+475
+00:45:00,013 --> 00:45:02,718
+Guzman: And any questions you may have, please email me or call me.
+
+476
+00:45:03,019 --> 00:45:05,283
+Guzman: I am happy to engage in that conversation.
+
+477
+00:45:06,064 --> 00:45:14,479
+Guzman: Of course, we are doing that with participation and a lot of communication with the general manager CEO, Deborah Johnson.
+
+478
+00:45:14,847 --> 00:45:20,033
+Guzman: The next meeting of the performance committee is scheduled for June 2, 2025 at 8.30 a.m.
+
+479
+00:45:20,613 --> 00:45:25,799
+Guzman: I really want to encourage all of you, directors, to please participate in that meeting.
+
+480
+00:45:26,540 --> 00:45:27,041
+Guzman: Two reasons.
+
+481
+00:45:27,201 --> 00:45:28,362
+Guzman: One, we are going to receive.
+
+482
+00:45:29,483 --> 00:45:35,990
+Guzman: I hope I don't get this wrong because I don't have my work plan in front of me, but the employee survey results in the beginning of that meeting.
+
+483
+00:45:36,111 --> 00:45:38,273
+Guzman: And then we will adjourn into executive session.
+
+484
+00:45:38,607 --> 00:45:43,333
+Guzman: for the second quarterly one-on-one opportunity with our general manager CEO.
+
+485
+00:45:43,874 --> 00:45:57,713
+Guzman: And that is part of our contracted agreement with the general manager CEO to receive information from her and provide feedback regarding personnel matters.
+
+486
+00:45:59,127 --> 00:46:06,416
+Guzman: Additionally, the performance committee is set to have a second meeting in June because of that quarterly check-in.
+
+487
+00:46:07,357 --> 00:46:12,243
+Guzman: The second meeting is planned, I believe, for June 23rd at 8.30 a.m.
+
+488
+00:46:12,263 --> 00:46:21,754
+Guzman: And that is in order to do a deep dive into our community and customer surveys, which align with our community value and customer excellent strategic initiatives.
+
+489
+00:46:22,315 --> 00:46:26,400
+Guzman: And I would again encourage all directors to participate in that meeting as well.
+
+490
+00:46:26,752 --> 00:46:33,682
+Guzman: which is the overview of the current status of the agency's surveys and where we're at with regard to public.
+
+491
+00:46:34,102 --> 00:46:41,893
+Guzman: It will inform the process for setting goals and priorities for the 2026 year, which we are also doing all at the same time.
+
+492
+00:46:42,094 --> 00:46:55,813
+Guzman: So prioritizing what is important for our customers, the survey reports are a great opportunity to engage with direct feedback from our constituents in all areas of the agency.
+
+493
+00:46:56,266 --> 00:47:02,801
+Guzman: I do believe a little birdie has told me on one of the buses that these should be really positive discussions.
+
+494
+00:47:03,462 --> 00:47:13,023
+Guzman: So if you need more than that invitation, please signal tonight and I will call you and email you and hound you to be on these meetings because I think they're really important for all of us.
+
+495
+00:47:13,063 --> 00:47:13,785
+Guzman: Thank you.
+
+496
+00:47:14,288 --> 00:47:15,591
+SPEAKER_10: Thank you committee chair goes on.
+
+497
+00:47:16,432 --> 00:47:17,234
+SPEAKER_10: All right, moving on.
+
+498
+00:47:18,055 --> 00:47:25,430
+SPEAKER_10: We're going to do the approval of board meeting minutes and committee reports, the board and committee meeting minutes were included in the board packet.
+
+499
+00:47:26,151 --> 00:47:30,299
+SPEAKER_10: Are there any corrections from the board for the minutes to be approved this evening.
+
+500
+00:47:33,506 --> 00:47:34,187
+SPEAKER_10: Any corrections.
+
+501
+00:47:35,568 --> 00:47:35,909
+SPEAKER_10: All right.
+
+502
+00:47:36,249 --> 00:47:42,739
+SPEAKER_10: Unless there's objection to considering the minutes all the same time, my please have a motion to approve the minutes for the following meetings.
+
+503
+00:47:43,380 --> 00:47:54,977
+SPEAKER_10: The April 9th, 2025 operation safety and security committee, the April 29th, 2025 board meeting, the May 12th, 2025 performance committee, May 13th, 2025 finance and planning committee.
+
+504
+00:47:55,801 --> 00:48:01,987
+SPEAKER_10: May 14th, 2025, Operation Safety and Security Committee, and then May 22nd, 2025, Executive Committee.
+
+505
+00:48:02,388 --> 00:48:03,248
+SPEAKER_10: So moved, Guzman.
+
+506
+00:48:03,589 --> 00:48:04,670
+SPEAKER_10: I have the Guzman.
+
+507
+00:48:05,591 --> 00:48:06,812
+SPEAKER_09: Second.
+
+508
+00:48:06,832 --> 00:48:07,112
+SPEAKER_09: Second.
+
+509
+00:48:07,293 --> 00:48:08,314
+SPEAKER_10: I'm going to give it to Guzman.
+
+510
+00:48:11,697 --> 00:48:15,521
+SPEAKER_10: So I heard Director Guzman as the mover and Director Guzman as the second.
+
+511
+00:48:15,661 --> 00:48:17,102
+SPEAKER_10: Is there any discussion on this motion?
+
+512
+00:48:21,767 --> 00:48:22,388
+SPEAKER_10: Okay.
+
+513
+00:48:22,408 --> 00:48:24,029
+SPEAKER_10: Seeing none, I'll now call the vote.
+
+514
+00:48:24,189 --> 00:48:25,791
+SPEAKER_10: Are there any no votes on this action?
+
+515
+00:48:28,319 --> 00:48:32,850
+SPEAKER_10: It'll pass 14, zero, and one absent.
+
+516
+00:48:34,574 --> 00:48:34,955
+SPEAKER_10: Excellent.
+
+517
+00:48:35,657 --> 00:48:35,978
+SPEAKER_10: All right.
+
+518
+00:48:36,018 --> 00:48:40,549
+SPEAKER_10: Moving on, it will be our chairs report.
+
+519
+00:48:40,950 --> 00:48:46,463
+SPEAKER_10: Due to the late hour, I will be quoting my principal and saying, I am giving you all the gift of time.
+
+520
+00:48:46,713 --> 00:48:55,524
+SPEAKER_10: And all I can say with my chair's report is we will have a border treat on June 7th talking about our 2026 priorities for the agency.
+
+521
+00:48:56,125 --> 00:48:58,628
+SPEAKER_10: Again, directors, hopefully you all can make that.
+
+522
+00:48:58,668 --> 00:49:03,274
+SPEAKER_10: It'll be a very healthy discussion, a very hearty discussion, I guarantee.
+
+523
+00:49:03,755 --> 00:49:06,238
+SPEAKER_10: But please make sure you have that marked down on your calendars.
+
+524
+00:49:06,738 --> 00:49:07,219
+SPEAKER_10: Thank you.
+
+525
+00:49:10,827 --> 00:49:13,209
+Larsen: Did you want to remind everybody about the survey we sent you?
+
+526
+00:49:13,229 --> 00:49:14,210
+SPEAKER_10: Of course, thank you.
+
+527
+00:49:14,631 --> 00:49:21,557
+SPEAKER_10: And of course, directors, you'll see in my weekly update, there was a survey that might have been passed too.
+
+528
+00:49:22,037 --> 00:49:24,560
+SPEAKER_10: And if you've not filled out that survey, please do so.
+
+529
+00:49:25,000 --> 00:49:28,223
+SPEAKER_10: Thank you for the directors who did fill it in.
+
+530
+00:49:28,443 --> 00:49:30,265
+SPEAKER_10: So that's okay.
+
+531
+00:49:30,365 --> 00:49:36,451
+SPEAKER_10: If we could get that in by Monday morning, that'd be excellent.
+
+532
+00:49:36,491 --> 00:49:38,272
+SPEAKER_10: I'll include that in my weekly update though.
+
+533
+00:49:38,473 --> 00:49:38,893
+SPEAKER_10: Thank you.
+
+534
+00:49:40,139 --> 00:49:44,505
+SPEAKER_10: I'll give it now over to you, GMCO Johnson.
+
+535
+00:49:44,525 --> 00:49:58,385
+SPEAKER_16: Thank you very much, Mr. Chair, and by to recognize the lateness of the hour, I just have a couple of elements that I'll share with you that are in alignment with our activities and strategic endeavors since our last board meeting on Tuesday, April 29th.
+
+536
+00:50:00,308 --> 00:50:09,100
+SPEAKER_16: One notable aspect is the legislative conference held by the American Public Transportation Association from May 18th through the 20th.
+
+537
+00:50:09,451 --> 00:50:22,069
+SPEAKER_16: In Washington DC, just for everyone's edification, this annual conference is an opportunity for public transportation industry professionals across the nation to visit Washington DC and connect with policymakers, implementers, and their staffs.
+
+538
+00:50:22,750 --> 00:50:33,045
+SPEAKER_16: The conference helps educate and inform active members on important federal legislation and policy initiatives and affords an unparalleled opportunity to shape the industry's positions in federal advocacy agenda.
+
+539
+00:50:33,515 --> 00:50:44,527
+SPEAKER_16: I along with directors of Keith Chandler and Guchin Ritter and government relations officer Michael Davies attended conference sessions and meetings with members of Colorado's congressional delegation and their staffs.
+
+540
+00:50:44,547 --> 00:51:00,045
+SPEAKER_16: While chairing an APTA committee meeting on Sunday, May 8th, I personally engaged with Tariq Bakari who is the acting administrator of the Federal Transit Administration who shared his views and inputs as it relates to public transit as well as the importance of federal and local partnerships.
+
+541
+00:51:00,498 --> 00:51:07,786
+SPEAKER_16: Just yesterday, Tuesday, May 27th, I along with members of my team met with individuals representing the Alliance to Transform Transportation.
+
+542
+00:51:08,547 --> 00:51:13,933
+SPEAKER_16: As you may be aware, it's a coalition of groups on transit related matters in Colorado.
+
+543
+00:51:14,573 --> 00:51:29,830
+SPEAKER_16: Alliance representatives in attendance included Executive Director of the Colorado Public Interest Research Group, Danny Katz, or Co-Purg, as we refer to it, Jill Lockenture, Executive Director of the Denver Streets Partnership, Portia Prescott, President of the Rocky Mountain NAACP,
+
+544
+00:51:30,215 --> 00:51:37,980
+SPEAKER_16: uh, branch, uh, the state conference representing Colorado, Montana, and Wyoming, Dennis Hawkins representing the amalgamated transit union 10 01.
+
+545
+00:51:38,382 --> 00:51:46,715
+SPEAKER_16: Matt Fromer representing Transportation and Land Use, well, he is the Transportation and Land Use Policy Manager from the Southwest Energy Efficiency Project.
+
+546
+00:51:47,175 --> 00:51:51,582
+SPEAKER_16: The meeting really was focused on Alliance's vision for transit in the Denver region.
+
+547
+00:51:52,403 --> 00:52:00,255
+SPEAKER_16: As you know, they have been very vocal in which they're seeking to increase funding for transit in the Denver region by $420 million per year.
+
+548
+00:52:00,539 --> 00:52:06,311
+SPEAKER_16: to bolster the frequency and availability of transit services in the metro area.
+
+549
+00:52:08,335 --> 00:52:21,383
+SPEAKER_16: From RTD's perspective, questions were posed relative to how that $420 million figure was derived and they explained how that came about with the work they had done with the third party entity.
+
+550
+00:52:21,599 --> 00:52:26,569
+SPEAKER_16: of very bare bones relative to providing some information.
+
+551
+00:52:27,110 --> 00:52:42,983
+SPEAKER_16: And then we talked about the agency's focus, which all of you are very well aware that we are laser focused on asset renewal, state of good repair, and rightsizing transit service and alignment with RTD's branded comprehensive operational analysis being the system optimization plan.
+
+552
+00:52:43,823 --> 00:52:57,801
+SPEAKER_16: Related to personal security, as was recently reported, RTD experienced a 60% reduction in security-related calls for service, as well as a three-year decrease in reports of criminal activities between 2022 and 2025 at Denver Union Station.
+
+553
+00:52:57,841 --> 00:53:12,379
+SPEAKER_16: The decrease is representative of concerted efforts to restore and maintain a welcoming transit environment within the critical multi-modal transit hub, and following a collaborative and multifaceted strategy aimed at enhancing
+
+554
+00:53:12,730 --> 00:53:17,755
+SPEAKER_16: personal safety and security through crime prevention through environmental design methodologies.
+
+555
+00:53:18,115 --> 00:53:24,121
+SPEAKER_16: This effort would have not have been a success without the commitment of numerous agency employees as well as support from the city and county of Denver.
+
+556
+00:53:25,482 --> 00:53:34,311
+SPEAKER_16: It's police department, the downtown Denver partnerships, Sage hospitality, the lower Denver neighborhood association, as well as several local businesses and downtown Denver residents.
+
+557
+00:53:34,851 --> 00:53:41,117
+SPEAKER_16: Fair enforcement has also increased in recent months, which is the result of RTDs growing ranks of sworn police officers
+
+558
+00:53:41,435 --> 00:53:56,093
+SPEAKER_16: haven't been trained to perform this function alongside the contracted team that we have in security with Allied Universal personnel who had primarily been responsible for this responsibility.
+
+559
+00:53:56,614 --> 00:54:04,624
+SPEAKER_16: I look forward to sharing additional details regarding the impacts of these efforts during the June Performance Committee, which you heard Committee Chair Guzman reference.
+
+560
+00:54:04,908 --> 00:54:11,398
+SPEAKER_16: When I along with staff will present data related to annual customer community and employee surveys that have recently concluded.
+
+561
+00:54:11,439 --> 00:54:32,232
+SPEAKER_16: On a related note, the agency has proactively increased its transit police officer presence at Denver Union Station and across the agency's downtown Denver sector to support the personal safety and security of customers and visitors attending major events and activity, notably as we know, while we're no longer in the hockey playoffs and NBA, but
+
+562
+00:54:32,701 --> 00:54:36,885
+SPEAKER_16: people had a welcoming experience in and around our facilities.
+
+563
+00:54:37,326 --> 00:54:48,898
+SPEAKER_16: And RTD PD had increased patrols at Denver Union Station and bus stops and rail stations, the high of, before the high profile events, which included the playoff games I just referenced.
+
+564
+00:54:48,918 --> 00:54:53,543
+SPEAKER_16: And this coincides with increasing Denver police patrols throughout the downtown area.
+
+565
+00:54:54,184 --> 00:55:01,071
+SPEAKER_16: And RTD and DPD are working closely to collaborate to support enhanced safety for the traveling public.
+
+566
+00:55:03,194 --> 00:55:15,850
+SPEAKER_16: And moreover, data and metrics related to personal safety and security are now conveniently located on the recently created security related metrics page, and we've actually showcased that on other social media channels as well.
+
+567
+00:55:17,092 --> 00:55:29,708
+SPEAKER_16: As it relates to our customer excellence in relation to the strategic priorities of customer excellence and employee ownership, I shared yesterday with the board the last of the 31 light rail speed restrictions put into place last year on the DH
+
+568
+00:55:30,228 --> 00:55:32,932
+SPEAKER_16: and E and R lines was lifted as of yesterday morning.
+
+569
+00:55:34,013 --> 00:55:38,539
+SPEAKER_16: I want to give a special shout out to our maintenance of way teams that have done yeoman's work.
+
+570
+00:55:38,559 --> 00:55:48,253
+SPEAKER_16: The final speed restriction, which was approximately 400 feet in southbound segment north of south more station and was removed after crews completed those repairs.
+
+571
+00:55:50,977 --> 00:56:00,049
+SPEAKER_16: Keeping in mind those rigorous restrictions were put into place due to the fact that we enhanced our inspections of track
+
+572
+00:56:00,451 --> 00:56:05,917
+SPEAKER_16: back in May 2024 as an enhanced focus on maintaining the agency's assets and a state of good repair.
+
+573
+00:56:06,417 --> 00:56:10,181
+SPEAKER_16: At the time, you know, crews found several minor issues and track imperfections.
+
+574
+00:56:10,621 --> 00:56:22,994
+SPEAKER_16: So as I said before, I thank and congratulate all the agency employees who worked tirelessly over the course of these 11 months.
+
+575
+00:56:23,294 --> 00:56:26,998
+SPEAKER_16: And like I said, a special shout out to MOW.
+
+576
+00:56:28,683 --> 00:56:43,228
+SPEAKER_16: I would be remiss if I didn't state that while this is a cost to celebrate, I shared previously as we look at our infrastructure and it continues to age, this will be par for the course, but since we're ahead of where we were before, we will see less of an impact, I'm certain.
+
+577
+00:56:44,049 --> 00:56:51,822
+SPEAKER_16: And last, but certainly not least, I'm pleased to welcome RTD's new Chief Financial Officer, Kelly Mackey, who's in the audience, she's given a wave.
+
+578
+00:56:52,139 --> 00:56:54,021
+SPEAKER_16: who began her tenure on May 12th.
+
+579
+00:56:54,342 --> 00:56:59,348
+SPEAKER_16: And this is her in her first in-person board meeting while we introduced her at the Finance and Planning Committee.
+
+580
+00:57:00,209 --> 00:57:02,672
+SPEAKER_16: You guys are real people, not figments of our imagination.
+
+581
+00:57:02,692 --> 00:57:04,415
+SPEAKER_16: So I wanted to ensure I did that here.
+
+582
+00:57:04,475 --> 00:57:09,942
+SPEAKER_16: So with that, I will yield the floor so we can move on to the rest of the matters that we have before.
+
+583
+00:57:09,962 --> 00:57:11,564
+SPEAKER_16: So thank you very much, Mr. Chair.
+
+584
+00:57:14,307 --> 00:57:16,089
+SPEAKER_09: Thank you, GMCO Johnson.
+
+585
+00:57:16,970 --> 00:57:19,834
+SPEAKER_09: Any comments or questions for GMCO Johnson?
+
+586
+00:57:23,003 --> 00:57:23,404
+SPEAKER_09: Yeah.
+
+587
+00:57:28,410 --> 00:57:29,071
+SPEAKER_10: Very exciting.
+
+588
+00:57:29,411 --> 00:57:30,953
+SPEAKER_10: And Kelly, welcome to the team.
+
+589
+00:57:31,474 --> 00:57:31,834
+SPEAKER_10: Thank you.
+
+590
+00:57:34,658 --> 00:57:35,038
+SPEAKER_10: All right.
+
+591
+00:57:35,559 --> 00:57:36,280
+SPEAKER_10: Moving on.
+
+592
+00:57:36,300 --> 00:57:39,364
+SPEAKER_10: Uh, they, we're going to move on to unanimous consent.
+
+593
+00:57:39,764 --> 00:57:50,057
+SPEAKER_10: Uh, there are three items on the unanimous consent agenda listed under section 16 actions A through C. Those items are the security operations budget transfer.
+
+594
+00:57:50,273 --> 00:57:57,692
+SPEAKER_10: The 2025-2028 Title VI Program Update, and the Allied Universal Security Services Contract Extension for one year.
+
+595
+00:57:57,712 --> 00:58:05,532
+SPEAKER_10: I do understand that Director Banker would like to offer some amendments to Item B, the 2025-2028 Title VI Program Update.
+
+596
+00:58:05,950 --> 00:58:11,237
+SPEAKER_10: And such I will remove, I will move that to a recommended actions, actions, excuse me.
+
+597
+00:58:11,817 --> 00:58:20,728
+SPEAKER_10: If anyone else has a change to discussion on or questions about any of the remaining unanimous consent items, please feel free to advise the chair at this time.
+
+598
+00:58:21,109 --> 00:58:26,656
+SPEAKER_10: And I'll of course be happy to pull the item from unanimous consent for consideration under recommended action.
+
+599
+00:58:27,757 --> 00:58:28,498
+=START-4=
+SPEAKER_10: Director Nicholson.
+
+600
+00:58:30,721 --> 00:58:33,484
+Nicholson: The Allied Universal Security Contract, please pull that.
+
+601
+00:58:34,085 --> 00:58:34,185
+Okay.
+
+602
+00:58:34,537 --> 00:58:40,383
+SPEAKER_10: So item B will be removed and placed into recommended action.
+
+603
+00:58:41,444 --> 00:58:47,771
+SPEAKER_10: Excuse me, former item C, as I look in real time here, the Allied Universal Security.
+
+604
+00:58:47,971 --> 00:58:51,635
+SPEAKER_10: Are we okay with security operations, budget transfer?
+
+605
+00:58:56,080 --> 00:59:00,505
+Whitmore: I would move to approve the remainder of the unanimous consent agenda.
+=END-4=
+
+606
+00:59:00,885 --> 00:59:01,506
+Whitmore: Second.
+
+607
+00:59:01,672 --> 00:59:04,635
+SPEAKER_10: Okay, I have Whitmore and then Roush as the second.
+
+608
+00:59:05,636 --> 00:59:26,078
+SPEAKER_10: Okay, so this is item A for the Board of Directors to approve a budget transfer of $3,845,437.10 between Operated Expenses Lines for Transit Security Services.
+
+609
+00:59:28,640 --> 00:59:31,223
+SPEAKER_10: Is there any no votes on that?
+
+610
+00:59:33,548 --> 00:59:33,848
+SPEAKER_10: Okay.
+
+611
+00:59:35,470 --> 00:59:37,954
+SPEAKER_10: Seeing none, that item will pass 14-0-1.
+
+612
+00:59:37,974 --> 00:59:44,602
+SPEAKER_10: All right, now we're moving on to our recommended action items.
+
+613
+00:59:45,363 --> 00:59:51,471
+SPEAKER_10: And we're gonna have first on our list, the Allied Universal Security Surface Contract Extension for one year.
+
+614
+00:59:51,511 --> 00:59:54,295
+SPEAKER_10: Is there a motion?
+
+615
+00:59:55,296 --> 00:59:55,697
+SPEAKER_10: So moved.
+
+616
+00:59:56,117 --> 00:59:56,738
+SPEAKER_10: Okay, Nicholson.
+
+617
+00:59:58,135 --> 00:59:58,576
+SPEAKER_10: In a second.
+
+618
+00:59:59,637 --> 01:00:00,077
+SPEAKER_10: And Russia.
+
+619
+01:00:01,800 --> 01:00:02,040
+SPEAKER_10: All right.
+
+620
+01:00:02,220 --> 01:00:02,941
+SPEAKER_10: Any discussion.
+
+621
+01:00:04,122 --> 01:00:04,723
+=START-5=
+SPEAKER_10: Director Nicholson.
+
+622
+01:00:05,384 --> 01:00:05,564
+Nicholson: Yeah.
+
+623
+01:00:05,584 --> 01:00:08,968
+Nicholson: So I just have a quick question about this one that came from a constituent.
+
+624
+01:00:10,570 --> 01:00:17,759
+Nicholson: How many people do we have working from working on our security side from Allied?
+
+625
+01:00:18,260 --> 01:00:22,906
+Nicholson: And how many do we have from, you know, RTDPD right now?
+
+626
+01:00:23,727 --> 01:00:24,007
+Nicholson: Thank you.
+
+627
+01:00:25,248 --> 01:00:25,389
+SPEAKER_10: Ms.
+
+628
+01:00:25,409 --> 01:00:25,729
+SPEAKER_10: Johnson.
+
+629
+01:00:26,333 --> 01:00:29,765
+SPEAKER_16: Yes, I will yield the floor to Chief Martin Gano who can address that question.
+=END-5=
+
+630
+01:00:29,805 --> 01:00:30,146
+SPEAKER_16: Thank you.
+
+631
+01:00:32,736 --> 01:00:33,458
+SPEAKER_10: Chief Martin Gano.
+
+632
+01:00:34,535 --> 01:00:37,481
+SPEAKER_22: I am trying to figure out whether we're going to be hot chat for me.
+
+633
+01:00:38,322 --> 01:00:38,683
+SPEAKER_22: Yes.
+
+634
+01:00:38,703 --> 01:00:38,923
+SPEAKER_22: Yeah.
+
+635
+01:00:38,943 --> 01:00:44,214
+SPEAKER_22: So technically, in regards to how many ally personnel, it's an hourly contract.
+
+636
+01:00:44,554 --> 01:00:47,520
+SPEAKER_22: So you'd have to take the amount of the hours and obviously divided by 40.
+
+637
+01:00:48,181 --> 01:00:51,848
+SPEAKER_22: It roughly equates to the recommended action for next year.
+
+638
+01:00:51,868 --> 01:00:53,812
+SPEAKER_22: I think it's about 9100 hours.
+
+639
+01:00:53,872 --> 01:00:56,998
+SPEAKER_22: So roughly equates about 180 security officers.
+
+640
+01:00:56,978 --> 01:01:02,706
+SPEAKER_22: Right now we currently have 87 on our staff in regards to post certified police officers.
+
+641
+01:01:03,046 --> 01:01:08,453
+SPEAKER_22: We have a couple in training and one in the academy who should be probably about 90 by the end of next month.
+
+642
+01:01:09,955 --> 01:01:10,796
+=START-6=
+Nicholson: Thank you, secretary.
+
+643
+01:01:13,760 --> 01:01:15,202
+Nicholson: This is for GMCO Johnson.
+
+644
+01:01:16,023 --> 01:01:18,767
+Nicholson: What are there any.
+
+645
+01:01:20,249 --> 01:01:24,837
+Nicholson: plans in place or is and please feel free to not answer this as we can't.
+
+646
+01:01:25,959 --> 01:01:32,070
+Nicholson: But I know there's been a drawdown over the last few years in our reliance on allied security.
+
+647
+01:01:32,110 --> 01:01:38,882
+Nicholson: Is there anything in this contract or in your planning around this contract or.
+
+648
+01:01:38,862 --> 01:01:53,822
+Nicholson: anything that can give us guidance on whether we expect that to continue after authorizing this, or are we expecting to stay at, you know, 90, 90 something hundred or 180 people over the next few years?
+
+649
+01:01:54,843 --> 01:01:55,084
+Nicholson: Yes.
+
+650
+01:01:55,524 --> 01:01:56,806
+SPEAKER_16: Thank you very much for the question.
+
+651
+01:01:56,946 --> 01:02:00,972
+SPEAKER_16: As chief indicated, this is a contract extension and there's hours that are specified.
+
+652
+01:02:01,072 --> 01:02:06,439
+SPEAKER_16: Hence, in reference to the dollar amount that we have here, I would have to come back to the board.
+
+653
+01:02:06,824 --> 01:02:12,632
+SPEAKER_16: as it relates to any type of authorization as we're doing now currently with this contract extension, if that were to be modified.
+
+654
+01:02:12,873 --> 01:02:30,197
+SPEAKER_16: So on this point in time, it would stay the same unless there's some extenuating circumstances whereby we go out for a solicitation and we're not able to ensure that we're meeting the timeline before, since that's why we're here now with the contract extension quite naturally in doing so.
+
+655
+01:02:30,278 --> 01:02:34,063
+SPEAKER_16: We have to ensure that we have the appropriate staffing levels.
+=END-6=
+
+656
+01:02:34,398 --> 01:02:39,584
+SPEAKER_16: So, I'm talking around and around in circles right now, but the answer would be no at this point in time.
+
+657
+01:02:41,165 --> 01:02:41,546
+SPEAKER_10: Secretary.
+
+658
+01:02:43,668 --> 01:02:44,729
+SPEAKER_10: Perfect.
+
+659
+01:02:45,170 --> 01:02:46,091
+SPEAKER_10: Second Vice Chair Whitmore.
+
+660
+01:02:47,172 --> 01:02:53,519
+Whitmore: So, Chief, jog my memory on our goal for the end of the year for sworn officers.
+
+661
+01:02:53,599 --> 01:02:54,800
+Whitmore: It's not 90, right?
+
+662
+01:02:54,820 --> 01:02:56,302
+Whitmore: It's continuing to grow.
+
+663
+01:02:56,862 --> 01:02:57,503
+SPEAKER_10: Chief Morrigano.
+
+664
+01:02:57,601 --> 01:02:59,584
+SPEAKER_22: Yeah, so we are budgeted for 150.
+
+665
+01:03:00,024 --> 01:03:02,667
+SPEAKER_22: We're still in the process of growing to those numbers.
+
+666
+01:03:04,310 --> 01:03:10,858
+SPEAKER_22: So obviously with applications, background checks, everything else, we're heading positively to that.
+
+667
+01:03:10,918 --> 01:03:12,880
+SPEAKER_22: We're putting in more in the academy here in June.
+
+668
+01:03:12,941 --> 01:03:15,404
+SPEAKER_22: We'll continue to get lateral transfers.
+
+669
+01:03:15,904 --> 01:03:19,829
+SPEAKER_22: I'm sorry, lateral applications from other agencies, officers of experience.
+
+670
+01:03:19,849 --> 01:03:22,713
+SPEAKER_22: So we're hoping to hit that 150 goal by the end of year.
+
+671
+01:03:22,733 --> 01:03:23,234
+Whitmore: All right.
+
+672
+01:03:23,254 --> 01:03:23,955
+Whitmore: Thank you very much.
+
+673
+01:03:23,975 --> 01:03:26,458
+Whitmore: I did have the right memory up here.
+
+674
+01:03:26,538 --> 01:03:27,439
+Whitmore: Thank you, Mr. Chair.
+
+675
+01:03:27,487 --> 01:03:29,028
+SPEAKER_10: Absolutely.
+
+676
+01:03:29,128 --> 01:03:32,351
+SPEAKER_10: Any further, well, any further questions or discussions on this?
+
+677
+01:03:33,292 --> 01:03:33,853
+SPEAKER_10: Yeah, Director Riesha.
+
+678
+01:03:35,694 --> 01:03:36,035
+Paglieri: Thank you, sir.
+
+679
+01:03:36,115 --> 01:03:57,274
+Paglieri: So I just wanted to note in the in the past upon request, the agency has provided a breakdown of how many just like our security personnel from, you know, our city to contracted and even break down in terms of with our contracted Allied Force like
+
+680
+01:03:58,402 --> 01:04:03,989
+Paglieri: the ones that are authorized to have firearms versus not, and our mental health staff and stuff.
+
+681
+01:04:04,009 --> 01:04:10,296
+Paglieri: So that's something that I think the agency, I'm sure the agency would be happy to provide like that breakdown chart.
+
+682
+01:04:10,376 --> 01:04:12,239
+Paglieri: I think it's been a little over a year since we've had one.
+
+683
+01:04:12,719 --> 01:04:21,249
+Paglieri: So I just wanted to offer that to those who are interested and just to piggyback on Secretary Nicholson's comments.
+
+684
+01:04:22,431 --> 01:04:22,711
+Paglieri: Thank you.
+
+685
+01:04:23,372 --> 01:04:24,013
+SPEAKER_10: Thank you, Director.
+
+686
+01:04:26,335 --> 01:04:26,435
+SPEAKER_10: Okay.
+
+687
+01:04:26,456 --> 01:04:27,717
+SPEAKER_10: Any further comments or questions?
+
+688
+01:04:29,317 --> 01:04:30,118
+SPEAKER_10: Okay, seeing none.
+
+689
+01:04:30,238 --> 01:04:32,161
+SPEAKER_10: So I did have, thank you, Chief.
+
+690
+01:04:32,962 --> 01:04:36,066
+SPEAKER_10: I did have Nicholson as the mover and Roush as the second.
+
+691
+01:04:36,566 --> 01:04:38,569
+SPEAKER_10: Are there any no votes on this item?
+
+692
+01:04:42,814 --> 01:04:46,739
+SPEAKER_10: Okay, seeing none, the item will pass 14-0-1 absent.
+
+693
+01:04:47,580 --> 01:04:51,866
+SPEAKER_10: We are hitting our two hour mark, so we are gonna take a break for our cart employee.
+
+694
+01:04:52,947 --> 01:04:56,151
+SPEAKER_10: Let's shoot to be back here at nine o'clock.
+
+695
+01:04:56,291 --> 01:04:57,012
+SPEAKER_10: Would that be enough time?
+
+696
+01:04:58,409 --> 01:04:58,749
+SPEAKER_10: Nope.
+
+697
+01:04:58,770 --> 01:04:59,350
+SPEAKER_10: Okay.
+
+698
+01:04:59,370 --> 01:04:59,571
+SPEAKER_10: Okay.
+
+699
+01:04:59,591 --> 01:05:00,592
+SPEAKER_10: Let's do 905 then.
+
+700
+01:05:01,153 --> 01:05:01,714
+Larsen: Thank you.
+
+701
+01:05:01,734 --> 01:05:02,675
+SPEAKER_10: Thank you.
+
+702
+01:05:02,695 --> 01:05:27,690
+SPEAKER_14: We'll back at 905.
+
+703
+01:05:27,940 --> 01:05:54,935
+SPEAKER_14: We've got it.
+
+704
+01:05:54,955 --> 01:05:55,215
+We've got it.
+
+705
+01:05:55,235 --> 01:05:55,435
+SPEAKER_14: All right.
+
+706
+01:05:55,455 --> 01:05:55,736
+SPEAKER_14: There are two.
+
+707
+01:05:55,756 --> 01:05:55,956
+SPEAKER_14: All right.
+
+708
+01:05:57,809 --> 01:06:08,376
+SPEAKER_14: not.
+
+709
+01:06:28,994 --> 01:06:30,536
+SPEAKER_14: Yeah.
+
+710
+01:06:30,836 --> 01:06:31,277
+SPEAKER_14: Yeah.
+
+711
+01:06:31,377 --> 01:06:51,103
+SPEAKER_14: Yeah.
+
+712
+01:07:03,976 --> 01:07:05,038
+Yeah.
+
+713
+01:07:05,058 --> 01:07:07,322
+Yeah.
+
+714
+01:07:07,943 --> 01:07:27,317
+SPEAKER_14: Yeah.
+
+715
+01:07:45,252 --> 01:07:50,622
+SPEAKER_14: You know what it is.
+
+716
+01:08:31,996 --> 01:08:33,899
+Okay.
+
+717
+01:08:34,380 --> 01:08:35,702
+But yeah.
+
+718
+01:08:37,064 --> 01:08:39,828
+Yeah.
+
+719
+01:08:40,449 --> 01:08:59,860
+SPEAKER_14: I hear.
+
+720
+01:09:04,700 --> 01:09:32,057
+SPEAKER_14: We had a tower backed up on Friday night.
+
+721
+01:09:32,408 --> 01:09:38,217
+SPEAKER_14: And, uh, Senator, if you're in the hot quarter, so you know, it's not a big deal.
+
+722
+01:09:38,278 --> 01:09:43,626
+SPEAKER_14: So, but if my daughter's school, no, they're out there, like an ankle thing.
+
+723
+01:09:43,767 --> 01:09:45,169
+SPEAKER_14: I don't know.
+
+724
+01:09:46,591 --> 01:09:47,272
+I don't know.
+
+725
+01:09:47,412 --> 01:09:48,294
+I don't know.
+
+726
+01:09:48,314 --> 01:09:49,776
+I don't know.
+
+727
+01:09:49,796 --> 01:09:51,940
+I don't know.
+
+728
+01:09:52,180 --> 01:09:53,783
+I don't know.
+
+729
+01:09:53,963 --> 01:09:55,065
+I don't know.
+
+730
+01:09:55,125 --> 01:09:56,187
+I don't know.
+
+731
+01:09:56,367 --> 01:09:57,589
+I don't know.
+
+732
+01:10:12,250 --> 01:10:17,678
+SPEAKER_14: Thank you.
+
+733
+01:10:19,941 --> 01:10:40,452
+SPEAKER_14: Thank you.
+
+734
+01:10:40,870 --> 01:10:58,963
+SPEAKER_14: You do it.
+
+735
+01:11:57,247 --> 01:12:06,719
+SPEAKER_14: We're out of time.
+
+736
+01:12:07,079 --> 01:12:14,428
+SPEAKER_14: We're out of time.
+
+737
+01:12:14,548 --> 01:12:25,802
+SPEAKER_14: We're out of time
+
+738
+01:12:36,532 --> 01:12:37,970
+I'm sorry.
+
+739
+01:13:11,024 --> 01:13:38,905
+SPEAKER_14: Okay.
+
+740
+01:13:52,013 --> 01:14:12,233
+SPEAKER_14: Thank you very much.
+
+741
+01:15:06,635 --> 01:15:07,924
+SPEAKER_09: Yeah, we're gonna get started.
+
+742
+01:15:08,186 --> 01:15:11,430
+SPEAKER_14: Have you seen Jack?
+
+743
+01:15:46,814 --> 01:16:12,809
+SPEAKER_14: All right, folks, we're at 906.
+
+744
+01:16:13,931 --> 01:16:15,032
+SPEAKER_10: We're going to get started.
+
+745
+01:16:19,433 --> 01:16:20,655
+SPEAKER_10: Director Bouquet, how do you vote?
+
+746
+01:16:21,015 --> 01:16:21,536
+SPEAKER_10: I mean, yes.
+
+747
+01:16:25,262 --> 01:16:31,852
+SPEAKER_10: We have a quorum of me and Director Packillary and Director Nicholson and Director Harwick.
+
+748
+01:16:47,075 --> 01:16:47,415
+SPEAKER_10: All right.
+
+749
+01:16:47,581 --> 01:16:49,083
+SPEAKER_10: Thank you everyone for your patience.
+
+750
+01:16:49,483 --> 01:16:52,807
+SPEAKER_10: We are now moving on to our next recommended action for tonight.
+
+751
+01:16:54,069 --> 01:17:06,664
+SPEAKER_10: And that is going to be the recommended action of the 2025-2028 Title VI program update to comply with federal laws, regulations, and guidelines related to Title VI of the Civil Rights Act of 1964.
+
+752
+01:17:07,165 --> 01:17:08,687
+SPEAKER_10: Do we have a motion?
+
+753
+01:17:09,768 --> 01:17:10,289
+Catlin: So moved.
+
+754
+01:17:10,849 --> 01:17:11,911
+SPEAKER_10: I have Catlin as the mover.
+
+755
+01:17:12,932 --> 01:17:13,633
+SPEAKER_10: Second, Guzman.
+
+756
+01:17:13,933 --> 01:17:15,495
+SPEAKER_10: Guzman is the second.
+
+757
+01:17:16,960 --> 01:17:21,367
+SPEAKER_10: I do understand that Director Banker has two amendments she would like to offer on this item.
+
+758
+01:17:21,747 --> 01:17:24,271
+SPEAKER_10: Director Banker will take your amendments one at a time.
+
+759
+01:17:25,814 --> 01:17:27,777
+SPEAKER_10: What is your first amendment, Director Banker?
+
+760
+01:17:28,338 --> 01:17:29,159
+Benker: Thank you very much.
+
+761
+01:17:29,860 --> 01:17:36,370
+Benker: And I'm glad everybody is now, you know, second wind and we're ready to go on to our
+
+762
+01:17:37,244 --> 01:17:39,409
+Benker: I don't know, six or seventh hour of meeting.
+
+763
+01:17:40,371 --> 01:17:43,760
+Benker: Actually, I will tell you I have three.
+
+764
+01:17:43,800 --> 01:17:45,043
+Benker: We'll see how things go.
+
+765
+01:17:45,083 --> 01:17:46,165
+Benker: They're short.
+
+766
+01:17:47,168 --> 01:17:49,674
+Benker: The first one, well, let me give you a little bit of background.
+
+767
+01:17:49,774 --> 01:17:50,636
+Benker: Okay.
+
+768
+01:17:50,656 --> 01:17:55,708
+Benker: So the background is I met with my four cities back in February and March.
+
+769
+01:17:55,688 --> 01:18:00,192
+Benker: And of course, you meet with them and you say hi and you say, okay, what are your needs?
+
+770
+01:18:00,272 --> 01:18:01,093
+Benker: What are your wants?
+
+771
+01:18:02,154 --> 01:18:11,943
+Benker: I met with all of them and they all gave me a list of basically trying to restore service that was removed during the pandemic.
+
+772
+01:18:11,963 --> 01:18:22,533
+Benker: And so, of course, as my job as director, I'm trying to work with our staff to try to get that service restored.
+
+773
+01:18:23,373 --> 01:18:23,974
+Benker: And so,
+
+774
+01:18:25,726 --> 01:18:49,371
+Benker: One of my questions or issues is I am guessing that when the RTD Board had to make the hard decisions of how to cut service almost in half because of this highly unusual pandemic, perhaps some of these cuts were not done equally across all 15 districts.
+
+775
+01:18:49,587 --> 01:18:54,775
+SPEAKER_10: Director Banker, I'm sorry to interrupt, just so that we keep in order, could we get a second on?
+
+776
+01:18:55,155 --> 01:18:56,838
+SPEAKER_10: Could you read the motion and then we get a second?
+
+777
+01:18:56,858 --> 01:19:10,378
+Benker: Yes, the motion is change the threshold for disproportionate burden and disparate impact from 10% to 20% as it relates to major service changes and consistent with the FTA circular 4702.1B.
+
+778
+01:19:12,020 --> 01:19:18,430
+Benker: And I believe the version that will be voted on is actually the version that
+
+779
+01:19:19,000 --> 01:19:20,842
+Benker: Mr. Kroll put up for us.
+
+780
+01:19:21,924 --> 01:19:24,147
+SPEAKER_10: So that's, that's the language right there.
+
+781
+01:19:24,187 --> 01:19:31,517
+SPEAKER_10: The first motion is to move the move to amend the 2025, 2028 title six program update, such that the threshold for triggering either.
+
+782
+01:19:31,977 --> 01:19:40,088
+SPEAKER_10: Disappointed Burton or disparate in that fine late night, finding a rising from a major service change from 10% to 20%.
+
+783
+01:19:41,770 --> 01:19:42,591
+SPEAKER_10: Do I have a second?
+
+784
+01:19:43,072 --> 01:19:43,433
+SPEAKER_10: Second.
+
+785
+01:19:43,453 --> 01:19:45,575
+SPEAKER_10: Pagliari is the second.
+
+786
+01:19:46,457 --> 01:19:46,797
+Benker: Thank you.
+
+787
+01:19:47,637 --> 01:19:54,125
+Benker: So just to continue a little bit more background and then we can start, I guess, the debate here.
+
+788
+01:19:55,066 --> 01:20:02,115
+Benker: I'm just trying to get service restored that was eliminated during the pandemic.
+
+789
+01:20:02,936 --> 01:20:17,475
+Benker: And there have been a couple of times now when I have requested and the answer that I have gotten several times is, well, it's going to depend on how the equity analysis calculations come out.
+
+790
+01:20:17,455 --> 01:20:32,292
+Benker: I'm just trying to find ways where we can perhaps start to restore some of the service that had been eliminated during the pandemic and perhaps do it a little bit quicker and
+
+791
+01:20:33,605 --> 01:20:37,794
+Benker: and also try to make it not quite so difficult.
+
+792
+01:20:38,215 --> 01:20:49,538
+Benker: So then what happened, of course, is everyone received about a week, 10 days ago, a letter from the city and county of Broomfield, and their transportation staff went through
+
+793
+01:20:49,518 --> 01:20:57,468
+Benker: our items quite closely and they sent us all a letter with recommended changes.
+
+794
+01:20:58,209 --> 01:21:08,021
+Benker: So I've gone through with their changes and that's where I've come up with the three amendments that I'd like to at least talk to the board, see what your thoughts are.
+
+795
+01:21:08,642 --> 01:21:11,225
+Benker: You know, hopefully it'll pass, but we'll see what happens.
+
+796
+01:21:11,666 --> 01:21:17,533
+Benker: But it's just basically what City and County of Broomfield had found when they did their research is that
+
+797
+01:21:17,513 --> 01:21:26,844
+Benker: the RTD is using some very conservative calculations compared to some of the other large transit agencies.
+
+798
+01:21:27,525 --> 01:21:32,992
+Benker: And so I did send you also a copy of the city and county of Broomfields letter just to refresh your memory.
+
+799
+01:21:33,993 --> 01:21:41,162
+Benker: And so I would like to put forth that the first amendment would be changing the threshold from 10% to 20%.
+
+800
+01:21:41,182 --> 01:21:42,663
+SPEAKER_10: Thank you, Treasurer Baker.
+
+801
+01:21:42,804 --> 01:21:45,647
+SPEAKER_10: So again, the discussion right now is on the motion
+
+802
+01:21:46,319 --> 01:21:48,643
+SPEAKER_10: This first motion, the first amendment.
+
+803
+01:21:48,984 --> 01:21:49,805
+SPEAKER_10: Director Catlin.
+
+804
+01:21:53,411 --> 01:21:54,313
+Catlin: Thank you, Mr. Chair.
+
+805
+01:21:54,934 --> 01:21:57,759
+Catlin: I'd like to ask GM CEO Johnson.
+
+806
+01:21:58,540 --> 01:22:11,422
+Catlin: I heard from someone I don't remember now because it's getting late, but someone said that some of those assumptions made by City and County Broomfield were incorrect.
+
+807
+01:22:11,482 --> 01:22:11,622
+SPEAKER_10: Ms.
+
+808
+01:22:11,662 --> 01:22:12,023
+SPEAKER_10: Johnson.
+
+809
+01:22:12,307 --> 01:22:13,428
+SPEAKER_16: Yes, thank you very much.
+
+810
+01:22:14,129 --> 01:22:32,606
+SPEAKER_16: Relative to the comments that were made, and thank you very much, Director Catlin, as it relates to the transit agencies that were mentioned being part of the Metropolitan Atlanta Rapid Transit Authority, Los Angeles County Metropolitan Transit Authority, King County Metro, which is in Greater Seattle and then Chicago Transit Authority.
+
+811
+01:22:34,388 --> 01:22:39,192
+SPEAKER_16: That information, especially coming from LA Metro as the former Chief Operations Officer there,
+
+812
+01:22:39,661 --> 01:22:43,024
+SPEAKER_16: This is not correct relative to where we sit.
+
+813
+01:22:43,485 --> 01:22:50,932
+SPEAKER_16: And more specifically, I do know our director of civil rights when we were going through this quite naturally in the role that he is in.
+
+814
+01:22:50,993 --> 01:22:56,018
+SPEAKER_16: He and his team did a desk audit and worked with colleagues at different transit agencies.
+
+815
+01:22:56,038 --> 01:23:01,363
+SPEAKER_16: So that's the communique that I did disseminate yesterday upon receiving this information.
+
+816
+01:23:01,603 --> 01:23:06,208
+SPEAKER_16: So Mr. Green, if you want to just expound succinctly and briefly.
+
+817
+01:23:06,661 --> 01:23:12,248
+SPEAKER_01: Yes, thank you so much, General Manager and CEO Johnson, to expand upon the response.
+
+818
+01:23:12,288 --> 01:23:21,740
+SPEAKER_01: I just also want to ground us in first state that it is our collective responsibility to make federally compliant and equitable decisions, especially as it relates to service changes.
+
+819
+01:23:22,381 --> 01:23:29,530
+SPEAKER_01: And in doing that audit, we looked at 22, rather 23 different organizations, which includes the four.
+
+820
+01:23:29,510 --> 01:23:33,695
+SPEAKER_01: Marta, LA Metro, King County, and the Chicago Transit Authority.
+
+821
+01:23:34,235 --> 01:23:45,428
+SPEAKER_01: And I would say the way to look at the disparate impact or disproportionate burden, the framing of it is how sensitive or less sensitive versus more sensitive, right?
+
+822
+01:23:45,629 --> 01:23:47,571
+SPEAKER_01: And ours is stacked in the middle.
+
+823
+01:23:47,611 --> 01:23:49,533
+SPEAKER_01: So I want to give you some numbers here.
+
+824
+01:23:50,294 --> 01:23:52,817
+SPEAKER_01: So for the four that I just mentioned,
+
+825
+01:23:53,911 --> 01:24:02,602
+SPEAKER_01: Marta has 10%, LA Metro has 5%, King County has 10%, CTA or Chicago Transit Authority has 15%.
+
+826
+01:24:03,623 --> 01:24:14,637
+SPEAKER_01: And then when we rack and stack, look at those 22 different organizations, six out of that 23 have 5% or less, two have 8%,
+
+827
+01:24:14,971 --> 01:24:23,929
+SPEAKER_01: six, which includes us, or seven, including us, is at 10%, three at 15%, and then three at 20%.
+
+828
+01:24:24,150 --> 01:24:30,803
+SPEAKER_01: And in my over eight years of doing this work, and I'll just say that
+
+829
+01:24:30,783 --> 01:24:42,882
+SPEAKER_01: When you are setting your policy, you don't want to do a disservice to the spirit and the letter of what we're ultimately trying to achieve, specifically with Title VI.
+
+830
+01:24:43,463 --> 01:24:49,112
+SPEAKER_01: Title VI is not a stopping mechanism of bringing back or restoring service.
+
+831
+01:24:49,818 --> 01:24:57,146
+SPEAKER_01: There are a lot of different variables, as I mentioned before, with respect to our service development guidelines, our operators resources, so on and so forth.
+
+832
+01:24:57,666 --> 01:25:09,138
+SPEAKER_01: This is just a mechanism for the agency, such as RTD and the board of directors, so we don't get too far over our skis without discounting populations that are more likely to be transit reliant.
+
+833
+01:25:09,158 --> 01:25:17,327
+SPEAKER_01: So again, it's not a stopping mechanism, but this is just more so to make sure that we are taking into consideration all of our customers.
+
+834
+01:25:19,349 --> 01:25:21,713
+Guissinger: I've director Ruchin next.
+
+835
+01:25:26,580 --> 01:25:31,227
+Paglieri: Um, I did have a question, but I also, um, treasure banker had her hand up and it was her motion.
+
+836
+01:25:31,327 --> 01:25:33,611
+Paglieri: So I'm happy to, to wait if that was in response.
+
+837
+01:25:34,392 --> 01:25:34,973
+Guissinger: Treasure banker.
+
+838
+01:25:36,335 --> 01:25:42,264
+Benker: Um, I, I feel that we are in an extremely unique situation because of the pandemic.
+
+839
+01:25:43,225 --> 01:25:46,470
+Benker: So how can we restore
+
+840
+01:25:47,750 --> 01:25:52,399
+Benker: let's say 40% of the service that had been cut several years ago.
+
+841
+01:25:52,840 --> 01:26:00,654
+Benker: How can we get back to 2019 when my district, other districts had that service?
+
+842
+01:26:01,536 --> 01:26:04,662
+Benker: And so now we're being told
+
+843
+01:26:04,642 --> 01:26:13,772
+Benker: that we can't get that service back because of this conservative calculation that we're doing, but we used to have it.
+
+844
+01:26:14,934 --> 01:26:22,062
+Benker: And so how do we get from where we are now to bringing service back to pre-pandemic levels?
+
+845
+01:26:23,403 --> 01:26:23,564
+Guissinger: Ms.
+
+846
+01:26:23,584 --> 01:26:23,964
+Guissinger: Johnson.
+
+847
+01:26:24,264 --> 01:26:25,886
+SPEAKER_16: Yes, thank you very much, Director Banker.
+
+848
+01:26:25,926 --> 01:26:27,508
+SPEAKER_16: That question is better suited for me.
+
+849
+01:26:27,548 --> 01:26:31,813
+SPEAKER_16: Relative to the service delivery framework that we have,
+
+850
+01:26:32,097 --> 01:26:50,798
+SPEAKER_16: While Title VI plays a role relative to major service changes as we talk about how we deploy service is based upon a myriad of different factors relative to our revenue service hours, but more specifically at how we use our comprehensive operational analysis specifically as we talk about the SOP.
+
+851
+01:26:51,439 --> 01:26:57,666
+SPEAKER_16: When I came into this organization, it was decided that we were going to look at 85% of what service levels were.
+
+852
+01:26:58,321 --> 01:27:00,785
+SPEAKER_16: 85% of what service levels were in 2019.
+
+853
+01:27:01,546 --> 01:27:10,721
+SPEAKER_16: We were in a different time relative to the commuting patterns, relative to how people were working going forward.
+
+854
+01:27:11,783 --> 01:27:16,971
+SPEAKER_16: What I will share is that we are being very diligent and judicious
+
+855
+01:27:17,390 --> 01:27:21,798
+SPEAKER_16: and how we're applying service because we do want to ensure there's equity.
+
+856
+01:27:21,838 --> 01:27:28,370
+SPEAKER_16: I'm going to speak a little bit out of school here because I shared this with you yesterday, but I'll say it in this context as well.
+
+857
+01:27:28,811 --> 01:27:39,330
+SPEAKER_16: As we talk about Longmont and we talk about service, we are looking at that for the fall service change.
+
+858
+01:27:39,665 --> 01:28:02,415
+SPEAKER_16: That is up to the board quite naturally, but I did want to put that forward because with the restoration of service keeping in mind that all transit agencies across, you know, the US were in these precarious positions and the Federal Transit Administration more or less provided waivers, waivers from the sense of how we were decreasing service due to the fact that we didn't have enough people power.
+
+859
+01:28:03,138 --> 01:28:08,485
+SPEAKER_16: Also, we currently are still working under a waiver as it relates to our spare ratio.
+
+860
+01:28:08,585 --> 01:28:18,579
+SPEAKER_16: What I mean by that is when you deploy service in the mornings and the afternoons with the peak, you have a certain pullout rate and you're only supposed to have a 20% spare ratio.
+
+861
+01:28:18,920 --> 01:28:26,250
+SPEAKER_16: We've deviated from that and have a waiver and we're right sizing the fleet as we move forward.
+
+862
+01:28:26,290 --> 01:28:32,318
+SPEAKER_16: So while you're bringing up these points, as you indicated, we are in uncharted territory or were.
+
+863
+01:28:32,500 --> 01:28:33,942
+SPEAKER_16: And we're coming back from that.
+
+864
+01:28:34,924 --> 01:28:47,185
+SPEAKER_16: We are looking at where there are needs relative to the entire area from an origin and destination vantage point just by virtue of how our service area is going forward.
+
+865
+01:28:47,686 --> 01:28:51,032
+SPEAKER_16: So I'm not providing this to say I don't.
+
+866
+01:28:51,012 --> 01:28:53,254
+SPEAKER_16: understand what you're trying to do.
+
+867
+01:28:53,275 --> 01:28:58,961
+SPEAKER_16: And as I share it with you, I do clearly and we want to work within the frameworks that we have.
+
+868
+01:28:59,602 --> 01:29:05,428
+SPEAKER_16: But a whole cell of restoration of what was happening in 2019, that wouldn't be fiscally responsible.
+
+869
+01:29:05,508 --> 01:29:13,577
+SPEAKER_16: And I say it from the vantage point of, we had a lot of service that was out on the street, maybe that yielded one passenger boarding per hour.
+
+870
+01:29:14,030 --> 01:29:15,552
+SPEAKER_16: but that was out on the street.
+
+871
+01:29:15,852 --> 01:29:19,316
+SPEAKER_16: Does that really yield the return on investment going forward?
+
+872
+01:29:19,416 --> 01:29:26,965
+SPEAKER_16: Hence, that's why there were modifications relative to reallocation of services going forward.
+
+873
+01:29:27,386 --> 01:29:28,847
+Benker: Okay, but if I can.
+
+874
+01:29:28,988 --> 01:29:30,930
+Benker: Treasure, yeah.
+
+875
+01:29:31,010 --> 01:29:35,015
+Benker: Some of the issues that you just raised are important.
+
+876
+01:29:35,195 --> 01:29:35,816
+Benker: There's no doubt.
+
+877
+01:29:36,156 --> 01:29:40,421
+Benker: However, I don't believe it goes to the equity calculation.
+
+878
+01:29:42,884 --> 01:29:43,024
+Benker: I
+
+879
+01:29:45,080 --> 01:30:00,760
+Benker: What I think is important to to hear from staff and I know we're going to be talking about this in our retreat, which is I'm looking forward to that is if it's possible for us to go back to over 100 million riders in three years.
+
+880
+01:30:01,432 --> 01:30:20,994
+Benker: what barriers are we facing to try to do that so that we can go from 65 million to 100, 106, 110, and start quickly, or not quickly, but faster than what we're doing now to get back up to higher service levels.
+
+881
+01:30:22,957 --> 01:30:23,117
+SPEAKER_16: Ms.
+
+882
+01:30:23,157 --> 01:30:23,497
+SPEAKER_16: Johnson.
+
+883
+01:30:23,778 --> 01:30:24,178
+SPEAKER_16: Thank you.
+
+884
+01:30:24,198 --> 01:30:27,642
+SPEAKER_16: There's a couple of external factors that play into that.
+
+885
+01:30:27,993 --> 01:30:34,926
+SPEAKER_16: quite naturally when we look at the central business district and the occupancy rate and the lack of people commuting in.
+
+886
+01:30:35,427 --> 01:30:47,309
+SPEAKER_16: It's important to keep in mind that there was, I'm forgetting the name, but the city and county of Denver did the report relative to the usage rate in looking at the occupancy levels.
+
+887
+01:30:47,570 --> 01:30:51,537
+SPEAKER_16: But more specifically, what's important to note is that
+
+888
+01:30:51,517 --> 01:30:56,726
+SPEAKER_16: there hasn't been the level of bounce back relative to this central business district.
+
+889
+01:30:57,949 --> 01:31:08,388
+SPEAKER_16: I believe the last time I looked at stats, city and county at Denver was in the bottom three out of out of 50 major cities.
+
+890
+01:31:08,828 --> 01:31:12,495
+SPEAKER_16: And then as we know, the state of Colorado is the number
+
+891
+01:31:14,078 --> 01:31:18,923
+SPEAKER_16: is the third state relative to remote work and then City of Boulder is number one.
+
+892
+01:31:19,344 --> 01:31:27,092
+SPEAKER_16: While I factor that in, we don't have the same operating environment that we did in 2019 or prior to the pandemic.
+
+893
+01:31:27,452 --> 01:31:36,882
+SPEAKER_16: How do we get back to the transit usage that we had before?
+
+894
+01:31:37,563 --> 01:31:41,487
+SPEAKER_16: I think there's so many extenuating factors going forward
+
+895
+01:31:41,838 --> 01:32:05,374
+SPEAKER_16: relative to how we're delivering the service, but also having the vehicle capacity, the people power, and the reliability aspect, which bring us full circle to state of good repair and the other aspects that have caused people to shy away from utilizing our network because we were sacrificing one element for something else relative to delivery.
+
+896
+01:32:05,894 --> 01:32:08,959
+SPEAKER_16: And I bring that up because as we talk about the people power,
+
+897
+01:32:09,260 --> 01:32:33,588
+SPEAKER_16: we clearly saw that our operating workforce was decreasing in 2016 as it was across the country, but more specifically, having other ancillary services that were readily available where people whereby were working extra shifts and then we didn't have enough people for daily pullout on those other routes.
+
+898
+01:32:34,009 --> 01:32:37,613
+SPEAKER_16: And so I'm providing that context to say
+
+899
+01:32:37,930 --> 01:32:57,930
+SPEAKER_16: to get back, there are certain things that the agency can surely do, but to get back to those numbers within the period of time that you specify would be very challenging just because of the different operating characteristics that have been altered by factors that are no fault of this agency's.
+
+900
+01:33:00,020 --> 01:33:00,440
+Paglieri: Thanks, sir.
+
+901
+01:33:00,480 --> 01:33:03,864
+Paglieri: So I have a question for legal.
+
+902
+01:33:05,285 --> 01:33:15,475
+Paglieri: So recognizing this has to be submitted shortly, I want to be careful of my words.
+
+903
+01:33:17,297 --> 01:33:28,187
+Paglieri: Can we make significant changes at this juncture after all of the public comment process or
+
+904
+01:33:28,741 --> 01:33:33,908
+Paglieri: Is that something that we, I guess, I don't know if it's a yes, no, or a gray area.
+
+905
+01:33:33,988 --> 01:33:36,131
+Paglieri: And I wanted to get a bit of feedback on that.
+
+906
+01:33:36,591 --> 01:33:41,217
+Paglieri: Now, to disparage the motion, I just also want to understand the potential legal implications.
+
+907
+01:33:46,324 --> 01:33:48,687
+SPEAKER_16: I will address that question.
+
+908
+01:33:49,228 --> 01:33:51,891
+SPEAKER_16: And then I'll ask Mr. Green to expound.
+
+909
+01:33:51,991 --> 01:33:55,035
+SPEAKER_16: I think if anything, as we talk about public engagement,
+
+910
+01:33:55,606 --> 01:34:19,386
+SPEAKER_16: and talk about the agencies, the perception of the agency being trustworthy, going forward and getting public engagement quite naturally and then not leveraging it for the betterment of the constituencies that we serve, I think pose a risk as it relates to the agency in reference of public perception.
+
+911
+01:34:19,855 --> 01:34:25,784
+SPEAKER_16: There is leeway relative to the circular in light of what can be done.
+
+912
+01:34:25,864 --> 01:34:38,945
+SPEAKER_16: We are sitting here on May 28th, recognizing that we have a new administration and that we do need to have a Title VI program that's submitted and we have been engaged on this topic since January.
+
+913
+01:34:39,406 --> 01:34:42,030
+SPEAKER_16: That's not to negate any amendments or anything like that.
+
+914
+01:34:42,110 --> 01:34:44,614
+SPEAKER_16: I am just trying to answer the question.
+
+915
+01:34:44,797 --> 01:34:51,965
+SPEAKER_16: But more specifically, Mr. Green, since you are very well-versed in 4702.1B, I would yield the floor to you.
+
+916
+01:34:52,025 --> 01:34:56,069
+SPEAKER_16: And that's the citation for the FTA circular that we're talking about.
+
+917
+01:34:56,509 --> 01:34:56,690
+SPEAKER_01: Yes.
+
+918
+01:34:56,750 --> 01:34:58,872
+SPEAKER_01: Thank you so much, GM CEO Johnson.
+
+919
+01:34:58,932 --> 01:35:00,133
+SPEAKER_01: You.
+
+920
+01:35:04,538 --> 01:35:06,940
+SPEAKER_01: Apology, the positive microphone.
+
+921
+01:35:07,221 --> 01:35:07,521
+SPEAKER_01: Yes.
+
+922
+01:35:07,881 --> 01:35:08,322
+SPEAKER_01: Apologies.
+
+923
+01:35:08,382 --> 01:35:12,306
+SPEAKER_01: But to piggyback off what GM CEO Johnson has noted,
+
+924
+01:35:13,332 --> 01:35:20,373
+SPEAKER_01: That is, I would couch that as the bigger risk is when we think about establishing policy, right?
+
+925
+01:35:20,433 --> 01:35:25,047
+SPEAKER_01: As it relates to 4702.1B, the FTA Title VI circular.
+
+926
+01:35:25,432 --> 01:35:34,847
+SPEAKER_01: it does call upon the agency to do a lot of outreach and public involvement to ensure that we are collecting that feedback to inform decisions.
+
+927
+01:35:35,408 --> 01:35:48,790
+SPEAKER_01: So at the ground level, if we think about public involvement in Title VI, it's part and parcel of what the Title VI program stands for, ensuring that folks in the community are able to inform the decision, such as the policy.
+
+928
+01:35:49,495 --> 01:35:53,620
+SPEAKER_01: So, but with respect to the circular, we can, i.e.
+
+929
+01:35:53,940 --> 01:35:57,885
+SPEAKER_01: the board of directors could adopt a different threshold.
+
+930
+01:35:57,905 --> 01:36:11,001
+SPEAKER_01: So for example, the one that director banker has put forth, although we received a lot of feedback indicating the 25% threshold and 36 month cumulative change, et cetera, all that's packaged in within the proposed update.
+
+931
+01:36:11,761 --> 01:36:19,030
+SPEAKER_01: There is an exception to that within the circular where it states where the board is ultimately approving the policy.
+
+932
+01:36:20,917 --> 01:36:21,318
+SPEAKER_01: Thank you.
+
+933
+01:36:22,179 --> 01:36:26,085
+SPEAKER_10: Director Gysinger and then Director Larson.
+
+934
+01:36:29,690 --> 01:36:31,212
+SPEAKER_10: Director Larson and then Harwick.
+
+935
+01:36:33,395 --> 01:36:33,816
+Larsen: Thank you.
+
+936
+01:36:35,378 --> 01:36:50,400
+Larsen: I guess my question is, I looked through a lot of the Title VI updates that were for service changes, this Title VI analysis that were in the
+
+937
+01:36:50,583 --> 01:37:13,095
+Larsen: the board packet, and it seemed like most of the time we, you know, sometimes there was a little bit of disparate impact on one route or the other, but mostly it sort of ended up that in the aggregate there wasn't really much, and there were legitimate justifications for what there was on an individual basis.
+
+938
+01:37:13,896 --> 01:37:18,042
+Larsen: I guess my, you know, my basic question is with
+
+939
+01:37:18,393 --> 01:37:26,480
+Larsen: with regard to this update and the changes that we're proposing, are we just, I mean, is there really a problem here?
+
+940
+01:37:26,500 --> 01:37:28,682
+Larsen: Are we just making this harder for ourselves?
+
+941
+01:37:28,742 --> 01:37:39,872
+Larsen: Because it doesn't seem like we're trying to generally start out making service changes with an intention of causing disparate impact one place or the other.
+
+942
+01:37:39,933 --> 01:37:43,716
+Larsen: We make them, I guess, for a variety of reasons.
+
+943
+01:37:44,677 --> 01:37:48,180
+Larsen: And on balance, they don't really seem to
+
+944
+01:37:48,785 --> 01:38:01,669
+Larsen: under our current setup, you know, ever, ever sort of look like they were, you know, there were somehow some, you know, bad intent or just inattention to who we're serving.
+
+945
+01:38:01,729 --> 01:38:07,840
+Larsen: It seems like we do a lot of analysis and then basically do what we would have done anyways.
+
+946
+01:38:08,208 --> 01:38:28,974
+Larsen: Why put sort of a greater burden, sort of regulate ourselves more than we have to, and why not just give us the freedom to operate as we would as much as we can, given that we don't, you know, it doesn't necessarily seem like it's been a problem for a long time, at least from what I could see.
+
+947
+01:38:29,014 --> 01:38:37,405
+Larsen: I mean, there weren't that many Title VI complaints that I could, that I, in the information that was provided.
+
+948
+01:38:37,874 --> 01:38:38,256
+Larsen: I don't know.
+
+949
+01:38:39,442 --> 01:38:42,537
+Larsen: My basic question is why would we make things harder for ourselves?
+
+950
+01:38:42,898 --> 01:38:43,140
+Larsen: Thanks.
+
+951
+01:38:44,908 --> 01:38:45,793
+SPEAKER_10: Thank you, Ms.
+
+952
+01:38:45,833 --> 01:38:46,315
+SPEAKER_10: Johnson.
+
+953
+01:38:47,780 --> 01:38:48,401
+SPEAKER_16: Thank you very much.
+
+954
+01:38:48,461 --> 01:39:05,298
+SPEAKER_16: The one thing I would share Director Larson, as we look at the modification that's been put forward for your consideration, like a 36 month period, as we're adding back service, there could be unforeseen consequences as we do them in a segmented fashion.
+
+955
+01:39:05,618 --> 01:39:15,188
+SPEAKER_16: And so that's one element as a whole, because if we're making modifications going forward, there could be an adverse impact.
+
+956
+01:39:15,488 --> 01:39:17,911
+SPEAKER_16: And so that's what I would showcase there.
+
+957
+01:39:18,692 --> 01:39:30,728
+SPEAKER_16: Keeping in mind to the point that you raised, when we talk about the aspect of DIDB, it's what can we do as an agency to help mitigate that to your point going forward.
+
+958
+01:39:30,949 --> 01:39:40,301
+SPEAKER_16: But it's just to ensure that we have a program whereby we are not causing undue harm to certain population segments.
+
+959
+01:39:42,764 --> 01:39:43,285
+Guissinger: Director Larson.
+
+960
+01:39:45,307 --> 01:39:53,215
+Larsen: But it just seems like when I was reading the documents that there, we, there's always a legitimate to justification for, for everything we want to do.
+
+961
+01:39:53,235 --> 01:40:01,124
+Larsen: Or we, you know, it's always, there's always this, we'll have a disparate impact, but we have a legitimate justification for, for doing this.
+
+962
+01:40:01,204 --> 01:40:02,425
+Larsen: So we're, we're just going to do it.
+
+963
+01:40:02,966 --> 01:40:11,955
+Larsen: I mean, how many times, how many times in the last however many years has it been that we did this analysis, we looked at all the service changes we wanted to do.
+
+964
+01:40:12,323 --> 01:40:16,770
+Larsen: And we were like, okay, no, we're not going to do this list of service changes.
+
+965
+01:40:16,810 --> 01:40:23,039
+Larsen: We're going to, you know, cross out these ones because the aggregate impact is too much.
+
+966
+01:40:23,640 --> 01:40:25,843
+Larsen: I mean, is it, is it, is that happened?
+
+967
+01:40:26,043 --> 01:40:32,733
+Larsen: I just didn't, from what I read in the packet, I didn't, I don't know if I caught everything, but it didn't seem like there were a lot of those.
+
+968
+01:40:32,994 --> 01:40:41,807
+Larsen: Or is this happening kind of at an earlier stage where when Bob in service says, let's just send a bunch of buses to Cherry Hills Village, somebody says, no, no.
+
+969
+01:40:42,040 --> 01:40:46,365
+Larsen: That's not going to work out before it even gets to this point.
+
+970
+01:40:47,566 --> 01:40:47,847
+Larsen: You know?
+
+971
+01:40:50,269 --> 01:40:50,750
+SPEAKER_16: I'm sorry.
+
+972
+01:40:51,491 --> 01:40:52,492
+SPEAKER_16: Thank you for the question.
+
+973
+01:40:52,532 --> 01:40:53,613
+SPEAKER_16: It's for me.
+
+974
+01:40:53,753 --> 01:40:59,179
+SPEAKER_16: I've only been here for five years and I came in the height of the pandemic and we've been adding back service and not.
+
+975
+01:40:59,560 --> 01:41:09,651
+SPEAKER_16: So that's difficult for me to answer just because we have not been in a situation whereby
+
+976
+01:41:10,357 --> 01:41:11,459
+SPEAKER_16: It's been the opposite.
+
+977
+01:41:12,120 --> 01:41:14,403
+SPEAKER_16: Carl, do you have anything to add?
+
+978
+01:41:15,004 --> 01:41:15,405
+SPEAKER_01: Yeah.
+
+979
+01:41:15,425 --> 01:41:16,927
+SPEAKER_01: I would just highlight chair bouquet.
+
+980
+01:41:16,947 --> 01:41:34,153
+SPEAKER_01: If I may, since January 2023, there was about 270 service change recommendations that have been implemented and roughly 26, 24, 26 of those 276 were considered major service changes.
+
+981
+01:41:34,657 --> 01:41:41,608
+SPEAKER_01: And out of that 26 to director Larson's point, there has been 13 potential disparate impacts.
+
+982
+01:41:42,449 --> 01:41:46,555
+SPEAKER_01: And to your point, there was a substantial legitimate justification.
+
+983
+01:41:46,575 --> 01:41:56,631
+SPEAKER_01: And going it's, I wouldn't necessarily couch it as an exercise, but I would say we were the transit equity office within within the civil rights division.
+
+984
+01:41:56,881 --> 01:42:01,415
+SPEAKER_01: works hand in glove with Jesse Carter and his team service development.
+
+985
+01:42:02,177 --> 01:42:09,861
+SPEAKER_01: And as we are having those conversations after the service change recommendation are put forth and we analyze it if there is a potential disparate impact.
+
+986
+01:42:10,212 --> 01:42:15,922
+SPEAKER_01: More often than not, to your point, and to my earlier, earlier point, that Title VI is not a stopping mechanism.
+
+987
+01:42:16,443 --> 01:42:27,202
+SPEAKER_01: And I wouldn't necessarily state that it's burdensome because it's one of our responsibilities to make sure that we are equitably distributing services across our service area.
+
+988
+01:42:27,863 --> 01:42:35,376
+SPEAKER_01: But more often not, there is a legitimate justification to put forth the service recommendation as it is presented to the board.
+
+989
+01:42:38,073 --> 01:42:38,474
+SPEAKER_10: Thank you.
+
+990
+01:42:39,576 --> 01:42:39,837
+SPEAKER_10: Director.
+
+991
+01:42:42,021 --> 01:42:42,121
+SPEAKER_10: Okay.
+
+992
+01:42:42,142 --> 01:42:48,515
+SPEAKER_10: Uh, I had director Harwick and just as a reminder, we're currently in discussion regarding this first motion.
+
+993
+01:42:48,595 --> 01:42:53,044
+SPEAKER_10: Just want to make sure that, um, first amendment, excuse me, first amendment.
+
+994
+01:42:53,064 --> 01:42:56,572
+SPEAKER_10: So make sure, uh, comments are around that.
+
+995
+01:42:57,033 --> 01:42:57,634
+SPEAKER_10: Director Harwick.
+
+996
+01:42:59,369 --> 01:43:10,030
+Harwick: Mine will be comments about this, but also moving forward as well, because I am in support of this, this title six, not, not the amendment, just as just a straight title six.
+
+997
+01:43:10,050 --> 01:43:15,741
+Harwick: Um, you know, I, I don't think moving, uh, from, from 10 or from.
+
+998
+01:43:15,721 --> 01:43:21,028
+Harwick: from 10% to 20% is going to increase ridership.
+
+999
+01:43:21,248 --> 01:43:31,441
+Harwick: I think that right now it allows our staff the ability to really center equity and effectively protect our communities.
+
+1000
+01:43:31,521 --> 01:43:38,269
+Harwick: And while I get that Broomfield feels like they want more service, I don't think this is going to get it there.
+
+1001
+01:43:38,907 --> 01:43:43,928
+Harwick: I think this is the 11th hour and I think that it's really imperative that our staff has worked extremely hard on this.
+
+1002
+01:43:43,948 --> 01:43:49,390
+Harwick: They've had to jump through a whole variety of hoops.
+
+1003
+01:43:50,095 --> 01:44:15,293
+Harwick: bunch of different board members and I think that we're here, they've done an incredible job and I think that this is, they are the subject matter experts and it's our opportunity here to put our trust in them, our belief in them and I think that we owe them that and we have been talking about this since January so we're well into four months and I think that it is key that we support this
+
+1004
+01:44:15,273 --> 01:44:24,211
+Harwick: Title six as is and we allow them to move forward and we allow them to start you know handing us off to the feds and we can move forward and That's where I'm at.
+
+1005
+01:44:24,331 --> 01:44:24,612
+Harwick: Thank you.
+
+1006
+01:44:24,972 --> 01:44:34,952
+=START-7=
+SPEAKER_10: Thank you director any further conversation on this amendment Secretary Nicholson So this is for our deputy general counsel
+
+1007
+01:44:35,388 --> 01:44:47,544
+Nicholson: If we were to pass this tonight, what's the legal risk to the agency when it comes to our federal Title VI approval as a result of this change?
+
+1008
+01:44:47,704 --> 01:45:00,101
+Nicholson: Like, is this gonna have any, would this have any legal repercussions or could we just, do we feel pretty comfortable that we could do this and not have the federal government take issue with it?
+
+1009
+01:45:01,482 --> 01:45:03,385
+SPEAKER_10: In regards to the amendment secretary?
+
+1010
+01:45:03,405 --> 01:45:03,505
+Yeah.
+=END-7=
+
+1011
+01:45:06,910 --> 01:45:07,491
+SPEAKER_10: deputy counsel.
+
+1012
+01:45:11,415 --> 01:45:11,755
+SPEAKER_12: There we go.
+
+1013
+01:45:11,775 --> 01:45:12,255
+SPEAKER_12: Excuse me.
+
+1014
+01:45:12,816 --> 01:45:14,177
+SPEAKER_12: Uh, thank you, director Nicholson.
+
+1015
+01:45:14,738 --> 01:45:16,019
+SPEAKER_12: Um, I, I don't have concerns.
+
+1016
+01:45:18,922 --> 01:45:19,323
+Guissinger: Secretary.
+
+1017
+01:45:21,165 --> 01:45:21,725
+Guissinger: That is all.
+
+1018
+01:45:22,806 --> 01:45:23,907
+Guissinger: Uh, yeah, treasure banker.
+
+1019
+01:45:25,389 --> 01:45:33,357
+Benker: Um, here is where I do not understand in 2019.
+
+1020
+01:45:35,716 --> 01:45:37,201
+Benker: We had the service.
+
+1021
+01:45:38,506 --> 01:45:42,902
+Benker: My area, my district as many others have grown.
+
+1022
+01:45:42,962 --> 01:45:46,013
+Benker: There's no
+
+1023
+01:45:47,208 --> 01:45:55,277
+Benker: For example, the town of Erie, just a few years ago was 20,000, now it's 40,000, like two, three years later.
+
+1024
+01:45:55,297 --> 01:46:03,345
+Benker: And when I met with Erie, they said, hey, we're planning going to 80,000 in just the next couple of years.
+
+1025
+01:46:04,086 --> 01:46:14,717
+Benker: I also read in the Denver Post that the town of Erie is the 15th fastest city in the country in terms of population growth.
+
+1026
+01:46:15,727 --> 01:46:31,322
+Benker: So my question is, is if we had the service prior to the pandemic and it was serving all of these communities, why is it so difficult to get that restored?
+
+1027
+01:46:35,466 --> 01:46:36,086
+SPEAKER_10: Just Johnson.
+
+1028
+01:46:39,770 --> 01:46:42,392
+SPEAKER_16: So thank you, Director Banker.
+
+1029
+01:46:44,667 --> 01:47:04,808
+SPEAKER_16: This, what I'm going to say goes back to the previous comments that I had before, recognizing that RTD is a regional service and the way the service was outlined for all intents and purposes was bringing individuals into the central business district.
+
+1030
+01:47:07,270 --> 01:47:12,936
+SPEAKER_16: That level of ridership isn't there and that's not to negate that there
+
+1031
+01:47:13,844 --> 01:47:19,258
+SPEAKER_16: is some elements centered on a need to move people to and fro.
+
+1032
+01:47:19,318 --> 01:47:23,047
+SPEAKER_16: Hence, that's why there was the advent of the partnership program.
+
+1033
+01:47:23,388 --> 01:47:30,486
+SPEAKER_16: And one of the reasons why Erie basically wanted to join the district because they were looking to put forward an application
+
+1034
+01:47:30,837 --> 01:47:56,018
+SPEAKER_16: for the partnership program, and I know you're just using that as an example, but just wanted to further iterate that because for all intents and purposes, as we're looking to provide mobility options, the intent behind the partnership program was more or less like a pilot in the sense that let's see how many people are utilizing this means of connection
+
+1035
+01:47:56,656 --> 01:48:08,651
+SPEAKER_16: prior to putting out a 40 foot or a 60 foot Arctic that costs more money per revenue hour and doesn't yield the same return on investment relative to the cost per boarding.
+
+1036
+01:48:10,253 --> 01:48:13,037
+SPEAKER_16: Does that help or did I complicated more?
+
+1037
+01:48:13,077 --> 01:48:16,661
+SPEAKER_16: Okay.
+
+1038
+01:48:16,682 --> 01:48:17,082
+SPEAKER_10: Thank you.
+
+1039
+01:48:17,222 --> 01:48:19,105
+SPEAKER_10: Director Guzman and then Director Geisinger.
+
+1040
+01:48:19,846 --> 01:48:23,791
+Guzman: So I would urge us to cleanly pass this through tonight.
+
+1041
+01:48:24,191 --> 01:48:26,494
+Guzman: I'm getting back to the motion before us.
+
+1042
+01:48:26,997 --> 01:48:39,312
+Guzman: I would like to ask one question, which is the 10 to 20% is still not going to prevent us from adding services.
+
+1043
+01:48:40,293 --> 01:48:55,232
+Guzman: It is simply a filter through which to look, if I understand this correctly, that we are not unintentionally harming community with protected status under the Title VI legislation,
+
+1044
+01:48:55,634 --> 01:49:02,843
+Guzman: or those that might be disproportionately burdened or impacted by their financial and economic status within the region.
+
+1045
+01:49:03,964 --> 01:49:16,219
+Guzman: The only purpose we need to pass this is because it is due, because it is the law, and it is how we ensure that we are able to receive our federal funding, which is approximately 25% of our total budget.
+
+1046
+01:49:17,400 --> 01:49:20,764
+Guzman: So I just want to make sure I understand.
+
+1047
+01:49:20,980 --> 01:49:25,827
+Guzman: what has been presented here does not tell the board no, we cannot provide transit service.
+
+1048
+01:49:26,608 --> 01:49:46,195
+Guzman: It is simply a way to look at it and say we may have an issue if it reaches a certain threshold that we need to be aware of in order to be able to approve changes in service, fair changes or other changes that would create a potential burden on specific
+
+1049
+01:49:47,137 --> 01:49:50,501
+Guzman: communities as defined within the Title VI language.
+
+1050
+01:49:50,701 --> 01:49:55,027
+Guzman: Is that correct or am I completely lost in this conversation?
+
+1051
+01:49:56,849 --> 01:49:57,590
+SPEAKER_01: Chair, are we okay for me?
+
+1052
+01:49:57,970 --> 01:49:59,031
+SPEAKER_10: Absolutely, Mr. Green.
+
+1053
+01:49:59,051 --> 01:50:03,136
+SPEAKER_01: If I'm tracking Director Guzman, I'll try to answer the question from what I hear.
+
+1054
+01:50:03,196 --> 01:50:05,880
+SPEAKER_01: And if you have any double back, then I'll respond to it.
+
+1055
+01:50:06,500 --> 01:50:12,047
+SPEAKER_01: So the current 10%, so if we think about different thresholds for DIDB,
+
+1056
+01:50:12,770 --> 01:50:41,983
+SPEAKER_01: And we are in, based off the desk audit, we're in the middle tier of having a threshold that allows us as an agency, which ultimately each service equity analysis is approved by the board of directors, where it allows us, again, to your point, when we're thinking about BIPOC or Black Indigenous people of color, for disparate impact or loan communities, for disproportionate burden, it allows us to make a well-informed, eyes-wide open decision
+
+1057
+01:50:42,402 --> 01:50:46,948
+SPEAKER_01: of better understanding of who's more likely to receive more of the impact.
+
+1058
+01:50:47,469 --> 01:50:56,020
+SPEAKER_01: And when we're thinking about service increases, we're thinking about the fair share of benefits, where if there is a service reduction, we're looking at who's more likely to receive more of the burden.
+
+1059
+01:50:56,540 --> 01:51:06,173
+SPEAKER_01: So to your point, Director Guzman, it allows us to just get a better understanding of the level of impact that we can have on a particular community.
+
+1060
+01:51:06,594 --> 01:51:09,237
+SPEAKER_01: It does not prevent us from moving forward.
+
+1061
+01:51:11,191 --> 01:51:11,612
+SPEAKER_01: Thank you.
+
+1062
+01:51:11,632 --> 01:51:18,953
+Guzman: I would just urge a no vote and let's move on to the policy.
+
+1063
+01:51:19,856 --> 01:51:20,317
+SPEAKER_10: All right.
+
+1064
+01:51:21,139 --> 01:51:25,993
+SPEAKER_10: Dr. Geisinger, I'm going to have you as our final comment on this specific amendment.
+
+1065
+01:51:26,227 --> 01:51:27,389
+SPEAKER_00: I'll be super quick.
+
+1066
+01:51:27,409 --> 01:51:33,637
+SPEAKER_00: At that last explanation that Mr. Green gave helped me in terms of just giving us a better holistic view.
+
+1067
+01:51:33,657 --> 01:51:41,487
+SPEAKER_00: But I shared Director Larson's sort of view of are we just making this harder for ourselves, creating more work?
+
+1068
+01:51:43,230 --> 01:51:44,051
+SPEAKER_00: Is that not right?
+
+1069
+01:51:45,593 --> 01:51:46,534
+SPEAKER_01: Mr. Green?
+
+1070
+01:51:46,554 --> 01:51:48,276
+SPEAKER_01: Yeah, that's a great follow up question.
+
+1071
+01:51:48,296 --> 01:51:49,618
+SPEAKER_01: I would say it
+
+1072
+01:51:50,847 --> 01:52:18,711
+SPEAKER_01: I wouldn't say it's making it harder because when we think about what we're ultimately trying to achieve and a percentage that's mathematically consistent relative to the populations that we serve, so in doing this work, given my background, right, in doing an assessment of whether if we, and that's why we didn't want to make any modifications of increasing or decreasing the major service change, we just wanted to keep it consistent, is
+
+1073
+01:52:18,978 --> 01:52:30,132
+SPEAKER_01: with doing this work, or even doing an analysis of previous run boards or equity analyses, 20% is something where you wouldn't see anything.
+
+1074
+01:52:31,393 --> 01:52:42,066
+SPEAKER_01: And that's a disservice when we think about our populations within our service area, specifically as we look at our census data where 38.1% is BIPOC, 13.1%.
+
+1075
+01:52:42,653 --> 01:52:45,596
+SPEAKER_01: or 14.1 rather for low income, right?
+
+1076
+01:52:45,716 --> 01:52:49,960
+SPEAKER_01: And then if we look at the onboard survey, 56% are considered BIPOC.
+
+1077
+01:52:50,981 --> 01:53:11,800
+SPEAKER_01: And so I say all that to say, just to wrap it up, is that 10% threshold for DINDB allows us to make an informed decision that is backed by not only our desk audit, but the years of experience and knowing, having a better understanding of ultimately what we're trying to achieve.
+
+1078
+01:53:14,345 --> 01:53:14,765
+SPEAKER_00: Thank you.
+
+1079
+01:53:15,086 --> 01:53:15,406
+SPEAKER_10: Thank you.
+
+1080
+01:53:15,927 --> 01:53:17,628
+SPEAKER_10: All right, let's do a roll call vote.
+
+1081
+01:53:17,648 --> 01:53:27,759
+SPEAKER_10: As a reminder, it is the First Amendment being introduced, as you all can see on that screen, with Director Banker as the mover and Director Pagulieri as the second.
+
+1082
+01:53:27,859 --> 01:53:30,541
+SPEAKER_10: Again, we're voting on this First Amendment.
+
+1083
+01:53:31,342 --> 01:53:31,923
+SPEAKER_10: Treasure Banker.
+
+1084
+01:53:32,784 --> 01:53:33,004
+Benker: Yes.
+
+1085
+01:53:33,825 --> 01:53:34,926
+SPEAKER_10: Director Buzik is gone.
+
+1086
+01:53:34,966 --> 01:53:36,387
+SPEAKER_10: Director Katlin.
+
+1087
+01:53:38,009 --> 01:53:39,030
+Catlin: No.
+
+1088
+01:53:39,050 --> 01:53:40,271
+SPEAKER_10: Director Geisinger.
+
+1089
+01:53:42,874 --> 01:53:42,934
+Catlin: No.
+
+1090
+01:53:44,348 --> 01:53:44,729
+SPEAKER_10: Director.
+
+1091
+01:53:44,849 --> 01:53:45,169
+SPEAKER_10: No.
+
+1092
+01:53:45,189 --> 01:53:45,329
+SPEAKER_10: No.
+
+1093
+01:53:46,051 --> 01:53:47,092
+Guzman: No.
+
+1094
+01:53:47,112 --> 01:53:47,332
+SPEAKER_10: No.
+
+1095
+01:53:47,413 --> 01:53:47,753
+SPEAKER_10: No.
+
+1096
+01:53:48,174 --> 01:53:48,935
+Guzman: No.
+
+1097
+01:53:48,955 --> 01:53:49,135
+SPEAKER_10: No.
+
+1098
+01:53:49,656 --> 01:53:49,856
+SPEAKER_10: No.
+
+1099
+01:53:50,637 --> 01:53:50,838
+SPEAKER_10: No.
+
+1100
+01:53:51,138 --> 01:53:51,258
+SPEAKER_10: No.
+
+1101
+01:53:51,999 --> 01:53:52,220
+SPEAKER_10: No.
+
+1102
+01:53:53,321 --> 01:53:53,562
+SPEAKER_10: No.
+
+1103
+01:53:53,622 --> 01:53:57,628
+SPEAKER_10: No.
+
+1104
+01:54:01,073 --> 01:54:02,916
+SPEAKER_10: No.
+
+1105
+01:54:04,458 --> 01:54:07,302
+SPEAKER_10: No.
+
+1106
+01:54:08,344 --> 01:54:10,507
+SPEAKER_10: No.
+
+1107
+01:54:10,708 --> 01:54:10,848
+SPEAKER_10: No.
+
+1108
+01:54:11,389 --> 01:54:11,689
+Whitmore: No.
+
+1109
+01:54:14,048 --> 01:54:15,471
+SPEAKER_10: I mean, yes, but the motion will fail.
+
+1110
+01:54:16,953 --> 01:54:20,099
+SPEAKER_10: And we have three to 10.
+
+1111
+01:54:21,342 --> 01:54:22,965
+SPEAKER_10: Okay.
+
+1112
+01:54:22,985 --> 01:54:23,466
+SPEAKER_10: Moving on.
+
+1113
+01:54:23,726 --> 01:54:24,307
+SPEAKER_10: Yes, Director.
+
+1114
+01:54:24,347 --> 01:54:26,491
+Benker: I would like to withdraw the next two amendments.
+
+1115
+01:54:26,912 --> 01:54:27,614
+SPEAKER_10: Next two amendments.
+
+1116
+01:54:27,754 --> 01:54:27,954
+Benker: Yes.
+
+1117
+01:54:28,635 --> 01:54:29,617
+SPEAKER_10: Okay.
+
+1118
+01:54:29,637 --> 01:54:32,142
+SPEAKER_10: The next two amendments have been withdrawn.
+
+1119
+01:54:33,522 --> 01:54:35,067
+Larsen: Okay, they were never introduced.
+
+1120
+01:54:35,107 --> 01:54:41,829
+Larsen: So they're not really with John, but now you would return back to the debate on the main motion, which is to approve the title six program update.
+
+1121
+01:54:42,251 --> 01:54:42,632
+SPEAKER_10: Excellent.
+
+1122
+01:54:43,174 --> 01:54:44,418
+SPEAKER_10: Back to the main motion at hand.
+
+1123
+01:54:45,000 --> 01:54:45,642
+SPEAKER_10: Director Keith.
+
+1124
+01:54:47,174 --> 01:54:54,424
+=START-8=
+Nicholson: So I contemplated a no vote out of principle on this action.
+
+1125
+01:54:54,484 --> 01:54:57,207
+Nicholson: There's a few things going on.
+
+1126
+01:54:57,247 --> 01:55:00,412
+Nicholson: First of all, it should never get to the last minute.
+
+1127
+01:55:00,932 --> 01:55:06,099
+Nicholson: The board should never be asked to pass things because it's due in two days.
+
+1128
+01:55:06,420 --> 01:55:12,608
+Nicholson: And I know there's a lot of things that go into the delay, but that's just not the right
+
+1129
+01:55:13,077 --> 01:55:19,510
+Nicholson: That's not the right urgency to place on the board act.
+
+1130
+01:55:19,810 --> 01:55:26,884
+Nicholson: Secondly, I don't know very much about this topic and I have sat in on two operations committee meetings.
+
+1131
+01:55:28,327 --> 01:55:29,550
+Nicholson: I've talked to a bunch of people.
+
+1132
+01:55:29,610 --> 01:55:32,335
+Nicholson: I've done my own research.
+
+1133
+01:55:32,315 --> 01:55:37,602
+Nicholson: And I still am looking for a succinct description of the program.
+
+1134
+01:55:37,642 --> 01:55:43,230
+Nicholson: I would note that there was a wonderful book written by Robert Carrow.
+
+1135
+01:55:43,250 --> 01:55:44,372
+Nicholson: It's called The Power Broker.
+
+1136
+01:55:44,612 --> 01:55:46,855
+Nicholson: I'm sure a lot of people in this room know it.
+
+1137
+01:55:47,596 --> 01:55:54,205
+Nicholson: Talks a lot about bad policy decisions on disadvantaged communities.
+
+1138
+01:55:54,185 --> 01:56:02,324
+Nicholson: and how those decisions were made and the harmful outcome of those decisions.
+
+1139
+01:56:03,767 --> 01:56:08,278
+Nicholson: It is 15 pages shorter than our packet tonight.
+
+1140
+01:56:08,731 --> 01:56:18,289
+Nicholson: He won the Pulitzer Prize for a 1200 page treatise on impact by public infrastructure.
+
+1141
+01:56:18,309 --> 01:56:25,423
+Nicholson: I would request that when we're passing along documents as part of a packet,
+
+1142
+01:56:25,403 --> 01:56:30,088
+Nicholson: it needs to have a point and it should be summarized from the committee for the rest of the board.
+
+1143
+01:56:30,148 --> 01:56:35,373
+Nicholson: Simply passing things along for us does not help me understand this better.
+
+1144
+01:56:35,393 --> 01:56:42,580
+Nicholson: I'm probably a yes vote tonight, but I was a no vote until about an hour and a half ago.
+
+1145
+01:56:42,640 --> 01:56:52,170
+Nicholson: And so I just, when you are putting together packets on complex questions for the board,
+
+1146
+01:56:52,150 --> 01:56:56,376
+Nicholson: Given us reams of paper does not help us get to a better decision.
+
+1147
+01:56:57,097 --> 01:57:09,856
+Nicholson: So that's something request for the two three ish committee chairs As you're putting together topics like this and that would be very helpful for me to make better Decisions.
+
+1148
+01:57:10,437 --> 01:57:10,697
+Nicholson: Thanks.
+
+1149
+01:57:11,018 --> 01:57:11,719
+SPEAKER_10: Thank you director.
+=END-8=
+
+1150
+01:57:11,839 --> 01:57:14,703
+SPEAKER_10: Okay any further comments or questions on the main motion?
+
+1151
+01:57:15,765 --> 01:57:20,892
+Guzman: Dr. Guzman, I would just like to mention that the Denver City Council unanimously
+
+1152
+01:57:21,496 --> 01:57:27,163
+Guzman: submitted a proclamation for RTD on May 19th, 2025.
+
+1153
+01:57:27,263 --> 01:57:28,845
+Guzman: It is in the director's emails.
+
+1154
+01:57:29,506 --> 01:57:46,086
+Guzman: It was sent over by city council that they wholeheartedly support the 2025, 2028 title six program to include the proposed updates to major service change, disparate impact and fair equity policies, as well as updates to RTD's public participation plan and language access plan, which we are voting on now.
+
+1155
+01:57:46,808 --> 01:57:51,073
+Guzman: and that the clerk and recorder of the city and county of Denver did affix the seal making it official.
+
+1156
+01:57:52,275 --> 01:57:54,017
+Guzman: I believe that that is necessary.
+
+1157
+01:57:54,037 --> 01:58:12,681
+Guzman: There's a whole proclamation, you can read through it, but former board director Lewis, sorry, we had two Lewises and I wanted to make sure I said it right, did work with city council member Serena Gutierrez Gonzalez and
+
+1158
+01:58:13,285 --> 01:58:17,534
+Guzman: The unanimity of that vote is remarkable from our city council.
+
+1159
+01:58:17,634 --> 01:58:21,081
+Guzman: So they stand behind this as well with us to move this forward.
+
+1160
+01:58:21,101 --> 01:58:22,063
+Guzman: Thank you.
+
+1161
+01:58:22,083 --> 01:58:22,905
+SPEAKER_10: Thank you, director.
+
+1162
+01:58:23,687 --> 01:58:24,388
+Larsen: Director Larson.
+
+1163
+01:58:26,312 --> 01:58:27,374
+Larsen: I'm going to be a no vote.
+
+1164
+01:58:27,815 --> 01:58:29,218
+Larsen: I think.
+
+1165
+01:58:29,738 --> 01:58:33,864
+Larsen: I think it's kind of like I said, we're constraining our freedom to operate.
+
+1166
+01:58:33,924 --> 01:58:36,928
+Larsen: We're spending a lot of energy and effort to track this.
+
+1167
+01:58:37,308 --> 01:58:51,007
+Larsen: And I know the intentions behind that are good, but I think just as a matter of principle, we shouldn't be sort of trying to over, or regulating ourselves more.
+
+1168
+01:58:51,428 --> 01:58:54,632
+Larsen: We should be thinking is, we have not,
+
+1169
+01:58:54,612 --> 01:59:07,170
+Larsen: There's not really a lot of evidence that we have disparately ever had any recent plans to expand service or decrease service in a way that
+
+1170
+01:59:07,623 --> 01:59:12,349
+Larsen: that causes a disparate impact on these populations.
+
+1171
+01:59:12,770 --> 01:59:31,133
+Larsen: And I honestly believe that if we focused 100% just on increasing ridership, which is what I think we should be doing, and not trying to expand our sort of purview about when, you know, when maybe we shouldn't increase ridership, I don't know if we really, if it's legitimate, we'll do it anyways.
+
+1172
+01:59:31,467 --> 01:59:46,633
+Larsen: I really think if we were focusing strictly on increasing ridership, we would actually, it would all be disparately impacted in favor of all the communities we're worried about just based on the way population is distributed in the area.
+
+1173
+01:59:47,114 --> 01:59:56,530
+Larsen: And I would like for us to kind of move towards a paradigm of focusing much, much more on increasing ridership across the board.
+
+1174
+01:59:56,965 --> 02:00:02,020
+Larsen: and less on finding possible reasons to not increase ridership.
+
+1175
+02:00:03,163 --> 02:00:04,146
+Larsen: So I'll be in no vote.
+
+1176
+02:00:04,166 --> 02:00:05,089
+Larsen: Thanks.
+
+1177
+02:00:05,109 --> 02:00:05,951
+Larsen: Thank you, Director Larson.
+
+1178
+02:00:06,032 --> 02:00:06,874
+=START-9=
+SPEAKER_10: Secretary Nicholson.
+
+1179
+02:00:08,491 --> 02:00:17,099
+Nicholson: So I sat through two committee meetings, a study session and a town hall all on this topic.
+
+1180
+02:00:17,479 --> 02:00:28,369
+Nicholson: And I should say, expertly facilitated by our co-chairs and by our chair of finance and our staff.
+
+1181
+02:00:28,649 --> 02:00:34,294
+Nicholson: And I feel like I just starting to get a decent understanding of it.
+
+1182
+02:00:34,494 --> 02:00:38,498
+Nicholson: Like I came into this knowing nothing about this.
+
+1183
+02:00:38,478 --> 02:00:58,461
+Nicholson: I was an absolute no when we first started and my public remarks, you know, made that very clear but I want to commend staff and our board leadership who were willing to indulge because I came to understand it.
+
+1184
+02:00:58,863 --> 02:01:10,864
+Nicholson: I came to understand what it was for, I came to understand how it works, and I don't necessarily agree with all of it, and I think we could use more data in addition to those data we have now to determine this, but...
+
+1185
+02:01:11,992 --> 02:01:13,995
+Nicholson: If we don't pass this, we lose federal funding.
+
+1186
+02:01:14,316 --> 02:01:16,479
+Nicholson: So there's a good reason to pass it even if you don't like it.
+
+1187
+02:01:18,021 --> 02:01:22,789
+Nicholson: But on top of that, I just think our staff did their jobs.
+
+1188
+02:01:23,290 --> 02:01:28,298
+Nicholson: They have demonstrated to me this is the right thing to do despite my skepticism.
+
+1189
+02:01:28,518 --> 02:01:30,341
+Nicholson: And so I'm definitely voting for it tonight.
+
+1190
+02:01:30,982 --> 02:01:31,723
+SPEAKER_10: Thank you.
+
+1191
+02:01:31,743 --> 02:01:33,105
+SPEAKER_10: Any further comments on the main motion?
+
+1192
+02:01:34,503 --> 02:01:35,205
+SPEAKER_10: Okay, seeing none.
+
+1193
+02:01:35,225 --> 02:01:38,011
+SPEAKER_10: We had Catlin as the mover and Guzman as the second.
+
+1194
+02:01:38,532 --> 02:01:40,497
+SPEAKER_10: There is indication that there will be no votes.
+
+1195
+02:01:40,557 --> 02:01:42,722
+SPEAKER_10: So I will be doing a roll call vote on this.
+=END-9=
+
+1196
+02:01:44,085 --> 02:01:44,846
+SPEAKER_10: Uh, treasurer banker.
+
+1197
+02:01:44,866 --> 02:01:46,149
+Benker: Uh, no.
+
+1198
+02:01:48,034 --> 02:01:48,695
+SPEAKER_10: Director Catlin.
+
+1199
+02:01:49,597 --> 02:01:49,818
+Catlin: Yes.
+
+1200
+02:01:52,243 --> 02:01:53,085
+SPEAKER_10: Dr. Geisinger.
+
+1201
+02:01:53,555 --> 02:01:53,835
+Guissinger: Yes.
+
+1202
+02:01:54,937 --> 02:01:55,718
+SPEAKER_10: Dr. Gutierrez.
+
+1203
+02:01:56,119 --> 02:01:56,439
+Guissinger: Yes.
+
+1204
+02:01:56,960 --> 02:01:57,621
+SPEAKER_10: Dr. Guzman.
+
+1205
+02:01:57,821 --> 02:01:58,062
+SPEAKER_10: Yes.
+
+1206
+02:01:58,362 --> 02:01:59,003
+SPEAKER_10: Dr. Harwick.
+
+1207
+02:01:59,424 --> 02:01:59,844
+SPEAKER_10: Yes.
+
+1208
+02:02:01,166 --> 02:02:01,847
+SPEAKER_10: Dr. Larson.
+
+1209
+02:02:02,428 --> 02:02:02,649
+Larsen: No.
+
+1210
+02:02:03,249 --> 02:02:04,051
+SPEAKER_10: Secretary Nicholson.
+
+1211
+02:02:04,712 --> 02:02:04,992
+SPEAKER_10: I'm in.
+
+1212
+02:02:06,294 --> 02:02:07,155
+SPEAKER_10: First Vice Chair O'Keeffe.
+
+1213
+02:02:08,017 --> 02:02:08,257
+Nicholson: Yes.
+
+1214
+02:02:08,657 --> 02:02:09,439
+SPEAKER_10: Dr. Pagulari.
+
+1215
+02:02:11,041 --> 02:02:11,321
+SPEAKER_10: Yes.
+
+1216
+02:02:11,962 --> 02:02:12,603
+SPEAKER_10: Dr. Ruscha.
+
+1217
+02:02:12,924 --> 02:02:14,666
+SPEAKER_10: Yep.
+
+1218
+02:02:14,747 --> 02:02:15,748
+SPEAKER_10: Second Vice Chair Whitmore.
+
+1219
+02:02:15,982 --> 02:02:16,282
+SPEAKER_10: Yes.
+
+1220
+02:02:17,043 --> 02:02:17,905
+SPEAKER_10: I'm also, yes.
+
+1221
+02:02:18,345 --> 02:02:24,453
+SPEAKER_10: So the motion, the main motion will pass 11, two and two absent.
+
+1222
+02:02:25,895 --> 02:02:26,095
+SPEAKER_10: Yes.
+
+1223
+02:02:26,416 --> 02:02:28,258
+SPEAKER_10: That math adds up.
+
+1224
+02:02:28,278 --> 02:02:28,559
+SPEAKER_10: Okay.
+
+1225
+02:02:29,079 --> 02:02:39,773
+SPEAKER_10: Moving on, we're going to be moving to our next recommended action, which is the budget transfer articulated buses supporting Colfax bus rapid transit or BRT service.
+
+1226
+02:02:39,873 --> 02:02:40,775
+SPEAKER_10: Do I have a mover?
+
+1227
+02:02:41,736 --> 02:02:42,136
+Guzman: So moved.
+
+1228
+02:02:42,176 --> 02:02:42,597
+Guzman: Guzman.
+
+1229
+02:02:42,644 --> 02:02:43,726
+SPEAKER_10: I have Guzman as the mover.
+
+1230
+02:02:43,746 --> 02:02:44,447
+SPEAKER_10: Do I have a second?
+
+1231
+02:02:44,567 --> 02:02:44,848
+SPEAKER_10: Second.
+
+1232
+02:02:46,550 --> 02:02:46,711
+Paglieri: Sir.
+
+1233
+02:02:47,071 --> 02:02:47,792
+Paglieri: Yeah.
+
+1234
+02:02:47,812 --> 02:02:48,073
+Paglieri: Oh, wait.
+
+1235
+02:02:48,473 --> 02:02:49,114
+Paglieri: Well, I could be wrong.
+
+1236
+02:02:49,134 --> 02:02:49,455
+Paglieri: I'm sorry.
+
+1237
+02:02:50,256 --> 02:02:51,238
+Paglieri: I forgot we started late.
+
+1238
+02:02:51,498 --> 02:02:52,560
+Paglieri: I thought we had our four hour mark.
+
+1239
+02:02:53,041 --> 02:02:53,562
+Paglieri: Please ignore me.
+
+1240
+02:02:56,546 --> 02:02:57,087
+SPEAKER_10: Oh, sorry.
+
+1241
+02:02:57,107 --> 02:02:58,870
+SPEAKER_10: Guzman is the mover.
+
+1242
+02:02:58,930 --> 02:03:00,132
+SPEAKER_10: Whitmore is the second.
+
+1243
+02:03:03,858 --> 02:03:04,900
+SPEAKER_10: Any discussion on it?
+
+1244
+02:03:05,881 --> 02:03:06,863
+SPEAKER_10: Yeah, director Pagular.
+
+1245
+02:03:07,231 --> 02:03:11,818
+SPEAKER_03: I just wanted to say a few quick words about why I will not be voting for this.
+
+1246
+02:03:11,858 --> 02:03:24,438
+SPEAKER_03: I was not necessarily sure how this would further the clean energy and zero emission goals of the state of Colorado.
+
+1247
+02:03:24,458 --> 02:03:29,025
+SPEAKER_03: And therefore, we'll just be voting now.
+
+1248
+02:03:29,085 --> 02:03:29,425
+SPEAKER_03: Thank you.
+
+1249
+02:03:31,949 --> 02:03:33,431
+SPEAKER_03: Any further conversation?
+
+1250
+02:03:33,472 --> 02:03:34,453
+=START-10=
+SPEAKER_03: Secretary Nicholson?
+
+1251
+02:03:35,767 --> 02:03:39,856
+Nicholson: Yeah, so I understand where we're the importance of what we're doing here.
+
+1252
+02:03:41,459 --> 02:03:50,839
+Nicholson: I think that these buses in particular, you know, in my religion, there's a thing why is this night different from all other nights why are these buses different from all other buses.
+
+1253
+02:03:52,068 --> 02:03:56,232
+Nicholson: These are going to be the flagship of our flagship BRT line.
+
+1254
+02:03:57,093 --> 02:04:03,740
+Nicholson: And if these suck, it will kill BRT.
+
+1255
+02:04:04,280 --> 02:04:18,555
+Nicholson: And if they are not comfortable, if they are not just awesome in every way possible, you can make a lot of choices when you buy a bus about how nice it's going to be in the same way you can make a lot of choices about when you buy a car about how nice it's going to be.
+
+1256
+02:04:19,215 --> 02:04:22,058
+Nicholson: And so I just want to lean in here
+
+1257
+02:04:22,038 --> 02:04:44,939
+Nicholson: and I do have one question, to say that we need to pull the stops out, we need to make sure we're giving you enough money, GMCO Johnson, to make sure we're buying top of the line, to make sure that these are things that when they run through my district, people go, wow, I want to get on that, not, wow, that doesn't look very nice.
+
+1258
+02:04:45,659 --> 02:04:52,045
+Nicholson: And so my question for you is, how do you know that the amount of money that we're authorizing today
+
+1259
+02:04:52,025 --> 02:04:54,128
+Nicholson: is enough to get top of the line.
+
+1260
+02:04:54,909 --> 02:05:05,364
+Nicholson: And how many bytes at the Apple are we going to get to make sure that you are buying the right buses for this incredibly important project?
+
+1261
+02:05:06,565 --> 02:05:06,746
+SPEAKER_10: Ms.
+
+1262
+02:05:06,806 --> 02:05:09,490
+SPEAKER_10: Johnson is 51 million enough to make them not suck.
+
+1263
+02:05:10,671 --> 02:05:11,232
+SPEAKER_16: Yeah.
+=END-10=
+
+1264
+02:05:12,308 --> 02:05:15,090
+SPEAKER_16: So thank you very much, Mr. Chair.
+
+1265
+02:05:15,731 --> 02:05:17,733
+SPEAKER_16: And thank you for the question.
+
+1266
+02:05:18,433 --> 02:05:19,594
+SPEAKER_09: My apologies.
+
+1267
+02:05:19,634 --> 02:05:20,355
+SPEAKER_16: That was a good question.
+
+1268
+02:05:20,575 --> 02:05:21,336
+SPEAKER_16: Keep it in mind.
+
+1269
+02:05:21,356 --> 02:05:25,660
+SPEAKER_16: This is a budget transfer and full transparency.
+
+1270
+02:05:26,180 --> 02:05:30,724
+SPEAKER_16: Director Nicholson emailed me about this because I think there was some confusion about where we are.
+
+1271
+02:05:31,045 --> 02:05:32,626
+SPEAKER_16: There is yet to be a solicitation.
+
+1272
+02:05:32,666 --> 02:05:34,488
+SPEAKER_16: There's yet to be specifications.
+
+1273
+02:05:34,888 --> 02:05:41,674
+SPEAKER_16: So these monies that are being transferred or needed
+
+1274
+02:05:42,076 --> 02:05:44,399
+SPEAKER_16: for all intents and purposes so we can start a procurement.
+
+1275
+02:05:46,841 --> 02:05:49,845
+SPEAKER_16: Now, keeping in mind, there's a couple of elements.
+
+1276
+02:05:50,185 --> 02:05:58,355
+SPEAKER_16: These buses have to be dedicated because this is designated as a bus rapid transit project as defined by the Federal Transit Administration.
+
+1277
+02:05:58,815 --> 02:06:04,402
+SPEAKER_16: There's certain criteria that we have to ensure that we adhere to.
+
+1278
+02:06:04,462 --> 02:06:11,610
+SPEAKER_16: This will be a dedicated fleet just by virtue of the configuration of BRT with it being a center running platform.
+
+1279
+02:06:12,097 --> 02:06:23,033
+SPEAKER_16: So when you talk about it being top of the line, that's yet to be seen in reference to what we have before us because there's only two original equipment manufacturers in the United States.
+
+1280
+02:06:23,093 --> 02:06:24,635
+SPEAKER_16: There's only so many suppliers.
+
+1281
+02:06:24,996 --> 02:06:33,548
+SPEAKER_16: There are certain seeds and there is a national task force in which I sit where we're talking about doing away with customization because that increases prices.
+
+1282
+02:06:33,798 --> 02:06:37,842
+SPEAKER_16: I bet you don't know how many shades of white there is with new flier industries.
+
+1283
+02:06:38,142 --> 02:06:38,323
+SPEAKER_16: 24.
+
+1284
+02:06:38,623 --> 02:06:39,684
+SPEAKER_16: How many?
+
+1285
+02:06:39,704 --> 02:06:40,285
+SPEAKER_16: 24.
+
+1286
+02:06:40,305 --> 02:06:41,186
+SPEAKER_16: 23.
+
+1287
+02:06:41,446 --> 02:06:42,927
+SPEAKER_16: I think I told you that earlier.
+
+1288
+02:06:43,008 --> 02:06:53,118
+SPEAKER_16: So the point of the matter is, as we talk about this, right, we're going to do our due diligence and we're going to ensure it's a competitive solicitation.
+
+1289
+02:06:53,158 --> 02:07:00,526
+SPEAKER_16: And we do understand the aspects because that's what separates bus rapid transit from general thick route service.
+
+1290
+02:07:01,427 --> 02:07:01,847
+SPEAKER_16: Thank you.
+
+1291
+02:07:02,485 --> 02:07:04,928
+=START-11=
+Nicholson: Secretary, I really appreciate it.
+
+1292
+02:07:05,008 --> 02:07:09,695
+Nicholson: And I look forward to you coming back often to update us on how the purchase is going.
+
+1293
+02:07:12,098 --> 02:07:12,599
+Whitmore: Yes.
+
+1294
+02:07:12,619 --> 02:07:23,594
+Guzman: Uh, director Griswold, just really quickly, uh, with regards to this, moving this money from the unrestricted fund is simply to begin the procurement process.
+=END-11=
+
+1295
+02:07:24,115 --> 02:07:27,900
+Guzman: And although it's not part of the 2025 budget, we do need to get started on it.
+
+1296
+02:07:28,501 --> 02:07:29,202
+Guzman: Um, however,
+
+1297
+02:07:29,452 --> 02:07:36,600
+Guzman: I would suggest that as we go forward, these buses are meant to be purchased in finality by 2027 to begin this service.
+
+1298
+02:07:37,241 --> 02:07:48,754
+Guzman: And that is work that we will do to fully do on finance and planning to ensure that it is included in all necessary documents that come before this board for approval.
+
+1299
+02:07:49,234 --> 02:07:52,458
+Guzman: And I am certain that our new CFO is up to the task on that.
+
+1300
+02:07:52,578 --> 02:07:58,885
+Guzman: So rest assured, directors, we're not wantonly spending money, but we do need to authorize
+
+1301
+02:07:59,422 --> 02:08:21,987
+SPEAKER_10: this for the procurement of the buses at this point thank you thank you director any further discussion on this item all right there is a note oh no sounds good all right i was it was indicated there will be a no vote so i'll do a roll call vote again this is the budget transfer articulate articulated buses supporting coal fax vrt service uh treasure banker
+
+1302
+02:08:22,473 --> 02:08:23,414
+Benker: Yes.
+
+1303
+02:08:23,435 --> 02:08:24,116
+SPEAKER_10: Dr. Catlin.
+
+1304
+02:08:24,396 --> 02:08:24,616
+Benker: Yes.
+
+1305
+02:08:25,498 --> 02:08:26,219
+SPEAKER_10: Dr. Geisinger.
+
+1306
+02:08:26,419 --> 02:08:26,660
+Benker: Yes.
+
+1307
+02:08:27,140 --> 02:08:27,901
+SPEAKER_10: Dr. Guciniter.
+
+1308
+02:08:28,262 --> 02:08:28,563
+SPEAKER_10: Yes.
+
+1309
+02:08:29,003 --> 02:08:29,604
+SPEAKER_10: Dr. Guzman.
+
+1310
+02:08:30,085 --> 02:08:30,325
+=START-12=
+Nicholson: Yes.
+
+1311
+02:08:30,546 --> 02:08:31,167
+SPEAKER_10: Dr. Harwick.
+
+1312
+02:08:31,227 --> 02:08:31,527
+SPEAKER_10: Yep.
+
+1313
+02:08:31,848 --> 02:08:32,529
+SPEAKER_10: Dr. Larsen.
+
+1314
+02:08:32,689 --> 02:08:32,989
+SPEAKER_10: Yes.
+
+1315
+02:08:33,110 --> 02:08:33,851
+SPEAKER_10: Dr. Nicholson.
+
+1316
+02:08:34,392 --> 02:08:35,594
+Nicholson: Nicholson Gauper.
+
+1317
+02:08:37,356 --> 02:08:37,577
+Nicholson: What?
+
+1318
+02:08:38,077 --> 02:08:38,498
+Nicholson: Sorry.
+
+1319
+02:08:38,518 --> 02:08:39,660
+Nicholson: That was a bad internet wreck.
+
+1320
+02:08:39,680 --> 02:08:39,940
+Nicholson: Yes.
+
+1321
+02:08:41,142 --> 02:08:41,963
+SPEAKER_10: Nicholson is a yes.
+
+1322
+02:08:42,044 --> 02:08:42,945
+SPEAKER_10: Director O'Keefe.
+
+1323
+02:08:45,355 --> 02:08:46,756
+SPEAKER_10: Director Roqueeth is a yes.
+
+1324
+02:08:47,217 --> 02:08:48,078
+SPEAKER_10: Director Pagulari.
+
+1325
+02:08:48,238 --> 02:08:48,478
+SPEAKER_10: No.
+
+1326
+02:08:48,958 --> 02:08:50,039
+SPEAKER_10: Director Pagulari is a no.
+
+1327
+02:08:50,099 --> 02:08:50,780
+SPEAKER_10: Director Arusha.
+
+1328
+02:08:51,000 --> 02:08:51,921
+Paglieri: Yes.
+=END-12=
+
+1329
+02:08:51,941 --> 02:08:52,582
+SPEAKER_10: Director Whitmore.
+
+1330
+02:08:53,663 --> 02:08:53,883
+SPEAKER_10: Yes.
+
+1331
+02:08:54,524 --> 02:08:55,745
+SPEAKER_10: OK.
+
+1332
+02:08:55,765 --> 02:08:58,768
+SPEAKER_10: So that passes 12, 1, and 2.
+
+1333
+02:08:59,668 --> 02:08:59,969
+SPEAKER_10: All right.
+
+1334
+02:09:00,009 --> 02:09:00,669
+SPEAKER_10: Thank you, folks.
+
+1335
+02:09:00,709 --> 02:09:01,750
+SPEAKER_10: So we have one.
+
+1336
+02:09:02,171 --> 02:09:03,472
+Larsen: Chair Buke, could you remind us?
+
+1337
+02:09:03,772 --> 02:09:08,577
+Larsen: Over here, we missed who the mover and the seconder were on that.
+
+1338
+02:09:08,957 --> 02:09:09,938
+Larsen: I had Guzman and Whitmore.
+
+1339
+02:09:10,278 --> 02:09:10,459
+Larsen: OK.
+
+1340
+02:09:10,539 --> 02:09:10,839
+Larsen: Thank you.
+
+1341
+02:09:11,540 --> 02:09:11,920
+SPEAKER_10: Thank you.
+
+1342
+02:09:12,743 --> 02:09:13,624
+SPEAKER_10: Um, okay.
+
+1343
+02:09:13,644 --> 02:09:13,985
+SPEAKER_10: Excellent.
+
+1344
+02:09:14,265 --> 02:09:15,787
+SPEAKER_10: Uh, thank you all again for your patience.
+
+1345
+02:09:15,807 --> 02:09:21,734
+SPEAKER_10: We do have one more item and that is the equitable transit oriented development policy amendment.
+
+1346
+02:09:23,096 --> 02:09:38,194
+SPEAKER_10: So for the board of directors to approve the amendment to resolution number two series of 2021, which created the equal transit oriented development policy that permits and encourages the development of affordable housing on RTD real property in order to include guidelines for disposing
+
+1347
+02:09:38,461 --> 02:09:42,527
+SPEAKER_10: of RTD real property, below fair market value or rent.
+
+1348
+02:09:42,887 --> 02:09:43,548
+SPEAKER_10: Do we have a motion?
+
+1349
+02:09:43,749 --> 02:09:44,490
+SPEAKER_10: So moved, Guzman.
+
+1350
+02:09:44,690 --> 02:09:45,471
+SPEAKER_10: Guzman's the mover.
+
+1351
+02:09:45,491 --> 02:09:46,092
+SPEAKER_10: Do we have a second?
+
+1352
+02:09:46,613 --> 02:09:47,755
+SPEAKER_10: I have Harwick as a second.
+
+1353
+02:09:49,697 --> 02:09:54,985
+SPEAKER_10: I do understand that on this item, we have some proposed amendments from Director Nicholson and Director Ruscha.
+
+1354
+02:09:55,926 --> 02:09:59,772
+SPEAKER_10: Since Director Nicholson's amendment was circulated to the board first, we will start there.
+
+1355
+02:10:00,393 --> 02:10:03,237
+=START-13=
+SPEAKER_10: Director Nicholson, please now make your motion to amend.
+
+1356
+02:10:03,824 --> 02:10:17,993
+Nicholson: Yes, I'd like to move to amend the etod policy and I'm hoping that GMC GMC that Mr. Crawl can put up those that language on the screen.
+
+1357
+02:10:18,954 --> 02:10:19,395
+Nicholson: It's there.
+
+1358
+02:10:20,037 --> 02:10:20,217
+SPEAKER_10: Right.
+
+1359
+02:10:21,920 --> 02:10:22,221
+Nicholson: May I.
+
+1360
+02:10:23,618 --> 02:10:26,363
+SPEAKER_10: Uh, would you like to read the motion and then we'll get a second.
+
+1361
+02:10:26,524 --> 02:10:26,884
+Nicholson: Thank you.
+
+1362
+02:10:26,924 --> 02:10:27,445
+Nicholson: Yeah.
+
+1363
+02:10:27,466 --> 02:10:41,593
+Nicholson: So, uh, move to amend the policy, uh, such that section five of the equitable transit oriented development policy regarding negotiated land price be updated as follows to raise the maximum negotiated land price discount to 75% from 50%.
+
+1364
+02:10:41,573 --> 02:10:59,970
+Nicholson: and add the following additional factors to favorably consider projects which include more accessible units than required by law, limit residential parking, are deeply affordable, emphasize priority groups as identified by the Colorado Housing and Finance Authority,
+
+1365
+02:11:00,085 --> 02:11:10,429
+Nicholson: and incorporate smaller footprint retail, including below market rate units, below market rate retail, excuse me, that prioritizes local businesses and entrepreneurs.
+
+1366
+02:11:13,236 --> 02:11:15,461
+SPEAKER_10: Excellent.
+
+1367
+02:11:15,481 --> 02:11:16,403
+SPEAKER_10: And do we have a second on that?
+
+1368
+02:11:16,985 --> 02:11:17,606
+Nicholson: Second.
+
+1369
+02:11:17,626 --> 02:11:18,448
+SPEAKER_10: Hardwick is the second.
+
+1370
+02:11:20,521 --> 02:11:22,165
+Nicholson: Secretary, would you like to discuss further?
+
+1371
+02:11:22,425 --> 02:11:22,786
+Nicholson: Thank you.
+
+1372
+02:11:22,806 --> 02:11:23,027
+Nicholson: Yes.
+
+1373
+02:11:23,367 --> 02:11:35,695
+Nicholson: Before I get into my remarks, I'd like to ask Executive Manager Kroll to briefly describe the five pieces of written public comment that we received on this recommended action from some of our local public officials.
+
+1374
+02:11:36,232 --> 02:11:44,392
+Larsen: Yes, so four of the written public common items were submitted by individuals specifically supportive of the change director Nicholson is offering.
+
+1375
+02:11:44,412 --> 02:11:54,055
+Larsen: And those four individuals were the mayor of Boulder, a city council member from Boulder, a city council member from Westminster and the Colorado Cross Disability Coalition.
+
+1376
+02:11:54,035 --> 02:12:08,098
+Larsen: And then the fifth letter was submitted by SWEAP in joint with Conservation Colorado and Denver Streets Partnership, which spoke more broadly to the overall changes being offered this evening.
+
+1377
+02:12:10,943 --> 02:12:11,564
+Larsen: Perfect, Secretary.
+
+1378
+02:12:12,045 --> 02:12:13,347
+Nicholson: Thank you.
+
+1379
+02:12:13,367 --> 02:12:15,891
+Nicholson: And thank you, Executive Manager Crawl.
+
+1380
+02:12:16,630 --> 02:12:19,394
+Nicholson: So here at RTD, we make lives better through connections.
+
+1381
+02:12:19,755 --> 02:12:23,381
+Nicholson: Tonight as a board, we have an opportunity to do that in a particularly powerful way.
+
+1382
+02:12:24,242 --> 02:12:26,125
+Nicholson: Our rider surveys tell a clear story.
+
+1383
+02:12:26,666 --> 02:12:33,277
+Nicholson: Over half our passengers live below 200% of the federal poverty level, and they are far less likely to own a car.
+
+1384
+02:12:34,018 --> 02:12:40,849
+Nicholson: Our riders with disabilities use RTD at disproportionately high rates, as do other vulnerable populations in our community.
+
+1385
+02:12:40,829 --> 02:12:47,738
+Nicholson: Yet only a fraction of affordable housing developed near our stations truly meets the needs of our most dedicated riders.
+
+1386
+02:12:48,419 --> 02:12:52,405
+Nicholson: Communities in our state have struggled to create housing targeted at our ridership.
+
+1387
+02:12:52,785 --> 02:12:59,134
+Nicholson: Inclusionary zoning has mostly led to housing at 60% AMI, about $51,000 a year in earnings.
+
+1388
+02:12:59,694 --> 02:13:08,406
+Nicholson: This housing is necessary but priced well out of reach for someone making only $31,000, which is 200% of the federal poverty line.
+
+1389
+02:13:08,386 --> 02:13:17,766
+Nicholson: This amendment empowers RTD to deepen our land discount offerings, up to 75%, to incentivize projects specifically tailored to the actual economic realities of our riders.
+
+1390
+02:13:18,428 --> 02:13:20,151
+Nicholson: Here's how that can work in practice.
+
+1391
+02:13:20,171 --> 02:13:27,407
+Nicholson: Just this month, Denver Health donated the land to create Tapestry, a deeply affordable, accessible, transit-oriented housing project.
+
+1392
+02:13:27,775 --> 02:13:36,789
+Nicholson: It supports a range of affordability from 30% to 80%, as well as far more three-bedroom and even four-bedroom units than most affordable projects being built today.
+
+1393
+02:13:37,590 --> 02:13:44,842
+Nicholson: It targets accessibility because distance to transit is a major barrier for people with disabilities to use transit.
+
+1394
+02:13:44,862 --> 02:13:52,213
+Nicholson: This holds for all types of disabilities and unfortunately, painfully few Class A fully accessible units exist
+
+1395
+02:13:52,193 --> 02:13:53,715
+Nicholson: in the RTD service area.
+
+1396
+02:13:54,255 --> 02:13:58,579
+Nicholson: By creating greater incentives for developers, we can do a lot to play our part in fixing that.
+
+1397
+02:13:59,340 --> 02:14:05,767
+Nicholson: It's late, so I won't go through the argument for reduced parking and the service of CHFA's priority populations.
+
+1398
+02:14:06,047 --> 02:14:07,649
+Nicholson: You all have an email from me with that data.
+
+1399
+02:14:08,169 --> 02:14:14,616
+Nicholson: But I do want Director Harwick to speak after me to address the language he added on smaller footprint and below market retail.
+
+1400
+02:14:15,437 --> 02:14:21,863
+Nicholson: Community is about more than housing, and I enthusiastically added his language for the reasons he'll highlight.
+
+1401
+02:14:22,113 --> 02:14:26,820
+Nicholson: This framework recognizes that we are not the housing policy experts.
+
+1402
+02:14:27,341 --> 02:14:46,290
+Nicholson: It increases the scope of our tools and trusts our staff to use them effectively to bring us thoughtful projects, projects that align with our strategic priority of community value and enable us to grow ridership by putting the people who most need transit where they can best be served by it.
+
+1403
+02:14:46,831 --> 02:14:48,233
+Nicholson: I ask your support for this amendment.
+
+1404
+02:14:48,754 --> 02:14:48,954
+Larsen: Thank you.
+
+1405
+02:14:49,856 --> 02:14:50,196
+Nicholson: Dr. Harbert.
+
+1406
+02:14:51,661 --> 02:15:08,050
+Harwick: Yeah, so I wanted to make sure that when we're talking about TOD that we're really thinking also about mixed use TOD and I'm wildly in favor of Anything that we can do to bring more housing let alone affordable housing to
+
+1407
+02:15:08,030 --> 02:15:09,191
+Harwick: to our park and rides.
+
+1408
+02:15:09,211 --> 02:15:20,846
+Harwick: I do think it's really key that we also think about what are the businesses that we are bringing in there and, you know, having spent a lot of time working at Starbucks and a good friend of mine works at Starbucks.
+
+1409
+02:15:20,866 --> 02:15:29,717
+Harwick: You know, I'm also really in favor of coffee shops like Prodigy and smaller shops, but also thinking about when I've traveled to other
+=END-13=
+
+1410
+02:15:29,697 --> 02:15:52,144
+Harwick: Communities throughout the world there oftentimes are smaller retail shops that give Young entrepreneurs that opportunity to start a business and not be burdened by a larger footprint that Some of our larger restaurants or larger retail shops can they can cover those those costs so you know this this to me was a way to encourage local businesses to
+
+1411
+02:15:52,124 --> 02:16:07,852
+Harwick: start up or expand and, you know, give them the opportunity in a place that we all, you know, we all, when we go to a parking ride and there's not something there to grab that quick bite to eat, I want to give them that opportunity, everyone that opportunity, one to shop there and sell there.
+
+1412
+02:16:09,415 --> 02:16:12,260
+SPEAKER_10: Director Harwick, any further discussion on this amendment?
+
+1413
+02:16:13,362 --> 02:16:13,963
+SPEAKER_10: Director Usha.
+
+1414
+02:16:14,230 --> 02:16:16,513
+Paglieri: Uh, Mr. Chair, maybe you can help me here.
+
+1415
+02:16:16,613 --> 02:16:21,940
+Paglieri: So I had a comment slash, but I had a comment on the main motion, but we moved to amendments.
+
+1416
+02:16:22,361 --> 02:16:28,269
+Paglieri: But like recognizing that Secretary Nicholson's language can't exist without the motion language of the way it's drafted.
+
+1417
+02:16:28,489 --> 02:16:30,432
+Paglieri: May I just make a general comment?
+
+1418
+02:16:30,452 --> 02:16:31,373
+Paglieri: Does that sort of make sense?
+
+1419
+02:16:31,533 --> 02:16:36,560
+Paglieri: It would apply to both, but I don't know if I would be called out of order and I'm tired of what you say.
+
+1420
+02:16:36,600 --> 02:16:37,201
+SPEAKER_10: So you know what?
+
+1421
+02:16:37,221 --> 02:16:37,641
+SPEAKER_10: Why not?
+
+1422
+02:16:37,721 --> 02:16:38,783
+SPEAKER_10: Let's give it a try.
+
+1423
+02:16:38,863 --> 02:16:39,664
+Paglieri: Thanks.
+
+1424
+02:16:39,644 --> 02:16:40,305
+Paglieri: I'm doing my best.
+
+1425
+02:16:40,826 --> 02:16:52,644
+Paglieri: Okay, so this morning we got an email from staff that addressed some outstanding questions that I still had, just so I knew what I was voting on.
+
+1426
+02:16:53,205 --> 02:17:06,225
+Paglieri: And I have a heartburn over just the main motion because the way it's written, we as a board,
+
+1427
+02:17:06,475 --> 02:17:20,030
+Paglieri: are not just expanding the bounds of what a policy is, we're also signing away like 30 plus years of precedent of having this guardrail that says, before you go dispense of real property, get our preliminary authorization.
+
+1428
+02:17:20,651 --> 02:17:28,600
+Paglieri: So I guess like I've, so I am already a little bit uncomfortable.
+
+1429
+02:17:29,000 --> 02:17:31,723
+Paglieri: And also the policy says that if
+
+1430
+02:17:32,092 --> 02:17:38,579
+Paglieri: A developer, as it relates to housing, cannot meet our 50% standard.
+
+1431
+02:17:39,039 --> 02:17:44,105
+Paglieri: They could still get a major discount, and it could be millions and millions of dollars.
+
+1432
+02:17:44,645 --> 02:17:51,312
+Paglieri: And so those two combined, and just recognizing that these deals take a long, long time, they're not suburb projects.
+
+1433
+02:17:52,794 --> 02:18:01,643
+Paglieri: In sum, it means that all of that is going to happen, and then it's going to come back to the board when all of those decisions have been made.
+
+1434
+02:18:01,859 --> 02:18:21,235
+Paglieri: and that and so it's for that because I'm struggling with the original proposal but I can accept it for now is why I can't vote yes on Secretary Nicholson's amendment because it doesn't because we don't have guardrails that I would prefer so I
+
+1435
+02:18:21,603 --> 02:18:25,688
+Paglieri: I hope that was not out of order and if it was, thanks for not calling me out of order.
+
+1436
+02:18:25,708 --> 02:18:26,069
+Guissinger: Thank you.
+
+1437
+02:18:26,409 --> 02:18:27,130
+Guzman: Are you director chef?
+
+1438
+02:18:27,471 --> 02:18:28,032
+Guzman: Director Guzmore.
+
+1439
+02:18:28,873 --> 02:18:35,642
+Guzman: So, ETOD has been discussed a number of times in the committee and this is my concern.
+
+1440
+02:18:38,446 --> 02:18:44,033
+Guzman: Although I am with you in spirit, deeply affordable housing is really important.
+
+1441
+02:18:44,519 --> 02:18:53,892
+Guzman: I'm not sure that giving an additional 25% discount in our policy is wise for a number of reasons.
+
+1442
+02:18:54,233 --> 02:18:58,679
+Guzman: I do believe, however, and maybe Madam CEO or Ms.
+
+1443
+02:18:58,719 --> 02:19:01,403
+Guzman: Chessie Brady might be able to speak to this, I'm not sure.
+
+1444
+02:19:03,206 --> 02:19:10,476
+Guzman: What we were asked for in this policy was to give guidelines to begin negotiation that would eventually come back to this board.
+
+1445
+02:19:11,688 --> 02:19:23,853
+Guzman: Let's say a developer comes to us and just brings us an amazing proposal that includes everything that you could want in a development and more.
+
+1446
+02:19:23,873 --> 02:19:29,605
+Guzman: I don't see why they wouldn't necessarily come back to us and say, hey, they're willing to do all of these things.
+
+1447
+02:19:29,985 --> 02:19:30,827
+Guzman: They being staff.
+
+1448
+02:19:31,145 --> 02:19:45,639
+Guzman: and asking for an additional amount of up to whatever amount makes sense to give that discount from the board that we would consider properly and then be able to authorize in that moment.
+
+1449
+02:19:46,379 --> 02:19:52,866
+Guzman: But in order to begin the process, we were simply asked to give authorization for them to work within a parameter.
+
+1450
+02:19:52,926 --> 02:19:59,272
+Guzman: That way there was no confusion that they would be able to do a 30 to 50% discount as was written in the original policy.
+
+1451
+02:19:59,772 --> 02:20:00,713
+Guzman: Beyond that,
+
+1452
+02:20:01,385 --> 02:20:08,376
+Guzman: the board would still have authority, as I understand it, if we were asked to offer an additional discount for more.
+
+1453
+02:20:09,037 --> 02:20:26,785
+Guzman: I don't know that we need to lock that into policy, and it does the one thing that I was trained by former directors and members that are currently here not to do, which is bind future boards in a way that creates difficulty for us to do our job as the fiduciaries of the agency.
+
+1454
+02:20:26,945 --> 02:20:28,928
+Guzman: And so I would like to ask that question
+
+1455
+02:20:29,431 --> 02:20:42,383
+Guzman: Is there anything that would prevent you from coming back to us if we were to receive such an excellent proposal that prevents you from saying, can we receive an additional discount to offer a developer board?
+
+1456
+02:20:43,125 --> 02:20:45,330
+Guzman: And would you approve this so we can make a project work?
+
+1457
+02:20:47,116 --> 02:20:47,296
+SPEAKER_10: Ms.
+
+1458
+02:20:47,316 --> 02:20:49,059
+SPEAKER_10: Brady, first off, thank you for your patience.
+
+1459
+02:20:49,079 --> 02:20:51,122
+SPEAKER_10: I greatly appreciate you sticking around tonight.
+
+1460
+02:20:51,162 --> 02:20:51,602
+Brady: Of course.
+
+1461
+02:20:51,923 --> 02:20:53,204
+SPEAKER_10: You're recognized.
+
+1462
+02:20:53,525 --> 02:20:53,865
+Brady: Thank you.
+
+1463
+02:20:54,526 --> 02:20:57,450
+Brady: No, there is nothing that would stop us from doing that.
+
+1464
+02:20:57,931 --> 02:21:03,639
+Brady: As you say, the point of the policy is to create guardrails and certainty within those guardrails.
+
+1465
+02:21:04,380 --> 02:21:13,652
+Brady: We would use the opinions of the board to guide developers towards what we think the board would be interested in as we're negotiating with them.
+
+1466
+02:21:13,753 --> 02:21:14,794
+Brady: And we would come back to the board
+
+1467
+02:21:15,112 --> 02:21:17,235
+Brady: for approval of any given project.
+
+1468
+02:21:18,056 --> 02:21:18,417
+Guzman: Thank you.
+
+1469
+02:21:19,218 --> 02:21:31,356
+Guzman: One more quick thing and Director Banker, Treasurer Banker, the sales and the lease income from our real estate properties are put into a specific account.
+
+1470
+02:21:31,456 --> 02:21:32,398
+Guzman: Can you guess which one?
+
+1471
+02:21:33,139 --> 02:21:44,916
+Guzman: Because when we deeply discount things beyond where we should, we are saying no to the potential income that we could use for operations and maintenance and service provision
+
+1472
+02:21:45,554 --> 02:21:46,636
+Guzman: elsewhere in the agency.
+
+1473
+02:21:47,296 --> 02:21:54,907
+Guzman: So on balance, real estate and real property are a finite resource, and dollars can be stretched thin.
+
+1474
+02:21:55,668 --> 02:22:06,324
+Guzman: But how we use the opportunity to either receive money to prolong and serve the public further is a huge consideration in this.
+
+1475
+02:22:06,564 --> 02:22:11,191
+Guzman: So although I am with you in spirit, I would be voting no on the amendment as it is right now.
+
+1476
+02:22:11,872 --> 02:22:12,492
+Guzman: Thank you, Director.
+
+1477
+02:22:13,434 --> 02:22:14,295
+SPEAKER_03: Director Pagulieri.
+
+1478
+02:22:14,630 --> 02:22:16,292
+SPEAKER_03: Thank you, I'll be brief.
+
+1479
+02:22:16,712 --> 02:22:21,438
+SPEAKER_03: I really like the language that highlights these things that I deeply agree with.
+
+1480
+02:22:22,219 --> 02:22:23,801
+SPEAKER_03: I am a little bit concerned about two things.
+
+1481
+02:22:23,841 --> 02:22:26,544
+SPEAKER_03: The first is the language deeply affordable.
+
+1482
+02:22:26,564 --> 02:22:31,309
+SPEAKER_03: It's a little bit ambiguous, if I'm saying that right.
+
+1483
+02:22:32,291 --> 02:22:42,983
+SPEAKER_03: And I think using language like that can, like, what's to say, they discounted $100 to some, that's a deep discount to others, that's nothing.
+
+1484
+02:22:42,963 --> 02:22:50,914
+SPEAKER_03: So I'd recommend removing that word and just maybe also deeply affordable unless you can divine it elsewhere.
+
+1485
+02:22:51,435 --> 02:22:53,638
+SPEAKER_03: But I do want to leave this language.
+
+1486
+02:22:53,658 --> 02:23:01,950
+SPEAKER_03: And the other thing is I just have a hard time giving a 75% discount even with these things that I want.
+
+1487
+02:23:01,930 --> 02:23:18,726
+SPEAKER_03: And perhaps that this is a really limited circumstance that we'd give 75%, but this is our property and I really would like to see it sold for the highest value to benefit all.
+
+1488
+02:23:18,947 --> 02:23:19,287
+SPEAKER_03: Thank you.
+
+1489
+02:23:19,788 --> 02:23:21,913
+SPEAKER_03: Thank you, Director.
+
+1490
+02:23:22,889 --> 02:23:25,332
+Benker: Just a quick question.
+
+1491
+02:23:25,892 --> 02:23:33,261
+Benker: Some of these surplus properties that we're talking about, we are not including our current park and rides, correct?
+
+1492
+02:23:34,282 --> 02:23:40,489
+Benker: Would be excess land, perhaps around a park and ride, but not one of our park and rides.
+
+1493
+02:23:42,011 --> 02:23:42,992
+Benker: Just clarification.
+
+1494
+02:23:43,733 --> 02:23:44,214
+Brady: Thank you.
+
+1495
+02:23:44,234 --> 02:23:48,158
+Brady: So this policy is aimed at transoriented development.
+
+1496
+02:23:48,619 --> 02:23:50,601
+Brady: So property that RTD owns
+
+1497
+02:23:50,800 --> 02:23:53,784
+Brady: at transit stations or near high frequency transit.
+
+1498
+02:23:54,404 --> 02:24:07,240
+Brady: Access property and surplus property are definable terms that perhaps Michelle could help us with, but those are distinctive properties that the board has named to be excess and surplus.
+
+1499
+02:24:07,661 --> 02:24:10,384
+Brady: And so I just want to separate that from a park and ride.
+
+1500
+02:24:10,424 --> 02:24:12,407
+Brady: A park and ride is certainly not excess or surplus.
+
+1501
+02:24:13,268 --> 02:24:15,531
+Brady: It may have underutilized land.
+
+1502
+02:24:15,691 --> 02:24:19,896
+Brady: It may have a large drainage area that is part of the park and ride.
+
+1503
+02:24:20,551 --> 02:24:29,414
+Brady: But not every development that we would consider on a park and ride would remove parking if that's getting more to your question.
+
+1504
+02:24:30,216 --> 02:24:30,938
+Brady: Okay, yes.
+
+1505
+02:24:33,425 --> 02:24:34,307
+=START-14=
+SPEAKER_10: Secretary Nicholson.
+
+1506
+02:24:35,435 --> 02:24:38,138
+Nicholson: I actually have some questions for Ms.
+
+1507
+02:24:38,659 --> 02:24:38,979
+Nicholson: Brady.
+
+1508
+02:24:39,620 --> 02:24:44,386
+Nicholson: So first off, Director Pagliari raised the concern about the term deep affordability.
+
+1509
+02:24:45,006 --> 02:24:49,612
+Nicholson: I think you and I know what that means, but maybe the rest of the board doesn't, given it's a term of art.
+
+1510
+02:24:49,672 --> 02:24:53,356
+Nicholson: Can you elaborate on what that's referring to?
+
+1511
+02:24:54,097 --> 02:24:54,258
+Nicholson: Ms.
+
+1512
+02:24:54,298 --> 02:24:54,538
+Nicholson: Brady.
+
+1513
+02:24:54,978 --> 02:24:55,279
+Brady: Sure.
+
+1514
+02:24:55,339 --> 02:24:55,519
+Brady: Yes.
+
+1515
+02:24:55,819 --> 02:25:03,889
+Brady: Deep affordability is a term in the affordable housing network that means generally 30 to 40% of AMI.
+
+1516
+02:25:04,308 --> 02:25:09,427
+Brady: It is squishy, I think still, but generally it's understood to mean 30 to 40%.
+
+1517
+02:25:09,487 --> 02:25:11,635
+Nicholson: Secretary.
+
+1518
+02:25:12,070 --> 02:25:19,360
+Nicholson: So second question, I've heard a couple of concerns about 75% as a discount.
+
+1519
+02:25:21,042 --> 02:25:34,541
+Nicholson: I was hoping maybe you could speak to like, because I mentioned it a little bit, but as someone who's an expert in the space, and I will say you and I worked pretty closely together on this language and went back and forth, you did a meeting with me.
+
+1520
+02:25:34,621 --> 02:25:37,024
+Nicholson: So this isn't just something that I wrote myself.
+
+1521
+02:25:37,104 --> 02:25:41,470
+Nicholson: This is something that got vetted pretty heavily by staff.
+
+1522
+02:25:42,395 --> 02:25:58,017
+Nicholson: What impact does a greater discount have on the types of projects that in the affordable housing space you tend to see people able to build?
+
+1523
+02:25:58,077 --> 02:26:02,243
+Nicholson: At least from where I sit, the reason for doing this is that
+
+1524
+02:26:02,223 --> 02:26:11,859
+Nicholson: When it comes to those deeply affordable, which are deeply subsidized units, when it comes to things like units that are fully accessible, those are expensive.
+
+1525
+02:26:12,120 --> 02:26:18,551
+Nicholson: They cost developers money, which is why when you don't have those subsidies, those units don't get built.
+
+1526
+02:26:18,611 --> 02:26:22,257
+Nicholson: I think it's about half the projects that are in the CHFA database.
+
+1527
+02:26:22,237 --> 02:26:30,490
+Nicholson: have zero units at 30% AMI and very few of them have anything with regard to accessibility.
+
+1528
+02:26:30,510 --> 02:26:36,559
+Nicholson: So I'm hoping you can maybe elaborate on, you know, you're the one who would be using this tool at the end of the day.
+
+1529
+02:26:36,599 --> 02:26:41,246
+Nicholson: How do you see it coming in handy with regard to what you're able to do?
+
+1530
+02:26:41,867 --> 02:26:43,330
+Nicholson: And then I've won the last follow up.
+
+1531
+02:26:45,152 --> 02:26:45,493
+SPEAKER_09: It's pretty.
+
+1532
+02:26:49,159 --> 02:26:49,459
+Nicholson: You're not.
+
+1533
+02:26:53,185 --> 02:27:00,073
+Brady: Thank you.
+
+1534
+02:27:00,793 --> 02:27:04,778
+Brady: So affordable housing projects aren't notoriously difficult to finance.
+
+1535
+02:27:05,479 --> 02:27:16,130
+Brady: And I mean, I think if you use the example earlier of tapestry and Denver health, Denver health, as you stated is correct donated the land for tapestry.
+
+1536
+02:27:16,170 --> 02:27:20,235
+Brady: I can assure you that that development was still very difficult to finance.
+
+1537
+02:27:21,076 --> 02:27:21,336
+Brady: So
+=END-14=
+
+1538
+02:27:21,569 --> 02:27:31,042
+Brady: even if the land we were giving the land at 100% discount, the projects would still not pencil in many cases.
+
+1539
+02:27:31,563 --> 02:27:49,888
+Brady: And so our ability to discount the land to 75% as the board prefers just in many cases could get us over the hump from a project not being built to a project being built and to that project having more affordable units as opposed to
+
+1540
+02:27:50,105 --> 02:27:53,649
+Brady: a higher, more of a middle income range.
+
+1541
+02:27:54,309 --> 02:27:56,752
+Brady: And that's the difference that the land discount makes.
+
+1542
+02:27:57,112 --> 02:28:07,704
+Brady: And that's the certainty that this policy helps me bring to conversations with developers is, gets them in the mindset of we're going to get some help here from RTD.
+
+1543
+02:28:08,484 --> 02:28:11,107
+Brady: We can focus on deeper affordability units.
+
+1544
+02:28:11,127 --> 02:28:18,475
+Brady: We can make bigger promises to Chaffa or other financing entities to host in Denver.
+
+1545
+02:28:18,877 --> 02:28:20,839
+Brady: It helps us keep the projects moving.
+
+1546
+02:28:21,420 --> 02:28:29,047
+Brady: Um, but, and I'd be frank with you, this is, as I said, tapestry, even with a hundred percent discount, it's still hard to do.
+
+1547
+02:28:29,227 --> 02:28:30,569
+Brady: This is not a silver bullet.
+
+1548
+02:28:31,169 --> 02:28:37,135
+Brady: Um, but it, it moves the needle and it helps us actually, you know, keep projects afloat and get to the finish line.
+
+1549
+02:28:37,555 --> 02:28:37,996
+SPEAKER_10: Thank you, Ms.
+
+1550
+02:28:38,016 --> 02:28:38,356
+SPEAKER_10: Brady.
+
+1551
+02:28:38,597 --> 02:28:41,960
+SPEAKER_10: We're going to wrap up with director O'Keith and then director Larson.
+
+1552
+02:28:42,460 --> 02:28:44,142
+=START-15=
+Nicholson: Oh, I thought I got last word.
+
+1553
+02:28:44,847 --> 02:28:47,854
+Nicholson: So, I support this amendment.
+
+1554
+02:28:47,994 --> 02:28:59,161
+Nicholson: I think it is a reasonable step toward developing communities that are very likely to use our services.
+
+1555
+02:28:59,301 --> 02:29:03,531
+Nicholson: And I think increasing ridership is something
+
+1556
+02:29:03,511 --> 02:29:04,613
+Nicholson: we all agree on.
+
+1557
+02:29:04,653 --> 02:29:06,916
+Nicholson: This is a concrete way to do that.
+
+1558
+02:29:08,018 --> 02:29:18,052
+Nicholson: It also takes land not just for our benefit in ridership, but also puts improvements on it that helps the tax base.
+
+1559
+02:29:18,473 --> 02:29:32,353
+Nicholson: And I think the communities that we serve would rather see a housing project end up on that property where it becomes improved.
+
+1560
+02:29:32,333 --> 02:29:33,815
+Nicholson: versus somewhere else.
+
+1561
+02:29:33,835 --> 02:29:35,136
+Nicholson: We're not the only game in town.
+
+1562
+02:29:35,176 --> 02:29:36,778
+Nicholson: There's a lot of discounts out there.
+
+1563
+02:29:37,518 --> 02:29:43,505
+Nicholson: And so we're not necessarily in a tight buyers market.
+
+1564
+02:29:43,645 --> 02:29:45,907
+Nicholson: There's a lot of projects that can go forward.
+
+1565
+02:29:46,588 --> 02:29:54,797
+Nicholson: And I think we need to put our best deal, at least give Chessie and the rest of the team the tools to bring the deal forward.
+
+1566
+02:29:55,758 --> 02:29:57,279
+Nicholson: I do want to put one plug in.
+
+1567
+02:29:57,319 --> 02:29:58,180
+Nicholson: We talked about it.
+
+1568
+02:29:58,481 --> 02:30:00,703
+Nicholson: I don't think round leases
+
+1569
+02:30:00,683 --> 02:30:03,386
+Nicholson: are the best tool in Colorado.
+
+1570
+02:30:03,426 --> 02:30:06,791
+Nicholson: First of all, it's not as common as other places in the world.
+
+1571
+02:30:07,431 --> 02:30:15,642
+Nicholson: And the other thing is toward the end of your ground lease, no matter how long you make it, the property will fall into disrepair.
+
+1572
+02:30:15,942 --> 02:30:21,409
+Nicholson: They are not going to put money into physical facilities that are going to roll off their books.
+
+1573
+02:30:21,389 --> 02:30:29,080
+Nicholson: So, for that reason, I like the discount is great and I love a sale versus a ground lease.
+
+1574
+02:30:29,100 --> 02:30:31,383
+Nicholson: And I know you'll keep that in mind as we go forward.
+
+1575
+02:30:32,084 --> 02:30:39,876
+Nicholson: And anyway, that's another argument in favor of that tactic.
+
+1576
+02:30:39,896 --> 02:30:40,456
+Larsen: Director Bill Arson.
+
+1577
+02:30:42,399 --> 02:30:42,860
+Larsen: Thank you.
+
+1578
+02:30:43,100 --> 02:30:46,485
+Larsen: I'm going to be a no vote on this.
+
+1579
+02:30:46,938 --> 02:30:50,763
+Larsen: I don't agree with our transit oriented development policy as it is right now.
+
+1580
+02:30:50,983 --> 02:30:57,752
+Larsen: I don't agree with the goal of trying to provide affordable housing or encourage it, incentivize it.
+
+1581
+02:30:58,132 --> 02:31:02,198
+Larsen: I think we should be focused on trying to increase ridership.
+
+1582
+02:31:02,218 --> 02:31:11,950
+Larsen: If we want to provide discounts on our land, we should provide them with the goal in mind of increasing the number of people that can live
+
+1583
+02:31:12,335 --> 02:31:17,220
+Larsen: on the property, whatever is developed, and the amount of traffic that is on the property.
+=END-15=
+
+1584
+02:31:18,381 --> 02:31:20,823
+Larsen: So I'm a no on this.
+
+1585
+02:31:21,504 --> 02:31:22,404
+Larsen: Thank you, Director Larson.
+
+1586
+02:31:22,545 --> 02:31:22,845
+SPEAKER_10: All right.
+
+1587
+02:31:23,265 --> 02:31:25,247
+SPEAKER_10: The indication there is a no vote.
+
+1588
+02:31:25,587 --> 02:31:27,109
+SPEAKER_10: I am going to do a roll call vote.
+
+1589
+02:31:27,189 --> 02:31:30,332
+SPEAKER_10: As a reminder, we are voting on Director Nicholson's amendment.
+
+1590
+02:31:30,832 --> 02:31:33,755
+SPEAKER_10: He was the mover and Director Harwick is the second.
+
+1591
+02:31:34,536 --> 02:31:35,256
+SPEAKER_10: Treasure banker.
+
+1592
+02:31:38,620 --> 02:31:38,800
+SPEAKER_10: Yes.
+
+1593
+02:31:38,820 --> 02:31:39,440
+SPEAKER_10: Director Catlin.
+
+1594
+02:31:40,922 --> 02:31:41,262
+Catlin: Yes.
+
+1595
+02:31:42,068 --> 02:31:42,869
+SPEAKER_10: Director Keisinger?
+
+1596
+02:31:43,189 --> 02:31:43,750
+Catlin: Yes.
+
+1597
+02:31:43,770 --> 02:31:44,571
+SPEAKER_10: Director Gucinander?
+
+1598
+02:31:45,092 --> 02:31:45,612
+Catlin: Yes.
+
+1599
+02:31:45,632 --> 02:31:46,313
+SPEAKER_10: Director Guzman?
+
+1600
+02:31:46,594 --> 02:31:47,735
+Guzman: No.
+
+1601
+02:31:47,755 --> 02:31:48,396
+SPEAKER_10: Director Harwick?
+
+1602
+02:31:48,556 --> 02:31:48,796
+SPEAKER_10: Yes.
+
+1603
+02:31:49,717 --> 02:31:50,458
+SPEAKER_10: Director Larsen?
+
+1604
+02:31:51,419 --> 02:31:51,620
+SPEAKER_10: No.
+
+1605
+02:31:52,721 --> 02:31:53,922
+SPEAKER_10: Secretary Nicholson?
+
+1606
+02:31:53,942 --> 02:31:54,183
+SPEAKER_10: Yes.
+
+1607
+02:31:55,064 --> 02:31:55,905
+SPEAKER_10: First Vice-Chair O'Keefe?
+
+1608
+02:31:56,706 --> 02:31:56,926
+=START-16=
+Nicholson: Yes.
+
+1609
+02:31:57,487 --> 02:31:58,268
+SPEAKER_10: Director Pagulari?
+
+1610
+02:31:58,748 --> 02:31:59,009
+SPEAKER_10: Yes.
+
+1611
+02:31:59,569 --> 02:32:00,210
+SPEAKER_10: Director Ruscha?
+
+1612
+02:32:02,873 --> 02:32:03,454
+Paglieri: Sorry, no.
+=END-16=
+
+1613
+02:32:04,375 --> 02:32:05,797
+SPEAKER_10: And finally, Second Vice-Chair Whitmore?
+
+1614
+02:32:06,358 --> 02:32:06,658
+SPEAKER_10: Yes.
+
+1615
+02:32:07,465 --> 02:32:18,662
+SPEAKER_10: Okay, and I am a yes, that amendment will pass 10, two, excuse me, 10, three and two.
+
+1616
+02:32:20,845 --> 02:32:25,652
+SPEAKER_10: Yes, 10, yes, three, no, two absent, that is the math.
+
+1617
+02:32:26,253 --> 02:32:32,663
+SPEAKER_10: Okay, moving on, we are gonna do our second amendment, which was brought forward by Director Ruscha.
+
+1618
+02:32:34,128 --> 02:32:37,552
+SPEAKER_10: And Director Ruscha, would you like to introduce the language of the amendment?
+
+1619
+02:32:39,454 --> 02:32:42,358
+Paglieri: It's being brought forth by Directors Ruscha and Guzman.
+
+1620
+02:32:43,038 --> 02:32:50,067
+Paglieri: And I think he has the language in front of him.
+
+1621
+02:32:50,087 --> 02:32:51,208
+Guzman: Director Guzman.
+
+1622
+02:32:51,228 --> 02:32:52,209
+Guzman: Thank you, Mr. Chair.
+
+1623
+02:32:52,249 --> 02:33:03,342
+Guzman: We would like to make a motion to add the language to the end of this policy that says, additionally, no project will be eligible for any discounts unless it complies with the greater of the following.
+
+1624
+02:33:04,148 --> 02:33:15,530
+Guzman: 5% of all units are accessible to persons with mobility disabilities and an additional 2% of all units are accessible to persons with hearing or visual disabilities or to current U.S.
+
+1625
+02:33:15,550 --> 02:33:18,616
+Guzman: Department of Housing, Urban Development Accessibility requirements.
+
+1626
+02:33:20,921 --> 02:33:21,702
+SPEAKER_10: Do you have a second?
+
+1627
+02:33:22,745 --> 02:33:23,766
+Larsen: We have Russia's second.
+
+1628
+02:33:24,828 --> 02:33:25,910
+Larsen: Uh, Mr. Crow.
+
+1629
+02:33:25,930 --> 02:33:26,270
+Larsen: I'm sorry.
+
+1630
+02:33:26,631 --> 02:33:38,207
+Larsen: Just to clarify, Director Guzman, as I understood you reading that into the record, the highlighted portion above would be deleted and is not included in your motion.
+
+1631
+02:33:38,267 --> 02:33:38,648
+Larsen: Correct?
+
+1632
+02:33:38,748 --> 02:33:39,089
+Larsen: Correct.
+
+1633
+02:33:41,973 --> 02:33:42,133
+SPEAKER_10: Correct.
+
+1634
+02:33:42,153 --> 02:33:45,879
+SPEAKER_10: So the language we see, this would substitute the language.
+
+1635
+02:33:46,419 --> 02:33:46,720
+SPEAKER_10: Okay.
+
+1636
+02:33:46,880 --> 02:33:47,180
+SPEAKER_10: Perfect.
+
+1637
+02:33:47,601 --> 02:33:51,907
+Guzman: Simplifying it to the bare minimum to get this done.
+
+1638
+02:33:51,927 --> 02:33:52,448
+Guzman: Director Russia.
+
+1639
+02:33:53,913 --> 02:33:58,800
+Paglieri: I was happy to speak to motion, but I wasn't sure if we were, I'm tired.
+
+1640
+02:33:59,100 --> 02:33:59,461
+Paglieri: Is that okay?
+
+1641
+02:34:00,502 --> 02:34:00,602
+SPEAKER_10: Okay.
+
+1642
+02:34:00,622 --> 02:34:04,728
+SPEAKER_10: I got Guzman as the mover and Risha as the second and we're up for a conversation.
+
+1643
+02:34:04,808 --> 02:34:04,989
+SPEAKER_10: Okay.
+
+1644
+02:34:05,009 --> 02:34:05,730
+SPEAKER_10: You're up, Dr. Risha.
+
+1645
+02:34:06,090 --> 02:34:06,511
+Paglieri: Thank you, sir.
+
+1646
+02:34:06,551 --> 02:34:06,831
+Paglieri: Okay.
+
+1647
+02:34:06,851 --> 02:34:23,194
+Paglieri: So just for everyone's identification, we struck the first sentence, it was a two sentence amendment, just recognizing that we didn't have full staff concurrence on the first sentence, which would have applied this accessibility minimum to market rate housing.
+
+1648
+02:34:23,174 --> 02:34:28,001
+Paglieri: And sometimes you shoot for the stars and land on the moon.
+
+1649
+02:34:29,003 --> 02:34:36,434
+Paglieri: The second sentence, which just applies the HUD requirement to affordable housing, we did get staff concurrence.
+
+1650
+02:34:36,454 --> 02:34:38,978
+Paglieri: So that's just the, that was the context behind that.
+
+1651
+02:34:40,741 --> 02:34:42,263
+Paglieri: I sent out like a
+
+1652
+02:34:43,390 --> 02:34:50,701
+Paglieri: I kind of frequently ask questions in anticipation of some questions, so I'm happy to entertain any or we can address them.
+
+1653
+02:34:51,202 --> 02:35:12,553
+Paglieri: I will say that we worked for three weeks and some change on this with housing advocates and folks who had worked in the space and people who had worked at CHAFA and at the state level on similar policy and advocacy organizations and then staff and legal.
+
+1654
+02:35:12,955 --> 02:35:22,209
+Paglieri: So, I mean, just, I'm sorry, I am tired, too.
+
+1655
+02:35:22,469 --> 02:35:34,407
+Paglieri: In case anybody has any questions about what this is, I think just simplify it and say that HUD has a
+
+1656
+02:35:34,673 --> 02:35:38,438
+Paglieri: current minimum accessibility requirement for funding, right?
+
+1657
+02:35:38,538 --> 02:35:47,108
+Paglieri: And it's 5% of units are accessible to persons with mobility disabilities, additional 2% of units are accessible to persons with hearing or visual disabilities.
+
+1658
+02:35:47,909 --> 02:35:55,538
+Paglieri: And so a lot of times in these projects, that HUD requirement is going to kick in, but not all projects are going to have HUD dollars.
+
+1659
+02:35:56,139 --> 02:36:01,305
+Paglieri: So just recognizing that a lot of jurisdictions take that HUD standard, which is
+
+1660
+02:36:01,522 --> 02:36:06,267
+Paglieri: I maybe miss Brady can correct me, but I think it's 20 plus years old, 30 plus years old now.
+
+1661
+02:36:06,868 --> 02:36:11,913
+Paglieri: Um, and they also incorporate that into their policies or their code or statute.
+
+1662
+02:36:12,193 --> 02:36:15,016
+Paglieri: We did the same kind of good for goose, good for gander.
+
+1663
+02:36:15,797 --> 02:36:18,059
+Paglieri: Um, I will stop there.
+
+1664
+02:36:18,079 --> 02:36:27,529
+SPEAKER_10: Uh, unless anyone else has further questions or, or comment questions or comments on this amendment, uh, Dr. Catlin and then secretary Nicholson.
+
+1665
+02:36:28,910 --> 02:36:44,835
+Catlin: I appreciate the thought going into this, but I believe that the First Amendment that we passed does give a lot of latitude towards Chessie and her staff to negotiate.
+
+1666
+02:36:45,556 --> 02:36:53,989
+Catlin: And I fear that this one might be a little bit too regulatory and prescriptive.
+
+1667
+02:36:55,707 --> 02:37:05,740
+Catlin: If that's the HUD requirement and somebody is applying for a HUD grant, then this would be taken care of automatically.
+
+1668
+02:37:06,341 --> 02:37:15,453
+Catlin: So right now I'm willing to listen to other discussions, but I fear that it would not give Ms.
+
+1669
+02:37:15,493 --> 02:37:22,643
+Catlin: Brady and her staff the maximum flexibility to look at the comprehensive merits of a proposal.
+
+1670
+02:37:25,441 --> 02:37:27,002
+SPEAKER_10: Um, yeah, Ms.
+
+1671
+02:37:27,022 --> 02:37:28,444
+Brady: Spriby.
+
+1672
+02:37:28,464 --> 02:37:28,664
+Brady: Yeah.
+
+1673
+02:37:28,824 --> 02:37:41,496
+Brady: So this is a bare minimum requirement that Denver already requires, for example, and the Colorado Department of Housing is already considering a higher threshold of requirement.
+
+1674
+02:37:41,576 --> 02:37:44,378
+Brady: So I have, I have no concerns about incorporating this.
+
+1675
+02:37:44,458 --> 02:37:48,122
+Brady: I think it, it's already going to be taken care of in most cases.
+
+1676
+02:37:48,522 --> 02:37:51,164
+Catlin: If I might, that's kind of my point.
+
+1677
+02:37:51,265 --> 02:37:52,866
+Catlin: It seems a little bit redundant.
+
+1678
+02:37:56,339 --> 02:37:57,140
+=START-17=
+Nicholson: Secretary Nicholson.
+
+1679
+02:37:58,223 --> 02:38:01,388
+Nicholson: I'd like to offer an amendment, if that's all right.
+
+1680
+02:38:02,991 --> 02:38:03,573
+SPEAKER_10: To the amendment.
+
+1681
+02:38:03,753 --> 02:38:04,174
+Nicholson: Thank you.
+
+1682
+02:38:05,396 --> 02:38:06,799
+SPEAKER_10: Just to clarify, that was a question.
+
+1683
+02:38:06,919 --> 02:38:08,622
+SPEAKER_10: You would like to offer an amendment to the amendment?
+
+1684
+02:38:08,983 --> 02:38:09,143
+Nicholson: Yes.
+
+1685
+02:38:10,666 --> 02:38:11,327
+Nicholson: Let's have an amendment.
+
+1686
+02:38:11,543 --> 02:38:12,985
+Larsen: Mr. Krull.
+
+1687
+02:38:13,005 --> 02:38:41,382
+Larsen: Technically the initial motion on the table is to amend the ETOD policy and this is an amendment to that amendment and at this point you would be amending an amendment to an amendment which is not allowed under Robert's rules so you would need to tackle this amendment as it's being presented and then if you feel so inclined offer an amendment to whatever state the
+
+1688
+02:38:41,362 --> 02:39:07,437
+Nicholson: uh policy is in at that point rock on uh secretary yeah so at that point i would say i'd have to be a no been for the very simple reason um where it says no project will be eligible we're talking about an uh equitable tod policy here um which is specifically focused on using our land to facilitate like the literally the policy is about giving discounts um i can't see
+
+1689
+02:39:07,417 --> 02:39:30,437
+Nicholson: putting something like this in there unless it is related to said discount so I'd be fine if it said additionally no project receiving a discount will be eligible for any discounts etc unless it complies with but I don't necessarily think it makes sense to do market rate policy in an etod policy thank you secretary i have treasurer banker and then director isha
+
+1690
+02:39:30,637 --> 02:39:31,959
+Benker: It's just real quick.
+
+1691
+02:39:31,999 --> 02:39:45,199
+Benker: Have you perhaps considered something more positive saying something like along the lines greater consideration would be given a project if these items were attained as opposed to make it mandatory?
+
+1692
+02:39:48,183 --> 02:39:49,786
+SPEAKER_10: Dr. Risha or Dr. Kisman?
+=END-17=
+
+1693
+02:39:49,806 --> 02:39:52,189
+Benker: Again, sort of an amendment, but just a thought.
+
+1694
+02:39:52,970 --> 02:39:53,111
+Paglieri: Thanks.
+
+1695
+02:39:53,131 --> 02:39:57,437
+Paglieri: So I just want to address what Secretary Nicholson said.
+
+1696
+02:39:57,856 --> 02:40:05,885
+Paglieri: I might have missed part of the closed captioning, but I think you said you don't think we should be applying accessibility minimums to market rate.
+
+1697
+02:40:06,826 --> 02:40:07,047
+Paglieri: Okay.
+
+1698
+02:40:07,387 --> 02:40:07,988
+Paglieri: That's exact.
+
+1699
+02:40:08,188 --> 02:40:08,508
+Paglieri: We don't.
+
+1700
+02:40:08,829 --> 02:40:09,690
+Paglieri: So this amendment doesn't do that.
+
+1701
+02:40:10,090 --> 02:40:23,226
+Paglieri: And the second piece, um, the reason why I didn't say it doesn't reference discounts is because, uh, so this goes at the end of the policy, which is all, like the way it's nested under the paragraph, the discount, this is talking about when discounts apply, if that makes sense.
+
+1702
+02:40:23,606 --> 02:40:24,387
+Paglieri: So it's just,
+
+1703
+02:40:25,902 --> 02:40:29,167
+Paglieri: It does what you said you wanted it to do.
+
+1704
+02:40:29,187 --> 02:40:30,128
+Paglieri: It's just late.
+
+1705
+02:40:30,669 --> 02:40:31,190
+=START-18=
+Nicholson: On Nicholson.
+
+1706
+02:40:31,410 --> 02:40:31,751
+Nicholson: Thank you.
+
+1707
+02:40:32,171 --> 02:40:36,358
+Nicholson: And then the, I guess the only question I have for, and this is actually for Ms.
+
+1708
+02:40:36,398 --> 02:40:37,900
+Nicholson: Brady, if that's okay.
+
+1709
+02:40:38,401 --> 02:40:50,138
+Nicholson: Under what, because you mentioned that Denver has a policy that supersede or that matches this and the state currently is considering a policy that would supersede it, but currently does not.
+
+1710
+02:40:50,675 --> 02:40:54,661
+Nicholson: Under what circumstances would this have any effect at all?
+
+1711
+02:40:54,841 --> 02:41:02,933
+Nicholson: Like in what circumstances can you imagine in your professional capacity, do you see this being something that would matter?
+
+1712
+02:41:04,034 --> 02:41:04,194
+SPEAKER_09: Ms.
+
+1713
+02:41:04,234 --> 02:41:04,515
+SPEAKER_09: Brady?
+
+1714
+02:41:05,276 --> 02:41:09,682
+Brady: Yes, in a jurisdiction that doesn't currently require accessible units.
+
+1715
+02:41:09,842 --> 02:41:15,070
+Brady: And Director Rush has mentioned some, I'm not aware of them, but this is not my area of expertise.
+
+1716
+02:41:15,090 --> 02:41:20,057
+Brady: So, but in a jurisdiction that does not already have those requirements that is not
+
+1717
+02:41:20,257 --> 02:41:33,936
+Brady: accepting HUD money, and if Colorado Department of Housing changes their rules, does not accept Department of Housing money, then that project would then be subject to this policy requirement.
+
+1718
+02:41:35,819 --> 02:41:36,239
+SPEAKER_10: Thank you, Ms.
+
+1719
+02:41:36,280 --> 02:41:36,560
+SPEAKER_10: Breedy.
+
+1720
+02:41:36,880 --> 02:41:37,702
+SPEAKER_10: Secretary, quickly.
+
+1721
+02:41:38,543 --> 02:41:50,179
+Nicholson: Yeah, just, I guess, for Director Rusher, Director Guzman, are there any jurisdictions in the RTD service area that don't have that same requirement that Denver does?
+
+1722
+02:41:52,100 --> 02:41:52,901
+SPEAKER_10: either directors?
+
+1723
+02:41:54,303 --> 02:41:58,991
+Paglieri: Yeah, I think I'm pretty smart, but I'm not qualified to talk about 53 separate jurisdictions.
+=END-18=
+
+1724
+02:41:59,051 --> 02:42:07,383
+Paglieri: So I'm just going to have to lean into this is E TOD and the E is equitable.
+
+1725
+02:42:07,904 --> 02:42:13,292
+Paglieri: We spend a lot of time talking about equity today, including spending a significant amount of time talking about people with disabilities.
+
+1726
+02:42:13,813 --> 02:42:19,542
+Paglieri: And so just again, recognizing that the HUD requirement
+
+1727
+02:42:22,610 --> 02:42:38,492
+Paglieri: is about equity and not excluding people on the basis of disability from accessing affordable housing because the FH Fair Housing Act, the ADA, and other areas of anti-discrimination law, including state law, don't effectively
+
+1728
+02:42:38,995 --> 02:42:40,377
+Paglieri: covered that aspect.
+
+1729
+02:42:41,599 --> 02:42:43,041
+Paglieri: Sorry, that was more than what you asked.
+
+1730
+02:42:43,061 --> 02:42:45,125
+Paglieri: But no, I can't answer your question.
+
+1731
+02:42:46,867 --> 02:42:57,083
+Paglieri: Just like you probably couldn't answer my question about every single jurisdiction in the RTD region that has something regarding parking minimums.
+
+1732
+02:42:58,024 --> 02:42:59,126
+Paglieri: It's a broad concept.
+
+1733
+02:43:00,528 --> 02:43:01,290
+SPEAKER_10: Thank you, Director Usha.
+
+1734
+02:43:01,730 --> 02:43:03,773
+SPEAKER_10: Any further conversation on this amendment?
+
+1735
+02:43:04,915 --> 02:43:05,636
+Guzman: Dr. Guzman.
+
+1736
+02:43:05,656 --> 02:43:07,399
+Guzman: I will offer this last thing.
+
+1737
+02:43:07,733 --> 02:43:21,912
+Guzman: and then we probably should go to a vote, but very simply put, we need to make sure that we are protecting the vulnerable, providing access to these housing units.
+
+1738
+02:43:22,193 --> 02:43:25,477
+Guzman: Even in the city and county of Denver's building codes is not clear.
+
+1739
+02:43:25,537 --> 02:43:26,839
+Guzman: It's as clear as mud.
+
+1740
+02:43:27,140 --> 02:43:33,326
+Guzman: There is reference to this if certain dollars are used, but stacking in the way that developers work, it's not necessarily required.
+
+1741
+02:43:33,366 --> 02:43:42,155
+Guzman: We aspire to a certain ICAA rule, but it's not clear if that means that they have to do this or not in order to get licensed.
+
+1742
+02:43:42,836 --> 02:43:55,408
+Guzman: And so to be fair to ourselves and to ensure that we are taking care of the ADA community and providing those accessible units, I would like to see this in the policy.
+
+1743
+02:43:55,591 --> 02:44:08,383
+Guzman: I would be fine, by the way, to adjust language on this to say we would consider giving additional discount, but I don't want any project to go forward that doesn't meet a bare minimum requirement that's established.
+
+1744
+02:44:08,423 --> 02:44:20,655
+Guzman: And although it is established in other places, it is not established in our policy, and we are the government of this region, and we should take it seriously that we have a due diligence and responsibility to those members of our community that would need this.
+
+1745
+02:44:20,875 --> 02:44:23,117
+Guzman: Thank you.
+
+1746
+02:44:24,683 --> 02:44:30,373
+Harwick: I always have to follow you, Director Guzman, but obviously I'm very in support.
+
+1747
+02:44:30,633 --> 02:44:41,672
+Harwick: Any time that we can be supportive of our communities most in need, those suffering from a whole variety of disabilities, I want to be able to put our best foot forward there.
+
+1748
+02:44:42,113 --> 02:44:46,540
+Harwick: And while we can't call specific jurisdictions, if there is that
+
+1749
+02:44:46,520 --> 02:44:53,495
+Harwick: chance that there is a jurisdiction that isn't meeting this requirement, then we should make sure we're getting there.
+
+1750
+02:44:53,555 --> 02:44:59,087
+Harwick: And if in the process the state comes up with something better or something in the future, that's okay.
+
+1751
+02:44:59,448 --> 02:45:06,503
+Harwick: But I think that this is a safety net in my mind about how to really get there for this community.
+
+1752
+02:45:08,727 --> 02:45:25,158
+Harwick: I think that also, as we're tying these developments, spur off around our transit, that's also giving them better access to the resources and giving them the life that they want and the freedom of movement that we so cherish.
+
+1753
+02:45:25,218 --> 02:45:27,242
+Harwick: So I'm highly in support of this.
+
+1754
+02:45:27,222 --> 02:45:27,562
+SPEAKER_10: Thank you.
+
+1755
+02:45:28,043 --> 02:45:29,304
+Harwick: Secretary, less than 30 seconds.
+
+1756
+02:45:30,606 --> 02:45:34,170
+=START-19=
+Nicholson: This question is for Chessie.
+
+1757
+02:45:34,410 --> 02:45:42,299
+Nicholson: My understanding with this language is that it applies to buildings with elevators in it.
+
+1758
+02:45:42,419 --> 02:45:56,976
+Nicholson: And so with single stair buildings, that there are different policies around equitable access because of the challenges, obviously, in a single stair building of getting people into the second, the third, the fourth, the fifth floor.
+
+1759
+02:45:57,277 --> 02:46:00,686
+Nicholson: You're probably the biggest expert on this in the room.
+
+1760
+02:46:01,869 --> 02:46:13,159
+Nicholson: Do you see any concerns with this language when it comes to buildings with stairs only versus elevators?
+
+1761
+02:46:13,865 --> 02:46:23,579
+Brady: I am not the biggest expert on this in the room, but I would say that equitable, I do know that equitable access and accessible units are different things and have different requirements.
+
+1762
+02:46:24,400 --> 02:46:27,885
+Brady: And so we're talking specifically about accessible units.
+
+1763
+02:46:29,207 --> 02:46:35,476
+Brady: We're also not, we're tending to be talking about larger buildings because we do want them to be dense at stations.
+
+1764
+02:46:35,497 --> 02:46:40,183
+Brady: So I think they're typically going to be elevator buildings, but I don't have any concerns about that.
+
+1765
+02:46:40,203 --> 02:46:40,584
+SPEAKER_10: Thank you, Ms.
+=END-19=
+
+1766
+02:46:40,604 --> 02:46:40,864
+SPEAKER_10: Brady.
+
+1767
+02:46:41,365 --> 02:46:42,707
+SPEAKER_10: Let's do the roll call vote.
+
+1768
+02:46:42,940 --> 02:46:47,687
+SPEAKER_10: Again, this is the amendment offered by Director Guzman and Director Rusha.
+
+1769
+02:46:48,288 --> 02:46:48,969
+SPEAKER_10: Treasure banker.
+
+1770
+02:46:52,935 --> 02:46:53,556
+SPEAKER_10: Director Catlin.
+
+1771
+02:46:55,058 --> 02:46:55,278
+Catlin: No.
+
+1772
+02:46:56,400 --> 02:46:57,141
+SPEAKER_10: Director Geisinger.
+
+1773
+02:46:58,383 --> 02:46:58,483
+SPEAKER_10: Yes.
+
+1774
+02:46:58,503 --> 02:46:59,204
+SPEAKER_10: Director Gujranader.
+
+1775
+02:47:00,246 --> 02:47:00,947
+Catlin: Yes.
+
+1776
+02:47:00,967 --> 02:47:01,628
+SPEAKER_10: Director Guzman.
+
+1777
+02:47:01,848 --> 02:47:02,830
+Guzman: Yes.
+
+1778
+02:47:02,850 --> 02:47:03,431
+SPEAKER_10: Director Harwick.
+
+1779
+02:47:03,571 --> 02:47:03,891
+SPEAKER_10: Yep.
+
+1780
+02:47:04,773 --> 02:47:05,394
+SPEAKER_10: Director Larson.
+
+1781
+02:47:06,335 --> 02:47:06,515
+SPEAKER_10: No.
+
+1782
+02:47:07,517 --> 02:47:08,278
+=START-20=
+SPEAKER_10: Director Nicholson.
+
+1783
+02:47:10,661 --> 02:47:10,882
+Nicholson: Yes.
+
+1784
+02:47:11,783 --> 02:47:12,424
+SPEAKER_10: Director O'Keefe.
+
+1785
+02:47:15,087 --> 02:47:15,367
+Nicholson: No.
+
+1786
+02:47:16,228 --> 02:47:16,328
+SPEAKER_10: No.
+
+1787
+02:47:16,348 --> 02:47:16,489
+SPEAKER_10: No.
+
+1788
+02:47:16,509 --> 02:47:16,749
+SPEAKER_10: No.
+
+1789
+02:47:16,769 --> 02:47:16,969
+SPEAKER_10: No.
+
+1790
+02:47:17,690 --> 02:47:17,950
+Larsen: No.
+=END-20=
+
+1791
+02:47:18,611 --> 02:47:18,731
+SPEAKER_10: No.
+
+1792
+02:47:18,751 --> 02:47:19,512
+SPEAKER_10: No.
+
+1793
+02:47:20,713 --> 02:47:20,894
+Larsen: No.
+
+1794
+02:47:21,855 --> 02:47:21,975
+SPEAKER_10: No.
+
+1795
+02:47:21,995 --> 02:47:22,095
+SPEAKER_10: No.
+
+1796
+02:47:22,115 --> 02:47:22,415
+SPEAKER_10: No.
+
+1797
+02:47:22,435 --> 02:47:22,555
+SPEAKER_10: No.
+
+1798
+02:47:22,596 --> 02:47:22,656
+SPEAKER_10: No.
+
+1799
+02:47:25,519 --> 02:47:25,799
+SPEAKER_10: No.
+
+1800
+02:47:25,819 --> 02:47:25,919
+SPEAKER_10: No.
+
+1801
+02:47:25,939 --> 02:47:26,200
+SPEAKER_10: No.
+
+1802
+02:47:26,760 --> 02:47:27,221
+SPEAKER_10: No.
+
+1803
+02:47:27,541 --> 02:47:27,701
+SPEAKER_10: No.
+
+1804
+02:47:27,882 --> 02:47:31,165
+SPEAKER_10: No.
+
+1805
+02:47:31,185 --> 02:47:31,305
+SPEAKER_10: No.
+
+1806
+02:47:32,046 --> 02:47:35,310
+SPEAKER_10: No.
+
+1807
+02:47:35,350 --> 02:47:37,973
+SPEAKER_10: No.
+
+1808
+02:47:39,218 --> 02:47:41,100
+SPEAKER_10: For nose excuse me for nose.
+
+1809
+02:47:41,361 --> 02:47:41,701
+SPEAKER_10: Thank you.
+
+1810
+02:47:42,161 --> 02:47:44,825
+SPEAKER_10: So nine four and two nine four and two my apologies.
+
+1811
+02:47:45,005 --> 02:47:52,233
+SPEAKER_10: We'll save that for the record Okay, um now moving on back to the main motion as amended.
+
+1812
+02:47:52,293 --> 02:47:54,095
+SPEAKER_10: Do we have any further discussion on the main motion?
+
+1813
+02:47:56,138 --> 02:48:05,609
+SPEAKER_10: Okay, I will do a roll call vote to for the main motion as amended treasure banker Director Catlin.
+
+1814
+02:48:06,170 --> 02:48:06,610
+Catlin: Yes
+
+1815
+02:48:07,248 --> 02:48:08,029
+SPEAKER_10: Director Geisinger.
+
+1816
+02:48:08,349 --> 02:48:08,689
+Catlin: Yep.
+
+1817
+02:48:08,710 --> 02:48:09,530
+SPEAKER_10: Director Guchinreider.
+
+1818
+02:48:10,351 --> 02:48:10,752
+Catlin: Yes.
+
+1819
+02:48:10,772 --> 02:48:11,512
+SPEAKER_10: Director Guzman.
+
+1820
+02:48:12,193 --> 02:48:12,413
+Guzman: Yes.
+
+1821
+02:48:12,634 --> 02:48:13,374
+SPEAKER_10: Director Harwick.
+
+1822
+02:48:13,394 --> 02:48:13,615
+SPEAKER_10: Yes.
+
+1823
+02:48:14,195 --> 02:48:15,477
+SPEAKER_10: Director Larson.
+
+1824
+02:48:15,497 --> 02:48:15,717
+SPEAKER_10: No.
+
+1825
+02:48:17,058 --> 02:48:17,919
+SPEAKER_10: Director Nicholson.
+
+1826
+02:48:18,520 --> 02:48:18,740
+Larsen: Yes.
+
+1827
+02:48:19,120 --> 02:48:19,921
+SPEAKER_10: Director O'Keefe.
+
+1828
+02:48:20,201 --> 02:48:20,482
+SPEAKER_10: Yes.
+
+1829
+02:48:20,642 --> 02:48:21,643
+SPEAKER_10: Director Paglieleri.
+
+1830
+02:48:22,644 --> 02:48:22,904
+Larsen: Yes.
+
+1831
+02:48:24,706 --> 02:48:25,447
+SPEAKER_10: Director Ruscha.
+
+1832
+02:48:25,727 --> 02:48:25,947
+Larsen: Yes.
+
+1833
+02:48:26,228 --> 02:48:26,968
+SPEAKER_10: Director Whitmore.
+
+1834
+02:48:27,269 --> 02:48:27,509
+SPEAKER_10: Yes.
+
+1835
+02:48:28,030 --> 02:48:28,910
+SPEAKER_10: I'm also yes.
+
+1836
+02:48:29,011 --> 02:48:29,731
+SPEAKER_10: We'll pass.
+
+1837
+02:48:29,751 --> 02:48:31,493
+SPEAKER_10: 12 yes.
+
+1838
+02:48:31,513 --> 02:48:32,594
+SPEAKER_10: 1 no.
+
+1839
+02:48:34,897 --> 02:48:35,557
+SPEAKER_10: 2 absent.
+
+1840
+02:48:35,778 --> 02:48:36,158
+SPEAKER_10: Thank you.
+
+1841
+02:48:37,015 --> 02:48:39,381
+SPEAKER_10: All right, moving on.
+
+1842
+02:48:39,441 --> 02:48:41,907
+SPEAKER_10: That was all our recommended actions.
+
+1843
+02:48:42,749 --> 02:48:43,972
+SPEAKER_10: Court of Director activities.
+
+1844
+02:48:45,777 --> 02:48:46,860
+SPEAKER_10: I think you're all good on that.
+
+1845
+02:48:47,180 --> 02:48:47,782
+SPEAKER_10: Other matters?
+
+1846
+02:48:50,729 --> 02:48:52,594
+Whitmore: Amen, buddy.
+
+1847
+02:48:52,709 --> 02:48:54,050
+SPEAKER_09: Director Guzman.
+
+1848
+02:48:54,070 --> 02:48:54,671
+Guzman: I got one quick.
+
+1849
+02:48:54,711 --> 02:48:55,031
+Guzman: Sorry.
+
+1850
+02:48:55,532 --> 02:49:03,519
+Guzman: Thank you, Mr. Chair, for approving the travel consideration for lodging and assistance to go to the NTI public engagement course in Florida.
+
+1851
+02:49:04,600 --> 02:49:10,706
+Guzman: Really packed, but came in really handy because as soon as I returned, we held the town hall to do exactly what I was sent to go learn about.
+
+1852
+02:49:10,886 --> 02:49:11,967
+Guzman: So I appreciate that.
+
+1853
+02:49:12,527 --> 02:49:17,712
+Guzman: And I was grateful for the assistance from staff and from Director Ruscha to be able to host that town hall.
+
+1854
+02:49:17,732 --> 02:49:17,932
+Guzman: Thanks.
+
+1855
+02:49:19,434 --> 02:49:21,375
+SPEAKER_10: Thank you, Director Guzman.
+
+1856
+02:49:21,395 --> 02:49:22,176
+=START-21=
+SPEAKER_10: Secretary Nicholson.
+
+1857
+02:49:22,358 --> 02:49:28,806
+Nicholson: I just wanted to flag that this weekend is the reopening of downtown celebration on Saturday and Sunday.
+
+1858
+02:49:28,906 --> 02:49:36,795
+Nicholson: So if you like RTD, please come take it to downtown and enjoy our lovely food and all the other cool stuff.
+
+1859
+02:49:36,936 --> 02:49:40,580
+Nicholson: Most of them all is back and running and we're very excited about it.
+
+1860
+02:49:41,481 --> 02:49:42,082
+SPEAKER_10: Any other matters?
+
+1861
+02:49:43,223 --> 02:49:44,104
+SPEAKER_10: Okay, I got a quick one.
+
+1862
+02:49:44,124 --> 02:49:46,527
+SPEAKER_10: It's only going to take 19 minutes.
+
+1863
+02:49:48,346 --> 02:49:48,907
+SPEAKER_10: Just joking.
+
+1864
+02:49:49,288 --> 02:49:53,656
+SPEAKER_10: My only other matter is please make sure that you, uh, directors fill out that form.
+
+1865
+02:49:54,057 --> 02:49:57,524
+SPEAKER_10: Um, that was due last week extended to Monday morning.
+
+1866
+02:49:57,664 --> 02:50:01,151
+SPEAKER_10: Please make sure you guys take care of that with that, the survey.
+
+1867
+02:50:01,211 --> 02:50:01,571
+SPEAKER_10: Thank you.
+
+1868
+02:50:01,912 --> 02:50:04,838
+SPEAKER_10: With that being said, uh, do I have a motion to adjourn?
+
+1869
+02:50:05,739 --> 02:50:06,441
+SPEAKER_10: Director Russia.
+
+1870
+02:50:06,821 --> 02:50:07,262
+SPEAKER_10: Second.
+
+1871
+02:50:07,282 --> 02:50:08,284
+SPEAKER_10: And a second from Goodgerner.
+
+1872
+02:50:08,344 --> 02:50:09,747
+SPEAKER_10: You guys all have a lovely night.
+
+1873
+02:50:09,927 --> 02:50:11,350
+SPEAKER_10: Thank you all for your patience.
+
+1874
+02:50:28,610 --> 02:50:29,070
+Bye.
+=END-21=


### PR DESCRIPTION
## Summary
- add `srt_markers` helper to insert `=START=/=END=` markers in SRT files
- expose new helper via `videocut annotate-srt`
- include processed May meeting SRT with markers
- parse marked SRT files into segment lists
- generate clips directly from an annotated SRT file

## Testing
- `PYTHONPATH=$(pwd) pytest tests/test_may_board_meeting.py::test_may_board_meeting_segments -q`
- `PYTHONPATH=$(pwd) pytest tests/test_core.py::test_generate_clips_invokes_ffmpeg -q`


------
https://chatgpt.com/codex/tasks/task_e_68468416a2548321889225f404f60d5f