### PR TITLE
Fix punctuation strip warning

### DIFF
--- a/videocut/segmenter.py
+++ b/videocut/segmenter.py
@@ -86,7 +86,7 @@ def build_segments(rows: List[Dict[str, str]]) -> List[str]:
 
         # remember Nicholson end time
         if spk == NICH:
-            words = [w.strip(".,!?\,") for w in txt.lower().split()]
+            words = [w.strip(".,!?,") for w in txt.lower().split()]
             simple = {"thank", "thanks", "you", "chair", "bouquet"}
             substantive = len(words) > 3 or not set(words) <= simple
             has_enough_words = len(words) >= 10


### PR DESCRIPTION
## Summary
- fix invalid escape sequence in `segmenter.py`
- run segmentation tests

## Testing
- `pytest -q tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip`

------
https://chatgpt.com/codex/tasks/task_e_684eef00244c83219e9bc47bab6b3875