### PR TITLE
Use transcript.txt for segment identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install -e .
      `[start‑end] NAME: text`.
    - WhisperX generates `May_Board_Meeting.json`, `May_Board_Meeting.tsv`,
      `May_Board_Meeting.srt`, `May_Board_Meeting.vtt` and `May_Board_Meeting.txt`.
-2. **Identify segments** – `videocut identify-segments May_Board_Meeting.json`
+2. **Identify segments** – `videocut identify-segments transcript.txt`
    - Creates a tab‑indented `segments.txt` containing `=START=` and `=END=`
      markers for each Nicholson segment.
 2a. *(optional)* Edit `segments.txt` to trim or reorder the segments.

--- a/READMEv2.md
+++ b/READMEv2.md
@@ -27,7 +27,7 @@ pip install -e .
 | Step | Command | Output |
 |------|---------|--------|
 | 1 | `videocut transcribe May_Board_Meeting.mp4 --pdf transcript.pdf` | `May_Board_Meeting.json` |
-| 2 | `videocut identify-segments May_Board_Meeting.json` | `segments.txt` (tab‑indented) |
+| 2 | `videocut identify-segments transcript.txt` | `segments.txt` (tab‑indented) |
 | 2a *(optional)* | *Edit* `segments.txt` to trim or reorder segments | — |
 | 3 | `videocut generate-clips May_Board_Meeting.mp4 segments.txt` | Clips and `timestamps.json` |
 | 4 | `videocut concatenate` | `final_video.mp4` |

--- a/tests/test_segmentation_utils.py
+++ b/tests/test_segmentation_utils.py
@@ -91,10 +91,13 @@ def test_cli_commands(tmp_path):
     videocut_cli.extract_marked(markup=str(markup), out=str(out2))
     assert out2.exists()
 
+    transcript = tmp_path / "transcript.txt"
+    transcript.write_text("[0-1] Nicholson: hi\n[1-2] Other: bye\n")
+
     cwd = Path.cwd()
     os.chdir(tmp_path)
     try:
-        videocut_cli.identify_segments_cmd(json_file=str(diarized))
+        videocut_cli.identify_segments_cmd(transcript=str(transcript))
     finally:
         os.chdir(cwd)
     assert (tmp_path / "segments.txt").exists()

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -155,14 +155,12 @@ def map_speakers(video: str, json_file: str, db: str = "speaker_db.json", out: O
 
 @app.command("identify-segments")
 def identify_segments_cmd(
-    json_file: str,
-    recognized: str = "recognized_map.json",
-    board_file: str = "board_members.txt",
+    transcript: str = "transcript.txt",
     out_txt: str = "segments.txt",
 ):
-    """Detect Nicholson segments using recognized speaker IDs."""
+    """Detect Nicholson segments using ``transcript.txt``."""
     tmp_json = Path(out_txt).with_suffix(".json")
-    nicholson.identify_segments(json_file, recognized, str(tmp_json), board_file)
+    nicholson.segment_nicholson_from_transcript(transcript, str(tmp_json))
     segmentation.segments_json_to_txt(str(tmp_json), out_txt)
     tmp_json.unlink(missing_ok=True)
 

--- a/videocut/core/nicholson.py
+++ b/videocut/core/nicholson.py
@@ -524,6 +524,104 @@ def load_markup(path: Path) -> List[dict]:
     return lines
 
 
+def _segment_entries(segs_data: List[dict], markup_lines: List[dict]) -> List[dict]:
+    """Return Nicholson segments from already parsed transcript entries."""
+    nicholson_id = find_nicholson_speaker(segs_data)
+    if nicholson_id is None:
+        print("❌  Nicholson speaker not found")
+        return []
+
+    results = []
+    n_idx = [i for i, seg in enumerate(segs_data) if seg.get("speaker") == nicholson_id]
+    if not n_idx:
+        return []
+
+    groups = []
+    start_idx = n_idx[0]
+    last_idx = n_idx[0]
+    for idx in n_idx[1:]:
+        prev_end = float(segs_data[last_idx]["end"])
+        cur_start = float(segs_data[idx]["start"])
+        if cur_start - prev_end >= MERGE_GAP_SEC:
+            groups.append((start_idx, last_idx))
+            start_idx = idx
+        last_idx = idx
+    groups.append((start_idx, last_idx))
+
+    for start_idx, last_idx in groups:
+        start_time = float(segs_data[start_idx]["start"])
+        end_time = float(segs_data[last_idx]["end"])
+
+        j = last_idx + 1
+        next_start = None
+        while j < len(segs_data):
+            seg = segs_data[j]
+            if seg.get("speaker") == nicholson_id:
+                break
+            text = seg.get("text", "")
+            if _recognizes_other(text):
+                next_start = (
+                    float(segs_data[j + 1]["start"]) if j + 1 < len(segs_data) else float(seg["end"])
+                )
+                break
+            if float(seg["start"]) - end_time >= MERGE_GAP_SEC and should_end(text):
+                end_time = float(seg["end"])
+                next_start = float(seg["start"])
+                break
+            end_time = float(seg["end"])
+            j += 1
+
+        if next_start is None and j < len(segs_data):
+            next_start = float(segs_data[j]["start"])
+        if next_start is not None:
+            end_time = min(end_time + TRAIL_SEC, next_start)
+        else:
+            end_time = end_time + TRAIL_SEC
+
+        end_time, segment_lines = trim_segment(start_time, end_time, markup_lines)
+        pre_lines = collect_pre(markup_lines, start_time)
+        post_lines = collect_post(markup_lines, end_time, next_start)
+
+        results.append(
+            {
+                "start": round(start_time, 2),
+                "end": round(end_time, 2),
+                "text": segment_lines,
+                "pre": pre_lines,
+                "post": post_lines,
+            }
+        )
+
+    return results
+
+
+def segment_nicholson_from_transcript(transcript_txt: str, out_json: str = "segments_to_keep.json") -> None:
+    """Identify Nicholson segments using ``transcript.txt``."""
+    entries = []
+    for line in Path(transcript_txt).read_text().splitlines():
+        m = _TS_RE.match(line)
+        if not m:
+            continue
+        rest = m.group("rest").strip()
+        speaker = ""
+        text = rest
+        if ":" in rest:
+            speaker, text = rest.split(":", 1)
+        entries.append(
+            {
+                "start": float(m.group("start")),
+                "end": float(m.group("end")),
+                "speaker": speaker.strip(),
+                "text": text.strip(),
+            }
+        )
+
+    markup_lines = load_markup(Path(transcript_txt))
+    segs = _segment_entries(entries, markup_lines)
+    Path(out_json).write_text(json.dumps(segs, indent=2))
+    print(f"✅  {len(segs)} segments → {out_json}")
+
+
 def collect_pre(segs: List[dict], start: float) -> List[str]:
     window = start - PRE_SEC
     return [s["line"] for s in segs if s["end"] <= start and s["end"] >= window]
@@ -644,75 +742,14 @@ def segment_nicholson(
     segs_data = data["segments"]
     markup_lines = load_markup(markup_path)
 
-    nicholson_id = find_nicholson_speaker(segs_data)
-    if nicholson_id is None:
-        nicholson_id = map_nicholson_speaker(str(in_path))
-
-    print(f"🔍  Secretary Nicholson identified as {nicholson_id}")
-
-    results = []
-    n_idx = [i for i, seg in enumerate(segs_data) if seg.get("speaker") == nicholson_id]
-    if not n_idx:
+    segs = _segment_entries(segs_data, markup_lines)
+    if not segs:
         out_path.write_text("[]")
         print("❌  No Nicholson segments found")
         return
 
-    groups = []
-    start_idx = n_idx[0]
-    last_idx = n_idx[0]
-    for idx in n_idx[1:]:
-        prev_end = float(segs_data[last_idx]["end"])
-        cur_start = float(segs_data[idx]["start"])
-        if cur_start - prev_end >= MERGE_GAP_SEC:
-            groups.append((start_idx, last_idx))
-            start_idx = idx
-        last_idx = idx
-    groups.append((start_idx, last_idx))
-
-    for start_idx, last_idx in groups:
-        start_time = float(segs_data[start_idx]["start"])
-        end_time = float(segs_data[last_idx]["end"])
-
-        j = last_idx + 1
-        next_start = None
-        while j < len(segs_data):
-            seg = segs_data[j]
-            if seg.get("speaker") == nicholson_id:
-                break
-            text = seg.get("text", "")
-            if _recognizes_other(text):
-                next_start = (
-                    float(segs_data[j + 1]["start"]) if j + 1 < len(segs_data) else float(seg["end"])
-                )
-                break
-            if float(seg["start"]) - end_time >= MERGE_GAP_SEC and should_end(text):
-                end_time = float(seg["end"])
-                next_start = float(seg["start"])
-                break
-            end_time = float(seg["end"])
-            j += 1
-
-        if next_start is None and j < len(segs_data):
-            next_start = float(segs_data[j]["start"])
-        if next_start is not None:
-            end_time = min(end_time + TRAIL_SEC, next_start)
-        else:
-            end_time = end_time + TRAIL_SEC
-
-        end_time, segment_lines = trim_segment(start_time, end_time, markup_lines)
-        pre_lines = collect_pre(markup_lines, start_time)
-        post_lines = collect_post(markup_lines, end_time, next_start)
-
-        results.append({
-            "start": round(start_time, 2),
-            "end": round(end_time, 2),
-            "text": segment_lines,
-            "pre": pre_lines,
-            "post": post_lines,
-        })
-
-    out_path.write_text(json.dumps(results, indent=2))
-    print(f"✅  {len(results)} segments → {out_path}")
+    out_path.write_text(json.dumps(segs, indent=2))
+    print(f"✅  {len(segs)} segments → {out_path}")
 
 
 def apply_name_map(seg_json: str, map_json: str, out_json: Optional[str] = None) -> None:
@@ -787,6 +824,7 @@ __all__ = [
     "map_recognized_auto",
     "add_speaker_labels",
     "auto_segments_for_speaker",
+    "segment_nicholson_from_transcript",
     "identify_segments",
     "find_nicholson_speaker",
     "segment_nicholson",


### PR DESCRIPTION
## Summary
- parse transcript.txt to find Nicholson segments
- expose `segment_nicholson_from_transcript` helper
- update CLI `identify-segments` to accept a transcript file
- document new workflow in READMEs
- adjust tests for new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb0d17b3083219122bd29630d5a48