### PR TITLE
Fix missing difflib import

### DIFF
--- a/videocut/core/pdf_utils.py
+++ b/videocut/core/pdf_utils.py
@@ -2,6 +2,7 @@ import json
 import re
 from pathlib import Path
 from typing import List, Set, Tuple, Dict
+import difflib
 
 from pdfminer.high_level import extract_text
 from .. import parse_pdf_text


### PR DESCRIPTION
## Summary
- fix crash in `match_pdf_json` by importing `difflib`

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1b76946c8321a23d798b05073fe8