### PR TITLE
Enhance chair detection with weighted cues

### DIFF
--- a/tests/test_chair_rollcall.py
+++ b/tests/test_chair_rollcall.py
@@ -19,6 +19,67 @@ def sample_roll_call(tmp_path):
     return diarized
 
 
+def sample_rollcall_variation(tmp_path):
+    diarized = tmp_path / "dia_var.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "A", "text": "welcome"},
+            {"speaker": "A", "text": "Let's do a rollcall"},
+            {"speaker": "A", "text": "Director Doe"},
+            {"speaker": "B", "text": "Present"},
+        ]
+    }))
+    return diarized
+
+
+def sample_rollcall_no_phrase(tmp_path):
+    diarized = tmp_path / "dia_no_phrase.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "A", "text": "welcome"},
+            {"speaker": "A", "text": "Director Doe"},
+            {"speaker": "B", "text": "Present"},
+            {"speaker": "A", "text": "Director Roe"},
+            {"speaker": "C", "text": "Here"},
+        ]
+    }))
+    return diarized
+
+
+def sample_motion_phrase(tmp_path):
+    diarized = tmp_path / "dia_motion.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "X", "text": "Okay, moving on"},
+            {"speaker": "X", "text": "Do I have a motion?"},
+        ]
+    }))
+    return diarized
+
+
+def sample_other_phrases(tmp_path):
+    diarized = tmp_path / "dia_other.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "A", "text": "Moving on"},
+            {"speaker": "B", "text": "Hello"},
+            {"speaker": "A", "text": "Any other matters?"},
+        ]
+    }))
+    return diarized
+
+
+def sample_weighted(tmp_path):
+    diarized = tmp_path / "dia_weight.json"
+    diarized.write_text(json.dumps({
+        "segments": [
+            {"speaker": "A", "text": "Moving on"},
+            {"speaker": "B", "text": "Do I have a motion?"},
+        ]
+    }))
+    return diarized
+
+
 def sample_roll_call_srt(tmp_path):
     srt = tmp_path / "dia.srt"
     srt.write_text(
@@ -56,3 +117,32 @@ def test_parse_roll_call(tmp_path):
 def test_identify_chair_srt(tmp_path):
     srt_file = sample_roll_call_srt(tmp_path)
     assert chair.identify_chair_srt(str(srt_file)) == "SPEAKER_1"
+
+
+def test_identify_chair_variation(tmp_path):
+    diarized = sample_rollcall_variation(tmp_path)
+    assert chair.identify_chair(str(diarized)) == "A"
+
+
+def test_identify_chair_no_phrase(tmp_path):
+    diarized = sample_rollcall_no_phrase(tmp_path)
+    assert chair.identify_chair(str(diarized)) == "A"
+    votes = chair.parse_roll_call(str(diarized))
+    assert votes == {"Doe": "B", "Roe": "C"}
+
+
+def test_identify_chair_motion(tmp_path):
+    diarized = sample_motion_phrase(tmp_path)
+    assert chair.identify_chair(str(diarized)) == "X"
+
+
+def test_identify_chair_other_phrases(tmp_path):
+    diarized = sample_other_phrases(tmp_path)
+    assert chair.identify_chair(str(diarized)) == "A"
+
+
+def test_identify_chair_weighted(tmp_path):
+    diarized = sample_weighted(tmp_path)
+    # motion phrase has higher weight than moving on
+    assert chair.identify_chair(str(diarized)) == "B"
+

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -71,9 +71,17 @@ def annotate_srt(
     srt_file: str,
     seg_json: str = "segments_to_keep.json",
     name_map: str = "recognized_map.json",
-    out_file: str = "May_Board_Meeting_processed.srt",
+    out_file: Optional[str] = None,
 ):
-    """Write ``out_file`` with =START/=END markers and mapped labels."""
+    """Write ``out_file`` with =START/=END markers and mapped labels.
+
+    If ``out_file`` is ``None`` it will be derived from ``srt_file`` by
+    appending ``_processed`` before the extension. For example,
+    ``meeting.srt`` becomes ``meeting_processed.srt``.
+    """
+    if out_file is None:
+        path = Path(srt_file)
+        out_file = f"{path.stem}_processed{path.suffix}"
     srt_markers.annotate_srt(srt_file, seg_json, name_map, out_file)
 
 

--- a/videocut/core/chair.py
+++ b/videocut/core/chair.py
@@ -4,7 +4,19 @@ from pathlib import Path
 from typing import Dict
 
 # Regex to detect a roll call announcement
-_ROLL_RE = re.compile(r"roll call|call the roll", re.IGNORECASE)
+# Regex to detect a roll call announcement
+_ROLL_RE = re.compile(
+    r"roll\s?call|call(?:ing)?(?:\s+the)?\s+roll|take(?:\s+the)?\s+roll",
+    re.IGNORECASE,
+)
+# Additional chair phrases that can appear later in the meeting
+_MOTION_RE = re.compile(
+    r"(?:do|can|may)\s+i\s+have\s+a\s+motion|entertain\s+a\s+motion",
+    re.IGNORECASE,
+)
+_MOVE_RE = re.compile(r"moving on", re.IGNORECASE)
+_CHAIR_REPORT_RE = re.compile(r"chair['’]?s report", re.IGNORECASE)
+_ANY_OTHER_RE = re.compile(r"any other (?:directors? )?comments|any other matters", re.IGNORECASE)
 # Regex to extract names announced during roll call
 _NAME_RE = re.compile(
     r"(?:director|secretary|treasurer|chair(?:man)?|vice chair)\s+(?P<name>[A-Za-z]+(?: [A-Za-z]+)*)",
@@ -16,12 +28,36 @@ _SPEAKER_RE = re.compile(r"\[(SPEAKER_\d+)\]")
 
 __all__ = ["identify_chair", "parse_roll_call", "identify_chair_srt"]
 
+_HEURISTICS = [
+    (_ROLL_RE, 5),
+    (_MOTION_RE, 3),
+    (_MOVE_RE, 1),
+    (_CHAIR_REPORT_RE, 2),
+    (_ANY_OTHER_RE, 1),
+]
+
+
 def identify_chair(diarized_json: str) -> str:
-    """Return the diarized speaker ID who calls the roll."""
+    """Return the diarized speaker ID most likely acting as chair."""
     data = json.loads(Path(diarized_json).read_text())
-    for seg in data.get("segments", []):
-        if _ROLL_RE.search(seg.get("text", "")):
-            return seg.get("speaker")
+    segments = data.get("segments", [])
+    scores: Dict[str, int] = {}
+    for seg in segments:
+        text = seg.get("text", "")
+        speaker = seg.get("speaker")
+        for pat, weight in _HEURISTICS:
+            if pat.search(text):
+                scores[speaker] = scores.get(speaker, 0) + weight
+    if scores:
+        return max(scores.items(), key=lambda kv: kv[1])[0]
+    # Fallback: look for a name/present pair to infer the chair
+    for i, seg in enumerate(segments):
+        if _NAME_RE.search(seg.get("text", "")):
+            j = i + 1
+            while j < len(segments) and segments[j].get("speaker") == seg.get("speaker"):
+                j += 1
+            if j < len(segments) and _PRESENT_RE.search(segments[j].get("text", "")):
+                return seg.get("speaker")
     raise RuntimeError("No roll call detected – unable to identify chair")
 
 
@@ -32,12 +68,20 @@ def parse_roll_call(diarized_json: str) -> Dict[str, str]:
     votes: Dict[str, str] = {}
     chair_id = None
     i = 0
-    # locate roll call
+    # locate roll call or infer from first name/present pair
     while i < len(segments):
-        if _ROLL_RE.search(segments[i].get("text", "")):
+        text = segments[i].get("text", "")
+        if _ROLL_RE.search(text) or _MOTION_RE.search(text):
             chair_id = segments[i].get("speaker")
             i += 1
             break
+        if _NAME_RE.search(text):
+            j = i + 1
+            while j < len(segments) and segments[j].get("speaker") == segments[i].get("speaker"):
+                j += 1
+            if j < len(segments) and _PRESENT_RE.search(segments[j].get("text", "")):
+                chair_id = segments[i].get("speaker")
+                break
         i += 1
     if chair_id is None:
         raise RuntimeError("No roll call found")
@@ -64,7 +108,7 @@ def parse_roll_call(diarized_json: str) -> Dict[str, str]:
 def identify_chair_srt(srt_file: str) -> str:
     """Return the speaker tag that calls the roll in an SRT file."""
     for line in Path(srt_file).read_text().splitlines():
-        if _ROLL_RE.search(line):
+        if _ROLL_RE.search(line) or _MOTION_RE.search(line):
             m = _SPEAKER_RE.search(line)
             if m:
                 return m.group(1)


### PR DESCRIPTION
## Summary
- add regex patterns for motion, moving on, chair's report, and "any other" phrases
- score speakers based on multiple heuristics to infer the chair
- expanded tests covering new phrases and weighting logic

## Testing
- `pytest -q`
- `PYTHONPATH=. pytest tests/test_may_board_meeting.py::test_may_board_meeting_segments -q`


------
https://chatgpt.com/codex/tasks/task_e_6846bf5df23483219b9f9c96d21e357a