### PR TITLE
Fix markup generation with speaker names

### DIFF
--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -49,6 +49,12 @@ def json_to_tsv(json_file: str, out: str = "input.tsv"):
 
 
 @app.command()
+def json_to_markup(json_file: str, out: str = "markup_guide.txt"):
+    """Generate ``markup_guide.txt`` from a diarized JSON file."""
+    segmentation.json_to_markup(json_file, out)
+
+
+@app.command()
 def identify_clips(tsv: str = "input.tsv", out: str = "segments_to_keep.json"):
     segmentation.identify_clips(tsv, out)
 
@@ -302,6 +308,10 @@ def pipeline(
     Path("recognized_map.json").write_text(json.dumps(ids, indent=2))
     roll = chair.parse_roll_call(json_file)
     Path("roll_call_map.json").write_text(json.dumps(roll, indent=2))
+
+    # Apply recognized names to the JSON and regenerate markup guide
+    nicholson.apply_name_map_json(json_file, "recognized_map.json", json_file)
+    segmentation.json_to_markup(json_file, "markup_guide.txt")
 
     tmp_json = "segments.json"
     nicholson.identify_segments(

--- a/videocut/core/segmentation.py
+++ b/videocut/core/segmentation.py
@@ -26,6 +26,25 @@ def json_to_tsv(json_path: str, out_tsv: str = "input.tsv") -> None:
     print(f"✅  {len(segs)} segment(s) → {out_tsv}")
 
 
+def json_to_markup(json_path: str, out_txt: str = "markup_guide.txt") -> None:
+    """Write ``out_txt`` with ``[start-end] SPEAKER: text`` lines from *json_path*."""
+    if not Path(json_path).exists():
+        sys.exit(f"❌  {json_path} not found")
+
+    data = json.loads(Path(json_path).read_text())
+    segs = data if isinstance(data, list) else data.get("segments", data)
+    lines = []
+    for seg in segs:
+        start = round(float(seg.get("start", 0)), 2)
+        end = round(float(seg.get("end", 0)), 2)
+        speaker = seg.get("label") or seg.get("speaker", "SPEAKER")
+        text = str(seg.get("text", "")).replace("\n", " ").strip()
+        lines.append(f"[{start}-{end}] {speaker}: {text}")
+
+    Path(out_txt).write_text("\n".join(lines))
+    print(f"✅  wrote {out_txt}")
+
+
 _TS_RE = re.compile(r"^\s*\[(?P<start>\d+\.?\d*)[–-](?P<end>\d+\.?\d*)\]\s*(?P<rest>.*)")
 PRE_SEC = 5
 TRAIL_SEC = 30
@@ -327,6 +346,7 @@ def load_segments(seg_file: str, srt_file: str | None = None) -> list[dict]:
 
 __all__ = [
     "json_to_tsv",
+    "json_to_markup",
     "json_to_editable",
     "write_segments_txt_from_editable",
     "identify_clips",


### PR DESCRIPTION
## Summary
- add `json_to_markup` helper to rebuild `markup_guide.txt` from a JSON transcript
- expose command via CLI
- update pipeline to apply name mapping and regenerate markup guide

## Testing
- `python -m videocut.cli json-to-markup videos/May_Board_Meeting/May_Board_Meeting.json --out /tmp/markup_cli.txt`

------
https://chatgpt.com/codex/tasks/task_e_684d1e289b30832189f3310e9f6d28a9