### PR TITLE
Fix segment handling per guidelines

### DIFF
--- a/people.json
+++ b/people.json
@@ -1,0 +1,22 @@
+{
+  "board_members": [
+    "Julien Bouquet",
+    "Patrick O'Keefe",
+    "Troy Whitmore",
+    "Chris Nicholson",
+    "Karen Benker",
+    "Vince Buzek",
+    "Michael Guzman",
+    "Peggy Catlin",
+    "Ian Harwick",
+    "Kathleen Chandler",
+    "Matt Larsen",
+    "Lynn Guissinger",
+    "Brett Paglieri",
+    "Chris Gutschenritter",
+    "JoyAnn Ruscha",
+    "Debra Johnson",
+    "Melanie Snyder",
+    "Jack Kroll"
+  ]
+}

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -176,7 +176,7 @@ def identify_segments_cmd(
     if source.endswith(".json"):
         nicholson.identify_segments(source, recognized, str(tmp_json), board_file)
     else:
-        nicholson.segment_nicholson_from_transcript(source, str(tmp_json))
+        nicholson.segment_nicholson_from_transcript(source, str(tmp_json), board_file)
     segmentation.segments_json_to_txt(source, str(tmp_json), out_txt)
     tmp_json.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
- tighten Nicholson segmentation logic
- merge segments within 30s instead of 15s
- remove pre-roll time so segments start with Nicholson speaking
- load board members from people.json and stop segments when another board member is recognized

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2c2baf4c8321affb1707da93e457