### PR TITLE
Add segment command for extracting speaker segments

### DIFF
--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -241,17 +241,14 @@ def prune_segments_cmd(
 
 @app.command()
 def segment(
-    json_file: str = typer.Argument(..., help="WhisperX transcript JSON file"),
-    out_json: str = "segments_to_keep.json",
-    out_txt: str = "segments.txt",
+    json_file: str = typer.Argument(..., help="WhisperX transcript JSON"),
+    out: str = "segments.txt",
+    speaker: str = typer.Option("Nicholson", help="Speaker name to match (default: Nicholson)"),
 ):
-    """Automatically segment video based on Nicholson's remarks and nearby responses."""
-    from .core.nicholson import identify_nicholson_segments
-    from .core.segmentation import segments_json_to_txt
+    """Extract segments for a given speaker from WhisperX JSON"""
+    from .core.segmentation import extract_segments_from_json
 
-    identify_nicholson_segments(json_file, out_json)
-    segments_json_to_txt(out_json, out_txt)
-    print(f"✅ Segment boundaries saved to {out_txt}")
+    extract_segments_from_json(json_file, speaker, out)
 
 
 @app.command()

--- a/videocut/core/segmentation.py
+++ b/videocut/core/segmentation.py
@@ -159,6 +159,37 @@ def extract_marked(markup: str = "markup_guide.txt", out_json: str = "segments_t
     print(f"✅  {len(segs)} segment(s) → {out_json}")
 
 
+def extract_segments_from_json(json_file: str, speaker_match: str, out_txt: str = "segments.txt"):
+    data = json.loads(Path(json_file).read_text())
+    segments = data.get("segments", data)
+
+    output = []
+    active = False
+
+    for seg in segments:
+        speaker = seg.get("label") or seg.get("speaker", "")
+        if speaker_match.lower() in speaker.lower():
+            start = round(seg["start"], 2)
+            end = round(seg["end"], 2)
+            text = seg.get("text", "").strip()
+
+            if not active:
+                output.append("=START=")
+                active = True
+
+            output.append(f"[{start}-{end}] {speaker}: {text}")
+
+        elif active:
+            output.append("=END=")
+            active = False
+
+    if active:
+        output.append("=END=")
+
+    Path(out_txt).write_text("\n".join(output))
+    print(f"✅ wrote {out_txt} with {output.count('=START=')} segments")
+
+
 def segments_json_to_txt(json_file: str, out_txt: str = "segments.txt") -> None:
     """Write a text representation of segments for manual editing."""
     if not Path(json_file).exists():
@@ -274,6 +305,7 @@ __all__ = [
     "identify_clips",
     "identify_clips_json",
     "extract_marked",
+    "extract_segments_from_json",
     "segments_json_to_txt",
     "segments_from_txt",
     "load_segments",


### PR DESCRIPTION
## Summary
- add CLI command `segment` for extracting segments by speaker
- implement `extract_segments_from_json` helper
- adjust tests for updated CLI behavior

## Testing
- `python -m py_compile videocut/cli.py videocut/core/segmentation.py tests/test_segmentation_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684d0cfe91b483218f767c5e1b387943