### PR TITLE
Fix duplicated final transcript line

### DIFF
--- a/videocut/parse_pdf_text.py
+++ b/videocut/parse_pdf_text.py
@@ -48,7 +48,9 @@ def parse_pdf(pdf_path: str) -> list[str]:
                 break
             if has_date:
                 if current:
-                    lines.append(current)
+                    if not lines or lines[-1] != current:
+                        lines.append(current)
+                    current = None
                 break
         # Older PDFs include public comment email headers at the very end.
         # They usually appear after the bulk of the meeting, so keep the
@@ -56,7 +58,9 @@ def parse_pdf(pdf_path: str) -> list[str]:
         # lines has been processed.
         if len(lines) > 500 and any(line.startswith(p) for p in STOP_PREFIXES):
             if current:
-                lines.append(current)
+                if not lines or lines[-1] != current:
+                    lines.append(current)
+                current = None
             break
         m = SPEAKER_RE.match(line)
         if m:


### PR DESCRIPTION
## Summary
- avoid reappending final line when PDF parsing stops
- only append the last line if it's not already present

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9ad8373083219d30bfb40a3b148e