### PR TITLE
Add word-level matching for PDF transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,22 @@ To regenerate `transcript.txt` from a diarized JSON and an official PDF:
 ```bash
 videocut json-to-transcript May_Board_Meeting.json transcript.pdf
 ```
+
+### Additional transcript utilities
+Use `pdf-extract` to create both a text and JSON version of a PDF transcript:
+```bash
+videocut pdf-extract transcript.pdf
+```
+
+You can align those PDF lines to a diarized JSON with `pdf-match`:
+```bash
+videocut pdf-match transcript.pdf May_Board_Meeting.json
+```
+This writes `matched.json` where each line's words are paired with their
+closest timestamped match from the JSON.
+
+Run `check-transcript` to flag segments with unusual timing:
+```bash
+videocut check-transcript May_Board_Meeting.json
+```
+This reports any segments whose words per second fall outside the normal range.

--- a/videocut/core/pdf_utils.py
+++ b/videocut/core/pdf_utils.py
@@ -13,6 +13,9 @@ __all__ = [
     "extract_transcript_dialogue",
     "apply_pdf_transcript_json",
     "write_timestamped_transcript",
+    "find_timing_anomalies",
+    "export_pdf_transcript",
+    "match_pdf_json",
 ]
 
 
@@ -32,7 +35,9 @@ def extract_speaker_names(pdf_path: str) -> Set[str]:
     return names
 
 
-def clean_recognized_map(mapping: dict, board_file: str | None = None, pdf_path: str | None = None) -> dict:
+def clean_recognized_map(
+    mapping: dict, board_file: str | None = None, pdf_path: str | None = None
+) -> dict:
     """Return a copy of *mapping* with normalized speaker names.
 
     Names are matched against the board member list and optionally against
@@ -42,17 +47,25 @@ def clean_recognized_map(mapping: dict, board_file: str | None = None, pdf_path:
     from difflib import get_close_matches
 
     board_map = load_board_map(board_file)
-    pdf_names = {n.lower(): n for n in extract_speaker_names(pdf_path)} if pdf_path else {}
+    pdf_names = (
+        {n.lower(): n for n in extract_speaker_names(pdf_path)} if pdf_path else {}
+    )
 
     result = {}
     for spk, info in mapping.items():
         name = info.get("name", "")
         name = normalize_recognized_name(name, board_map)
         if pdf_names:
-            match = get_close_matches(name.lower(), list(pdf_names.keys()), n=1, cutoff=0.8)
+            match = get_close_matches(
+                name.lower(), list(pdf_names.keys()), n=1, cutoff=0.8
+            )
             if match:
                 name = pdf_names[match[0]]
-        alts = [normalize_recognized_name(a, board_map) for a in info.get("alternatives", []) if a]
+        alts = [
+            normalize_recognized_name(a, board_map)
+            for a in info.get("alternatives", [])
+            if a
+        ]
         result[spk] = {"name": name, "alternatives": sorted(set(alts))}
     return result
 
@@ -78,7 +91,9 @@ def extract_transcript_dialogue(pdf_path: str) -> List[Tuple[str, str]]:
     return dialogue
 
 
-def apply_pdf_transcript_json(json_file: str, pdf_path: str, out_json: str | None = None) -> None:
+def apply_pdf_transcript_json(
+    json_file: str, pdf_path: str, out_json: str | None = None
+) -> None:
     """Replace transcript lines and speakers in ``json_file`` using *pdf_path*."""
     data = json.loads(Path(json_file).read_text())
     dialog = extract_transcript_dialogue(pdf_path)
@@ -87,7 +102,7 @@ def apply_pdf_transcript_json(json_file: str, pdf_path: str, out_json: str | Non
         seg["label"] = speaker
         seg["text"] = line
     if len(dialog) < len(segs):
-        del segs[len(dialog):]
+        del segs[len(dialog) :]
     Path(out_json or json_file).write_text(json.dumps(data, indent=2))
     print(f"✅  transcript text replaced → {out_json or json_file}")
 
@@ -188,3 +203,119 @@ def write_timestamped_transcript(
     print(
         f"✅  timestamped transcript → {out_txt or Path(pdf_path).with_suffix('.txt')}"
     )
+
+
+def find_timing_anomalies(
+    json_file: str, min_wps: float = 0.5, max_wps: float = 5.0
+) -> List[dict]:
+    """Return segments whose words-per-second fall outside ``min_wps`` and ``max_wps``."""
+
+    data = json.loads(Path(json_file).read_text())
+    segs = data.get("segments", data)
+    anomalies = []
+    for i, seg in enumerate(segs):
+        start = float(seg.get("start", 0))
+        end = float(seg.get("end", 0))
+        text = str(seg.get("text", ""))
+        words = len(text.split())
+        dur = end - start
+        wps = words / dur if dur > 0 else float("inf")
+        if wps < min_wps or wps > max_wps:
+            anomalies.append(
+                {
+                    "index": i,
+                    "start": start,
+                    "end": end,
+                    "wps": round(wps, 2),
+                    "text": text,
+                }
+            )
+    return anomalies
+
+
+def export_pdf_transcript(
+    pdf_path: str,
+    txt_out: str | None = None,
+    json_out: str | None = None,
+) -> List[dict]:
+    """Write a text and JSON version of *pdf_path* transcript."""
+
+    lines = extract_transcript_lines(pdf_path)
+    txt_file = txt_out or str(Path(pdf_path).with_name("pdf_transcript.txt"))
+    Path(txt_file).write_text("\n".join(lines) + "\n")
+
+    items = [{"text": line, "words": line.split()} for line in lines]
+    json_file = json_out or str(Path(pdf_path).with_name("pdf_transcript.json"))
+    Path(json_file).write_text(json.dumps(items, indent=2))
+    print(f"✅  transcript text → {txt_file}")
+    print(f"✅  transcript JSON → {json_file}")
+    return items
+
+
+def match_pdf_json(
+    pdf_path: str,
+    diarized_json: str,
+    out_json: str = "matched.json",
+) -> None:
+    """Match PDF transcript lines to segments in ``diarized_json``."""
+
+    def _norm(word: str) -> str:
+        return re.sub(r"[^\w']+", "", word).lower()
+
+    lines = export_pdf_transcript(pdf_path)
+    data = json.loads(Path(diarized_json).read_text())
+    segs = data.get("segments", data)
+
+    diar_words = []
+    for seg in segs:
+        if seg.get("words"):
+            diar_words.extend(seg["words"])
+        else:
+            txt_words = str(seg.get("text", "")).split()
+            start = float(seg.get("start", 0))
+            end = float(seg.get("end", 0))
+            dur = end - start
+            step = dur / len(txt_words) if txt_words else 0
+            for i, w in enumerate(txt_words):
+                diar_words.append(
+                    {
+                        "word": w,
+                        "start": start + i * step,
+                        "end": start + (i + 1) * step,
+                    }
+                )
+
+    result = []
+    j = 0
+    for item in lines:
+        pdf_words = item["words"]
+        window = diar_words[j : j + max(len(pdf_words) * 3, 1)]
+        sm = difflib.SequenceMatcher(
+            None, [_norm(w) for w in pdf_words], [_norm(w["word"]) for w in window]
+        )
+        words_out = []
+        j_offset = j
+        for tag, i1, i2, j1, j2 in sm.get_opcodes():
+            if tag == "equal":
+                for ii, jj in zip(range(i1, i2), range(j1, j2)):
+                    jw = window[jj]
+                    words_out.append(
+                        {
+                            "word": pdf_words[ii],
+                            "start": jw.get("start"),
+                            "end": jw.get("end"),
+                        }
+                    )
+                    j = j_offset + jj + 1
+            elif tag in ("replace", "delete"):
+                for ii in range(i1, i2):
+                    words_out.append({"word": pdf_words[ii], "start": None, "end": None})
+            elif tag == "insert":
+                j = j_offset + j2
+
+        start_ts = next((w["start"] for w in words_out if w["start"] is not None), None)
+        end_ts = next((w["end"] for w in reversed(words_out) if w["end"] is not None), None)
+        result.append({"text": item["text"], "start": start_ts, "end": end_ts, "words": words_out})
+
+    Path(out_json).write_text(json.dumps(result, indent=2))
+    print(f"✅  matched transcript → {out_json}")


### PR DESCRIPTION
## Summary
- align each PDF word to the nearest diarized word in `match_pdf_json`
- keep the `transcribe` command identical to the frozen version
- document that `pdf-match` creates a detailed `matched.json`

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684efde5431883219155ead96e4df49f