### PR TITLE
Update segmenter hand-off and glue rules

### DIFF
--- a/segmentation_rules.md
+++ b/segmentation_rules.md
@@ -2,10 +2,10 @@
 
 These rules describe how `segmenter.py` builds `segments.txt` for the Nicholson highlight reel.
 
-1. **Gluing** – If two Nicholson clips are less than 30 seconds apart, they are merged into a single segment. Material between them is included in that segment.
+1. **Gluing** – If two Nicholson clips are less than 30 seconds apart **or separated by four or fewer transcript lines**, they are merged into a single segment. Material between them is included in that segment.
 2. **Transcript Input** – Input lines may be flush-left or tab indented. Each non-marker output line is indented with a single tab.
 3. **Markers** – `=START=` and `=END=` appear flush-left and wrap kept segments.
-4. **Chair Hand‑off** – When the chair (`Julien Bouquet`) speaks a line beginning with "Director " or containing "thank you, secretary", the current segment ends just before that line.
+4. **Chair Hand‑off** – When the chair (`Julien Bouquet`) speaks a line beginning with "Director " or containing "thank you, secretary", the current segment ends just before that line **unless the chair is recognizing someone who is not a director on that line or the next**.
 5. **Opening a Segment** – A segment starts only when `Chris Nicholson` speaks a substantive line containing **at least ten words**. Short acknowledgements such as "Thank you, Chair" do not open a segment.
 6. **Closing the File** – If a segment remains open at the end of the transcript, an `=END=` marker is appended.
 


### PR DESCRIPTION
## Summary
- refine chair hand‑off detection so Nicholson segments do not end when the chair recognizes non‑directors
- glue Nicholson clips when the number of intervening transcript lines is four or fewer
- document the new behavior

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef2e1e6e48321b02f1bcd7f05e0f1