### PR TITLE
Add segment CLI command

### DIFF
--- a/tests/test_segmentation_utils.py
+++ b/tests/test_segmentation_utils.py
@@ -144,3 +144,25 @@ def test_segments_txt_roundtrip(tmp_path):
 
     pairs = segmentation.segments_from_txt(str(txt))
     assert pairs == [(1, 2), (3, 3)]
+
+
+def test_segment_cli(tmp_path, monkeypatch):
+    diarized = tmp_path / "dia.json"
+    diarized.write_text("{}")
+
+    called = {}
+
+    def fake_identify(json_file, out_json):
+        called["json"] = json_file
+        Path(out_json).write_text("[]")
+
+    def fake_txt(json_file, out_txt):
+        called["txt"] = (json_file, out_txt)
+
+    monkeypatch.setattr(nicholson, "identify_nicholson_segments", fake_identify)
+    monkeypatch.setattr(segmentation, "segments_json_to_txt", fake_txt)
+
+    videocut_cli.segment(json_file=str(diarized))
+
+    assert called["json"] == str(diarized)
+    assert called["txt"] == ("segments_to_keep.json", "segments.txt")

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -240,6 +240,21 @@ def prune_segments_cmd(
 
 
 @app.command()
+def segment(
+    json_file: str = typer.Argument(..., help="WhisperX transcript JSON file"),
+    out_json: str = "segments_to_keep.json",
+    out_txt: str = "segments.txt",
+):
+    """Automatically segment video based on Nicholson's remarks and nearby responses."""
+    from .core.nicholson import identify_nicholson_segments
+    from .core.segmentation import segments_json_to_txt
+
+    identify_nicholson_segments(json_file, out_json)
+    segments_json_to_txt(out_json, out_txt)
+    print(f"✅ Segment boundaries saved to {out_txt}")
+
+
+@app.command()
 def recognized_directors(
     recognized: str = "recognized_map.json",
     board_file: str = "board_members.txt",

--- a/videocut/core/nicholson.py
+++ b/videocut/core/nicholson.py
@@ -760,6 +760,11 @@ def segment_nicholson(
     print(f"✅  {len(segs)} segments → {out_path}")
 
 
+def identify_nicholson_segments(json_file: str, out_json: str = "segments_to_keep.json") -> None:
+    """Alias for :func:`segment_nicholson` for backward compatibility."""
+    segment_nicholson(json_file, out_json)
+
+
 def apply_name_map(seg_json: str, map_json: str, out_json: Optional[str] = None) -> None:
     """Replace SPEAKER tokens in *seg_json* with names from *map_json*."""
     segs = json.loads(Path(seg_json).read_text())
@@ -833,6 +838,7 @@ __all__ = [
     "add_speaker_labels",
     "auto_segments_for_speaker",
     "segment_nicholson_from_transcript",
+    "identify_nicholson_segments",
     "identify_segments",
     "find_nicholson_speaker",
     "segment_nicholson",


### PR DESCRIPTION
## Summary
- add `segment` command to CLI for auto segmenting based on Nicholson
- expose `identify_nicholson_segments` wrapper in core
- test the new CLI command

## Testing
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu`
- `pip install whisperx==3.3.4`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d08a2fd0c8321931c122fafa1957c