### PR TITLE
Remove wrapper script

### DIFF
--- a/segmentation_rules.md
+++ b/segmentation_rules.md
@@ -1,6 +1,6 @@
 # Segmentation Rules
 
-These rules describe how `segmenter.py` builds `segments.txt` for the Nicholson highlight reel.
+These rules describe how the :mod:`videocut.segmenter` module builds `segments.txt` for the Nicholson highlight reel.
 
 1. **Gluing** – If two Nicholson clips are less than 30 seconds apart **or separated by four or fewer transcript lines**, they are merged into a single segment. Material between them is included in that segment.
 2. **Transcript Input** – Input lines may be flush-left or tab indented. Each non-marker output line is indented with a single tab.

--- a/segmenter.py
+++ b/segmenter.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-"""Compatibility wrapper for videocut.segmenter."""
-from videocut.segmenter import *
-
-if __name__ == "__main__":
-    from videocut.segmenter import main
-    main()

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -1,7 +1,10 @@
-import pathlib, subprocess, filecmp, shutil
+import pathlib
+import subprocess
+import filecmp
+import shutil
+import sys
 
 SEG = pathlib.Path('segments.txt')
-SRC = pathlib.Path('segmenter.py')
 
 
 def test_tab_indentation():
@@ -15,5 +18,5 @@ def test_tab_indentation():
 def test_roundtrip(tmp_path, monkeypatch):
     orig = tmp_path / 'orig.txt'
     shutil.copy(SEG, orig)
-    subprocess.run(['python', SRC], check=True)
+    subprocess.run([sys.executable, '-m', 'videocut.segmenter'], check=True)
     assert filecmp.cmp(SEG, orig), 'Round-trip changed segments.txt'


### PR DESCRIPTION
## Summary
- document that segments come from `videocut.segmenter`
- call module in `tests/test_segments.py` instead of wrapper
- delete obsolete `segmenter.py` wrapper

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684e926111dc8321bb595d5efd2e47d3