### PR TITLE
Fix transcript_json_to_txt for list input

### DIFF
--- a/videocut/core/pdf_utils.py
+++ b/videocut/core/pdf_utils.py
@@ -326,7 +326,10 @@ def match_pdf_json(
 def transcript_json_to_txt(json_path: str, out_txt: str = "transcript.txt") -> None:
     """Write ``out_txt`` from a matched transcript JSON file."""
     data = json.loads(Path(json_path).read_text())
-    segs = data.get("segments", data)
+    if isinstance(data, list):
+        segs = data
+    else:
+        segs = data.get("segments", data)
     lines = []
     for seg in segs:
         start = seg.get("start") or 0.0


### PR DESCRIPTION
## Summary
- allow transcript_json_to_txt to accept either dict or list JSON

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1fb138e0832191084d1f818e1740