### PR TITLE
Handle typos in recognized names

### DIFF
--- a/board_members.txt
+++ b/board_members.txt
@@ -13,3 +13,7 @@ Lynn Guissinger
 Brett Paglieri
 Chris Gutschenritter
 JoyAnn Ruscha
+
+Debra Johnson
+Melanie Snyder
+Jack Kroll


### PR DESCRIPTION
## Summary
- support fuzzy matching of recognized names against official board/staff list
- expose helpers for board name loading and normalization
- include RTD staff in `board_members.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847745007ac83219b49f32caed3a9c4