### PR TITLE
Improve DTW alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ For raw SRT captions you can perform a band-limited DTW alignment with:
 ```bash
 videocut dtw-align pdf_transcript.txt May_Board_Meeting.srt
 ```
-which writes `matched_dtw.json` and `dtw-transcript.txt` ready for
-`videocut segment`.
+This generates `matched_dtw.json` and `dtw-transcript.txt` ready for
+`videocut segment`.  Token timestamps are evenly spread across each
+caption's duration for better alignment accuracy.
 
 ### 3 · Match (NEW)
 


### PR DESCRIPTION
## Summary
- distribute SRT token times evenly across caption duration
- fix DTW backtrace search beyond band width
- document dtw-align improvements

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa8a6efa4832182c55726961e7914