### PR TITLE
Preserve diarization IDs when applying PDF transcript

### DIFF
--- a/videocut/core/pdf_utils.py
+++ b/videocut/core/pdf_utils.py
@@ -89,7 +89,7 @@ def apply_pdf_transcript_json(json_file: str, pdf_path: str, out_json: str | Non
     dialog = extract_transcript_dialogue(pdf_path)
     segs = data.get("segments", [])
     for seg, (speaker, line) in zip(segs, dialog):
-        seg["speaker"] = speaker
+        seg["label"] = speaker
         seg["text"] = line
     Path(out_json or json_file).write_text(json.dumps(data, indent=2))
     print(f"✅  transcript text replaced → {out_json or json_file}")

--- a/videocut/core/segmentation.py
+++ b/videocut/core/segmentation.py
@@ -19,7 +19,7 @@ def json_to_tsv(json_path: str, out_tsv: str = "input.tsv") -> None:
             wr.writerow([
                 seg.get("start"),
                 seg.get("end"),
-                seg.get("speaker", ""),
+                seg.get("label") or seg.get("speaker", ""),
                 str(seg.get("text", "")).replace("\n", " "),
                 "",
             ])
@@ -84,7 +84,7 @@ def json_to_editable(json_path: str, out_json: str = "segments_edit.json", marku
             content = "\n".join(content_lines).strip()
         else:
             content = str(seg.get("text", "")).strip()
-            speaker = seg.get("speaker", "")
+            speaker = seg.get("label") or seg.get("speaker", "")
             pre_lines = []
             post_lines = []
 

--- a/videocut/core/transcription.py
+++ b/videocut/core/transcription.py
@@ -69,7 +69,10 @@ def transcribe(
     with open("markup_guide.txt", "w") as g:
         for seg in segs:
             start, end = round(seg["start"], 2), round(seg["end"], 2)
-            speaker = seg.get("speaker", "SPEAKER") if diarize else "SPEAKER"
+            if diarize:
+                speaker = seg.get("label") or seg.get("speaker", "SPEAKER")
+            else:
+                speaker = "SPEAKER"
             text = seg["text"].strip().replace("\n", " ")
             g.write(f"[{start}-{end}] {speaker}: {text}\n")
     print("✅  markup_guide.txt ready – edit ranges or use TSV workflow")


### PR DESCRIPTION
## Summary
- keep WhisperX speaker IDs and store PDF names in `label`
- show PDF labels when available in segmentation and transcription utilities

## Testing
- `pytest -q`
- `pytest tests/test_may_board_meeting.py::test_may_board_meeting_segments -q`

------
https://chatgpt.com/codex/tasks/task_e_6849117758d48321815f4959a54f2aaa