### PR TITLE
Add segments.txt workflow for clip generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ pip install -e .
 2. **Identify recognized speakers** – `videocut identify-recognized input.json`
    detects the chair from the roll call and writes `recognized_map.json` and
    `roll_call_map.json`.
-3. **Identify segments** – `videocut identify-segments input.json` creates
-   `segments_to_keep.json` grouping Secretary Nicholson's remarks.
-4. **Generate clips** – `videocut generate-clips input.mp4` cuts clips to `clips/`.
-5. **Concatenate** – `videocut concatenate` joins clips into `final_video.mp4`.
-6. **Annotate markup** – `videocut annotate-markup` writes `markup_with_markers.txt`.
-7. **Clip transcripts** – `videocut clip-transcripts` produces `clip_transcripts.txt`.
+3. **Identify segments** – `videocut identify-segments input.json` writes a
+   tab-indented `segments.txt` grouping Secretary Nicholson's remarks.
+4. *(Optional)* **Edit `segments.txt`** – trim or rearrange lines before
+   generating clips.
+5. **Generate clips** – `videocut generate-clips input.mp4` reads `segments.txt`
+   (and the matching SRT captions) and cuts clips to `clips/`.
+6. **Concatenate** – `videocut concatenate` joins clips into `final_video.mp4`.
+7. **Annotate markup** – `videocut annotate-markup` writes `markup_with_markers.txt`.
+8. **Clip transcripts** – `videocut clip-transcripts` produces `clip_transcripts.txt`.
 
 All of these steps run automatically with:
 ```bash

--- a/clip_transcripts.py
+++ b/clip_transcripts.py
@@ -3,6 +3,7 @@
 import json
 import re
 from pathlib import Path
+from videocut.core import segmentation
 
 
 def parse_line(line: str) -> dict | None:
@@ -20,7 +21,7 @@ def parse_line(line: str) -> dict | None:
 def main() -> None:
     """Write ``clip_transcripts.txt`` for the segments marked to keep."""
 
-    segments = json.loads(Path("segments_to_keep.json").read_text())
+    segments = segmentation.load_segments("segments.txt")
     lines = Path("markup_guide.txt").read_text().splitlines()
 
     entries = [parse_line(line) for line in lines if parse_line(line)]

--- a/videocut/core/clip_transcripts.py
+++ b/videocut/core/clip_transcripts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from . import segmentation
 
 
 _TS_RE = re.compile(r"\[(?P<start>\d+\.?\d*)[–-](?P<end>\d+\.?\d*)")
@@ -23,11 +24,12 @@ def parse_line(line: str) -> dict | None:
 
 def clip_transcripts(
     markup_file: str = "markup_guide.txt",
-    seg_json: str = "segments_to_keep.json",
+    seg_file: str = "segments.txt",
     out_file: str = "clip_transcripts.txt",
+    srt_file: str | None = None,
 ) -> None:
     """Write ``out_file`` listing transcript snippets for kept clips."""
-    segments = json.loads(Path(seg_json).read_text())
+    segments = segmentation.load_segments(seg_file, srt_file)
     lines = Path(markup_file).read_text().splitlines()
     entries = [e for l in lines if (e := parse_line(l))]
 


### PR DESCRIPTION
## Summary
- switch CLI and pipeline to produce `segments.txt` instead of a JSON file
- parse `segments.txt` with SRT captions via new `load_segments` helper
- update annotation and clip-transcript utilities to accept text segments
- document the simplified workflow

## Testing
- `PYTHONPATH=. pytest tests/test_may_board_meeting.py::test_may_board_meeting_segments -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847497643b08321a73ed0399c48e083