### PR TITLE
Fix DTW alignment band width

### DIFF
--- a/videocut/core/dtw_align.py
+++ b/videocut/core/dtw_align.py
@@ -69,6 +69,10 @@ def _banded_dtw(src: List[str], ref: List[str], band: int = 100):
     cost = 0 if words equal else 1
     """
     n, m = len(src), len(ref)
+    # ensure the band is wide enough to cover length differences
+    if abs(n - m) > band:
+        band = abs(n - m)
+
     big = n + m + 1
     dp  = np.full((n+1, 2*band+1), big, np.int32)
     path = np.full((n+1, 2*band+1), -1, np.int16)   # 0=diag,1=up,2=left


### PR DESCRIPTION
## Summary
- expand DTW search band when the two sequences differ greatly

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa9d74e8c8321b81b821c78efeeee