### PR TITLE
Simplify pipeline workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # VideoCut
 
-VideoCut provides a small video editing pipeline driven by WhisperX transcripts.  The project now exposes a single `videocut` command powered by **Typer** for easy usage.  All functionality can still be invoked step-by-step or via a one-shot pipeline command.
+VideoCut provides a streamlined video editing pipeline powered by WhisperX. The `videocut` command runs every step needed to process a board meeting recording.
 
 ## Requirements
-
 - Python 3.11+
-- [FFmpeg](https://ffmpeg.org/) available on your `PATH`
-- [WhisperX](https://github.com/m-bain/whisperX) and its dependencies (installed via `requirements.txt`)
+- [FFmpeg](https://ffmpeg.org/) on your `PATH`
+- [WhisperX](https://github.com/m-bain/whisperX) and its dependencies
+- `HF_TOKEN` environment variable for speaker diarization
 
 ## Setup
-
-Create a virtual environment and install packages:
-
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
@@ -19,279 +16,26 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
-If you already have transcripts and want to skip WhisperX's heavy install,
-install only the lightweight dependencies instead:
-
-```bash
-pip install -r no_transcribe_requirements.txt
-```
-
-Verify the CLI loads properly:
-
-```bash
-videocut --help
-```
-
-Speaker diarization requires a Hugging Face access token.  Set `HF_TOKEN` in your environment or in a `.env` file:
-
-```bash
-HF_TOKEN=your_hf_token_here
-```
-
 ## Workflow
+1. **Transcribe** – `videocut transcribe input.mp4 --diarize --hf_token $HF_TOKEN`
+   produces `input.json` and `markup_guide.txt` with diarized speaker labels.
+2. **Identify recognized speakers** – `videocut identify-recognized input.json`
+   detects the chair from the roll call and writes `recognized_map.json` and
+   `roll_call_map.json`.
+3. **Identify segments** – `videocut identify-segments input.json` creates
+   `segments_to_keep.json` grouping Secretary Nicholson's remarks.
+4. **Generate clips** – `videocut generate-clips input.mp4` cuts clips to `clips/`.
+5. **Concatenate** – `videocut concatenate` joins clips into `final_video.mp4`.
+6. **Annotate markup** – `videocut annotate-markup` writes `markup_with_markers.txt`.
+7. **Clip transcripts** – `videocut clip-transcripts` produces `clip_transcripts.txt`.
 
-1. **Transcribe with diarization** – `videocut transcribe input.mp4 --diarize --hf_token $HF_TOKEN` runs WhisperX and produces `markup_guide.txt` and `input.json` with speaker labels.
-   Provide `--speaker-db speakers.json` to map diarized IDs to real names.
-2. **Identify segments** – `videocut identify-segments input.json` generates
-   `segments_to_keep.json` grouping Nicholson's remarks into coherent segments using recognized speaker IDs.
-   The script also cross-checks with text heuristics and warns if the methods disagree.
-<<<<   A list of official board member names is provided in `board_members.txt` so replies
-   from non‑directors can be captured when extending Nicholson's segments.
-   Run `videocut apply-name-map` to replace `SPEAKER_xx` tokens in the JSON with
-   mapped names and `videocut prune-segments` to drop trivial clips.
->>>>>>>+main
-=
-   A l   A list of official board member names in `board_members.txt` lets the tool
-   include staff answers when Nicholson asks a question.  Speaker IDs are now
-   replaced with recognized names automatically and `videocut prune-segments`
-   can drop trivial clips.
->>>>>>>-fup1ec-codex/fi
-eview and edit** – optionally run `videocut json-to-editable segments_to_keep.json` and modify the JSON to fine‑tune the clips.
-4. **Generate clips** – `videocut generate-clips input.mp4` cuts clips into a `clips/` directory.
-5. **Concatenate** – `videocut concatenate` stitches the clips together with white flashes.
-6. **Annotate markup** – `videocut annotate-markup` creates `markup_with_markers.txt` showing kept segments in context.
-7. **Clip transcripts** – `videocut clip-transcripts` summarizes the transcript lines for each long clip.
-
-All of these steps can be executed sequentially with `videocut pipeline input.mp4 --diarize --hf_token $HF_TOKEN` which auto‑marks Nicholson by default.
-
-### Automatic speaker identification
-
-When diarization is enabled, VideoCut scans the transcript for recognition cues
-such as "Director Doe you're recognized" or simply "You're recognized" when the
-chair has just mentioned a name. Short lines that end with just "Director Name" or phrases like "yield the floor to Director Name" are also detected. The chair is identified from the roll call first, then these cues map each diarized speaker ID to its most likely name with any alternatives. Results are written to `recognized_map.json`.
-`identify-recognized` command can be run manually if needed:
-
+All of these steps run automatically with:
 ```bash
-videocut identify-recognized input.json
-```
-
-The pipeline command performs this detection automatically and prints a warning
-if no recognition cues are found.
-
-For multiple people you can supply a phrase map to `identify-speakers`:
-
-```bash
-videocut identify-speakers input.json phrase_map.json
-```
-
-The resulting `speaker_map.json` can then be applied back to the transcript:
-
-```bash
-
-videocut apply-speaker-labels input.json speaker_map.json --out labeled.json
-```
-
-### Chair identification and roll call
-
-When a meeting transcript includes a roll call vote, the speaker who announces
-"call the roll" is treated as the chair. Names read during the roll call are
-paired with the voices that respond "present" or "here" so diarization can be
-validated. The mapping of names to speaker labels can be extracted with:
-
-```bash
-videocut identify-chair input.json
-```
-
-### Example commands
-
-```bash
-# Build embeddings from known speakers
-videocut build-speaker-db samples/ --out speakers.json
-
-# Transcription with diarization
-videocut transcribe meeting.mp4 --diarize --hf_token $HF_TOKEN --speaker-db speakers.json
-
-# Identify Nicholson segments into grouped clips
-videocut identify-segments meeting.json
-
-# (Optional) tweak the segments
-videocut json-to-editable segments_to_keep.json --out segments_edit.json
-# ...edit segments_edit.json as desired...
-
-# Cut clips and assemble the final video
-videocut generate-clips meeting.mp4 --segs segments_to_keep.json
-videocut concatenate --clips_dir clips --out final.mp4
-videocut annotate-markup
-videocut clip-transcripts
-
-# Repla# Replace SPEAKER IDs with names and prune trivial segments
-videocut apply-name-map segments_to_keep.json recognized_map.json
->>>>>>>+main
-ial segm# Prune trivial segments
->>>>>>>-fup1ec-codex/fi
-nts segments_to_keep.json
-
-# List recognized directors
-videocut recognized-directors recognized_map.json board_members.txt
-
-# Map speakers after transcription
-videocut map-speakers meeting.mp4 meeting.json --db speakers.json
+videocut pipeline input.mp4 --hf_token $HF_TOKEN
 ```
 
 ## Package layout
-
 - `videocut/cli.py` – Typer command line interface
-- `videocut/core/` – modular helpers (`transcription.py`, `segmentation.py`, `video_editing.py`, `nicholson.py`, `annotation.py`, `clip_transcripts.py`, `speaker_mapping.py`)
-- `videos/` – example data used for testing the pipeline
-- `board_members.txt` – official names used when matching directors
-
-WhisperX and FFmpeg must be installed separately.  Once those are available, the `videocut` command can automate cutting long meeting videos into polished clips.
-# VideoCut
-
-VideoCut provides a small video editing pipeline driven by WhisperX transcripts.  The project now exposes a single `videocut` command powered by **Typer** for easy usage.  All functionality can still be invoked step-by-step or via a one-shot pipeline command.
-
-## Requirements
-
-- Python 3.11+
-- [FFmpeg](https://ffmpeg.org/) available on your `PATH`
-- [WhisperX](https://github.com/m-bain/whisperX) and its dependencies (installed via `requirements.txt`)
-
-## Setup
-
-Create a virtual environment and install packages:
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-pip install -e .
-```
-
-If you already have transcripts and want to skip WhisperX's heavy install,
-install only the lightweight dependencies instead:
-
-```bash
-pip install -r no_transcribe_requirements.txt
-```
-
-Verify the CLI loads properly:
-
-```bash
-videocut --help
-```
-
-Speaker diarization requires a Hugging Face access token.  Set `HF_TOKEN` in your environment or in a `.env` file:
-
-```bash
-HF_TOKEN=your_hf_token_here
-```
-
-## Workflow
-
-1. **Transcribe with diarization** – `videocut transcribe input.mp4 --diarize --hf_token $HF_TOKEN` runs WhisperX and produces `markup_guide.txt` and `input.json` with speaker labels.
-   Provide `--speaker-db speakers.json` to map diarized IDs to real names.
-2. **Identify segments** – `videocut identify-segments input.json` generates
-   `segments_to_keep.json` grouping Nicholson's remarks into coherent segments using recognized speaker IDs.
-   The script also cross-checks with text heuristics and warns if the methods disagree.
-<<<<   A list of official board member names is provided in `board_members.txt` so replies
-   from non‑directors can be captured when extending Nicholson's segments.
-   Run `videocut apply-name-map` to replace `SPEAKER_xx` tokens in the JSON with
-   mapped names and `videocut prune-segments` to drop trivial clips.
->>>>>>>+main
-=
-   A l   A list of official board member names in `board_members.txt` lets the tool
-   include staff answers when Nicholson asks a question.  Speaker IDs are now
-   replaced with recognized names automatically and `videocut prune-segments`
-   can drop trivial clips.
->>>>>>>-fup1ec-codex/fi
-eview and edit** – optionally run `videocut json-to-editable segments_to_keep.json` and modify the JSON to fine‑tune the clips.
-4. **Generate clips** – `videocut generate-clips input.mp4` cuts clips into a `clips/` directory.
-5. **Concatenate** – `videocut concatenate` stitches the clips together with white flashes.
-6. **Annotate markup** – `videocut annotate-markup` creates `markup_with_markers.txt` showing kept segments in context.
-7. **Clip transcripts** – `videocut clip-transcripts` summarizes the transcript lines for each long clip.
-
-All of these steps can be executed sequentially with `videocut pipeline input.mp4 --diarize --hf_token $HF_TOKEN` which auto‑marks Nicholson by default.
-
-### Automatic speaker identification
-
-When diarization is enabled, VideoCut scans the transcript for recognition cues
-such as "Director Doe you're recognized" or simply "You're recognized" when the
-chair has just mentioned a name. Short lines that end with just "Director Name" or phrases like "yield the floor to Director Name" are also detected. The chair is identified from the roll call first, then these cues map each diarized speaker ID to its most likely name with any alternatives. Results are written to `recognized_map.json`.
-`identify-recognized` command can be run manually if needed:
-
-```bash
-videocut identify-recognized input.json
-```
-
-The pipeline command performs this detection automatically and prints a warning
-if no recognition cues are found.
-
-For multiple people you can supply a phrase map to `identify-speakers`:
-
-```bash
-videocut identify-speakers input.json phrase_map.json
-```
-
-The resulting `speaker_map.json` can then be applied back to the transcript:
-
-```bash
-
-videocut apply-speaker-labels input.json speaker_map.json --out labeled.json
-```
-
-### Chair identification and roll call
-
-When a meeting transcript includes a roll call vote, the speaker who announces
-"call the roll" is treated as the chair. Names read during the roll call are
-paired with the voices that respond "present" or "here" so diarization can be
-validated. The mapping of names to speaker labels can be extracted with:
-
-```bash
-videocut identify-chair input.json
-```
-
-### Example commands
-
-```bash
-# Build embeddings from known speakers
-videocut build-speaker-db samples/ --out speakers.json
-
-# Transcription with diarization
-videocut transcribe meeting.mp4 --diarize --hf_token $HF_TOKEN --speaker-db speakers.json
-
-# Identify Nicholson segments into grouped clips
-videocut identify-segments meeting.json
-
-# (Optional) tweak the segments
-videocut json-to-editable segments_to_keep.json --out segments_edit.json
-# ...edit segments_edit.json as desired...
-
-# Cut clips and assemble the final video
-videocut generate-clips meeting.mp4 --segs segments_to_keep.json
-videocut concatenate --clips_dir clips --out final.mp4
-videocut annotate-markup
-videocut clip-transcripts
-
-<<<<<<< main
-# Repla# Replace SPEAKER IDs with names and prune trivial segments
-videocut apply-name-map segments_to_keep.json recognized_map.json
->>>>>>>+main
-ial segm# Prune trivial segments
->>>>>>>-fup1ec-codex/fi
-nts segments_to_keep.json
-
-# List recognized directors
-videocut recognized-directors recognized_map.json board_members.txt
-
-# Map speakers after transcription
-videocut map-speakers meeting.mp4 meeting.json --db speakers.json
-```
-
-## Package layout
-
-- `videocut/cli.py` – Typer command line interface
-- `videocut/core/` – modular helpers (`transcription.py`, `segmentation.py`, `video_editing.py`, `nicholson.py`, `annotation.py`, `clip_transcripts.py`, `speaker_mapping.py`)
-- `videos/` – example data used for testing the pipeline
-- `board_members.txt` – official names used when matching directors
-
-WhisperX and FFmpeg must be installed separately.  Once those are available, the `videocut` command can automate cutting long meeting videos into polished clips.
+- `videocut/core/` – modular helpers
+- `videos/` – example data used for testing
+- `board_members.txt` – official director names

--- a/specification.md
+++ b/specification.md
@@ -14,7 +14,8 @@ High-level workflow:
 2. **Identify segments** – create `segments_to_keep.json` selecting Secretary Nicholson's speech. The script cross-checks heuristics against recognized speakers and warns if they disagree. The JSON can be manually edited or converted to an editable format after this step.
 3. **Generate clips** – cut clips with fade-in/out.
 4. **Concatenate** – join clips together with white flashes in between.
-5. **Optional utilities** – annotate markup with `{START}`/`{END}` markers and generate a transcript summary of long clips.
+5. **Annotate markup** – create `markup_with_markers.txt` for the kept segments.
+6. **Clip transcripts** – summarize transcript lines for each long clip.
 
 ---
 
@@ -22,7 +23,7 @@ High-level workflow:
 
 - A transcription engine capable of producing JSON output
 - Command-line video processing tools for clipping and concatenation
-- Optional: access token for speaker diarization
+- Access token for speaker diarization
 
 ---
 
@@ -32,7 +33,7 @@ High-level workflow:
 
 - Automatically selects an appropriate compute mode based on the hardware architecture.
 - Transcribes the input video to produce `<input>.json` and `markup_guide.txt` with lines in the form `[start-end] SPEAKER: text`.
-- Supports optional diarization when provided with a token.
+- Always performs diarization using the provided access token.
 - Exits if the expected JSON file is not produced.
 
 ### Clip utilities
@@ -117,7 +118,8 @@ To recreate this project in another environment, follow these guidelines:
    - `segments_to_keep.json` listing the final clip boundaries
    - `clips/clip_XXX.mp4` files
    - `final_video.mp4`
-   - Optional: `markup_with_markers.txt` and `clip_transcripts.txt`
+   - `markup_with_markers.txt`
+   - `clip_transcripts.txt`
 7. **Environment** – ensure the video-processing binaries are accessible. Speaker diarization requires an authentication token when used.
 
 Adhering to these behaviors will yield a compatible replacement for the current VideoCut implementation.

--- a/tests/test_pipeline_recognition.py
+++ b/tests/test_pipeline_recognition.py
@@ -11,12 +11,15 @@ _spec.loader.exec_module(videocut_cli)
 import videocut.core.transcription as transcribe_mod
 import videocut.core.nicholson as nicholson_mod
 import videocut.core.video_editing as video_editing
+import videocut.core.chair as chair_mod
+import videocut.core.annotation as annotation_mod
+import videocut.core.clip_transcripts as clip_mod
 
 
 def test_pipeline_recognition(tmp_path, monkeypatch):
     json_file = tmp_path / "input.json"
 
-    def fake_transcribe(video, hf_token, diarize):
+    def fake_transcribe(video, hf_token, diarize=True, speaker_db=None):
         json_file.write_text(json.dumps({
             "segments": [
                 {"speaker": "A", "text": "director doe you're recognized"},
@@ -45,14 +48,15 @@ def test_pipeline_recognition(tmp_path, monkeypatch):
         return {"B": {"name": "Doe", "alternatives": []}}
 
     monkeypatch.setattr(nicholson_mod, "map_recognized_auto", fake_map)
+    monkeypatch.setattr(chair_mod, "parse_roll_call", lambda jf: {})
+    monkeypatch.setattr(annotation_mod, "annotate_segments", lambda a, b, c: called.setdefault("annotate", True))
+    monkeypatch.setattr(clip_mod, "clip_transcripts", lambda a, b, c: called.setdefault("clips_txt", True))
 
     monkeypatch.chdir(tmp_path)
 
     videocut_cli.pipeline(
         video="input.mp4",
-        diarize=True,
         hf_token="tok",
-        auto_nicholson=True,
     )
 
     assert called.get("map")


### PR DESCRIPTION
## Summary
- streamline README workflow steps
- remove optional behavior from pipeline command
- update pipeline recognition test
- document required diarization in specification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473a0af39083219c8dd04868cb2353