### PR TITLE
Add segmentation evaluation test

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,12 @@
+{
+  "overall": 0.0,
+  "scores": [
+    0.0,
+    0.0
+  ]
+}\nTimestamp: Wed Jun 11 05:47:41 UTC 2025
+Commit: 612b69fa0be19638ff9aaf7321ab3997520efe6d
+identify-recognized failed with "No roll call detected".
+identify-segments succeeded.
+LLM segmentation produced only one short segment, giving overall score 0.0 compared to CLI output.
+Manual review: CLI segmentation correctly grouped Nicholson remarks. LLM approach failed to classify lines as Nicholson.

--- a/llm_segmentation.py
+++ b/llm_segmentation.py
@@ -1,0 +1,44 @@
+import re, json
+from pathlib import Path
+from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+
+MODEL = 'google/flan-t5-small'
+tokenizer = AutoTokenizer.from_pretrained(MODEL)
+model = AutoModelForSeq2SeqLM.from_pretrained(MODEL)
+
+lines = Path('videos/example/markup_guide.txt').read_text().splitlines()
+segments = []
+cur_start = None
+last_end = None
+
+for line in lines:
+    m = re.match(r"\[(\d+\.\d+)-(\d+\.\d+)\]\s*(.*)", line)
+    if not m:
+        continue
+    start = float(m.group(1))
+    end = float(m.group(2))
+    text = m.group(3)
+    prompt = (
+        "Secretary Nicholson is designated as SPEAKER_00. "
+        "Does this line show a statement from SPEAKER_00? "
+        "Answer yes or no only: " + text
+    )
+    inputs = tokenizer(prompt, return_tensors='pt')
+    outputs = model.generate(**inputs, max_length=5)
+    ans = tokenizer.decode(outputs[0], skip_special_tokens=True).strip().lower()
+    is_nicholson = ans.startswith('yes')
+    if is_nicholson:
+        if cur_start is None:
+            cur_start = start
+        last_end = end
+    else:
+        if cur_start is not None:
+            segments.append({'start': cur_start, 'end': last_end})
+            cur_start = None
+            last_end = None
+
+if cur_start is not None:
+    segments.append({'start': cur_start, 'end': last_end})
+
+Path('segments_llm.json').write_text(json.dumps(segments, indent=2))
+print(f"LLM segments -> segments_llm.json")

--- a/tests.md
+++ b/tests.md
@@ -1,0 +1,10 @@
+# Available Tests
+
+- `test_core.py`: verifies transcription helper functions and clip generation commands.
+- `test_speaker_mapping.py`: checks speaker mapping utilities and related CLI commands.
+- `test_chair_rollcall.py`: exercises chair identification and roll call parsing.
+- `test_segmentation_utils.py`: covers segmentation helper functions including text/JSON round trips.
+- `test_auto_segment_nicholson.py`: validates Nicholson segmentation heuristics.
+- `test_may_board_meeting.py::test_may_board_meeting_segments`: evaluates segmentation accuracy on the May_Board_Meeting example.
+- **Segmentation test**: run `videocut identify-recognized` and `videocut identify-segments` on `videos/example/example.mp4`,
+  attempt segmentation with an LLM, and compare the results. Logs written to `debug.log`.


### PR DESCRIPTION
## Summary
- add simple LLM-based segmentation script
- record segmentation results and evaluation in `debug.log`
- document available tests in `tests.md`

## Testing
- `pytest -q tests/test_may_board_meeting.py::test_may_board_meeting_segments`

------
https://chatgpt.com/codex/tasks/task_e_6849160803c48321a159dd3b51843754