### PR TITLE
Allow recognition by title

### DIFF
--- a/segmentation_rules.md
+++ b/segmentation_rules.md
@@ -5,7 +5,7 @@ These rules describe how `segmenter.py` builds `segments.txt` for the Nicholson 
 1. **Gluing** – If two Nicholson clips are less than 30 seconds apart **or separated by four or fewer transcript lines**, they are merged into a single segment. Material between them is included in that segment.
 2. **Transcript Input** – Input lines may be flush-left or tab indented. Each non-marker output line is indented with a single tab.
 3. **Markers** – `=START=` and `=END=` appear flush-left and wrap kept segments.
-4. **Chair Hand‑off** – When the chair (`Julien Bouquet`) mentions a director by name and that director speaks next, the current segment ends just before the chair's line. Recognition of staff or non‑directors does not end the segment.
+4. **Chair Hand‑off** – When the chair (`Julien Bouquet`) mentions a director by name or by official title (for example, "Treasurer Benker") and that director speaks next, the current segment ends just before the chair's line. Recognition of staff or non‑directors does not end the segment.
 5. **Opening a Segment** – A segment starts only when `Chris Nicholson` speaks a substantive line containing **at least ten words**. Short acknowledgements such as "Thank you, Chair" do not open a segment.
 6. **Closing the File** – If a segment remains open at the end of the transcript, an `=END=` marker is appended.
 

--- a/videocut/segmenter.py
+++ b/videocut/segmenter.py
@@ -15,6 +15,7 @@ BOARD_LOWER = {n.lower() for n in BOARD}
 
 NICH = "Chris Nicholson"
 CHAIR = "Julien Bouquet"
+TITLES = ["director", "chair", "secretary", "treasurer"]
 GLUE = 30.0
 GLUE_LINES = 5  # glue if <=4 lines between Nicholson segments
 
@@ -67,20 +68,34 @@ def build_segments(rows: List[Dict[str, str]]) -> List[str]:
         # close segment just before chair hand-off
         if open_seg and spk == CHAIR:
             lower = txt.lower()
-            after = lower.split("thank you, secretary", 1)[-1]
+            after = lower
+            for prefix in (
+                "thank you, secretary",
+                "thank you, chair",
+                "thank you, treasurer",
+            ):
+                after = after.split(prefix, 1)[-1]
+
             recog_director = False
 
-            if after.strip().startswith("director ") or " director " in after:
+            if any(
+                after.strip().startswith(f"{t} ") or f" {t} " in after
+                for t in TITLES
+            ):
                 recog_director = True
             elif i + 1 < len(rows):
                 next_spk = rows[i + 1]["spk"].strip()
                 next_lower = next_spk.lower()
                 if next_spk not in {CHAIR, NICH} and next_lower in BOARD_LOWER:
-                    if any(f"director {part}" in lower for part in next_lower.split()):
+                    if any(
+                        f"{t} {part}" in lower
+                        for part in next_lower.split()
+                        for t in TITLES
+                    ):
                         recog_director = True
                 elif next_spk == CHAIR:
                     nxt = rows[i + 1]["txt"].strip().lower()
-                    if nxt.startswith("director "):
+                    if any(nxt.startswith(f"{t} ") for t in TITLES):
                         recog_director = True
 
             if recog_director:


### PR DESCRIPTION
## Summary
- support closing a Nicholson segment when the chair uses titles
- note in docs that titles like Treasurer may be used

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684efbe6dbe88321b5d19f76429daa86