### PR TITLE
Fix PDF transcript application trimming extra segments

### DIFF
--- a/tests/test_pdf_utils.py
+++ b/tests/test_pdf_utils.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+from videocut.core import pdf_utils
+
+def test_apply_pdf_transcript_truncates(tmp_path, monkeypatch):
+    data = {
+        "segments": [
+            {"start": 0, "end": 1, "label": "A", "text": "foo"},
+            {"start": 1, "end": 2, "label": "B", "text": "bar"},
+            {"start": 2, "end": 3, "label": "C", "text": "baz"},
+        ]
+    }
+    json_file = tmp_path / "dia.json"
+    json_file.write_text(json.dumps(data))
+    pdf_file = tmp_path / "t.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+
+    monkeypatch.setattr(pdf_utils, "extract_transcript_dialogue", lambda p: [("X", "l1"), ("Y", "l2")])
+
+    pdf_utils.apply_pdf_transcript_json(str(json_file), str(pdf_file))
+
+    result = json.loads(json_file.read_text())
+    assert len(result["segments"]) == 2
+    assert result["segments"][0]["label"] == "X"
+    assert result["segments"][0]["text"] == "l1"
+    assert result["segments"][1]["label"] == "Y"
+    assert result["segments"][1]["text"] == "l2"

--- a/videocut/core/pdf_utils.py
+++ b/videocut/core/pdf_utils.py
@@ -86,6 +86,8 @@ def apply_pdf_transcript_json(json_file: str, pdf_path: str, out_json: str | Non
     for seg, (speaker, line) in zip(segs, dialog):
         seg["label"] = speaker
         seg["text"] = line
+    if len(dialog) < len(segs):
+        del segs[len(dialog):]
     Path(out_json or json_file).write_text(json.dumps(data, indent=2))
     print(f"✅  transcript text replaced → {out_json or json_file}")
 


### PR DESCRIPTION
## Summary
- trim segments that exceed the length of the PDF transcript
- add regression test for PDF transcript application

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684ddcb5c8108321b741ecfce244e1ec