### PR TITLE
Fix dtw-align for lines without speaker label

### DIFF
--- a/videocut/core/convert.py
+++ b/videocut/core/convert.py
@@ -19,8 +19,16 @@ def matched_to_txt(matched_json: str | Path,
             if rec.get("start") is None:
                 fh.write(f"# UNMATCHED: {rec['text']}\n")
                 continue
-            speaker, body = rec["text"].split(":", 1)
+
+            text = rec.get("text", "")
+            if ":" in text:
+                speaker, body = text.split(":", 1)
+                speaker = speaker.strip()
+                body = body.strip()
+                line = f"{speaker}: {body}"
+            else:
+                line = text.strip()
+
             fh.write(
-                f"\t[{fmt(rec['start'])}-{fmt(rec['end'])}] "
-                f"{speaker.strip()}: {body.strip()}\n"
+                f"\t[{fmt(rec['start'])}-{fmt(rec['end'])}] {line}\n"
             )


### PR DESCRIPTION
## Summary
- handle matched lines without `speaker:` prefix when converting to text

## Testing
- `pytest tests/test_segments_format.py::test_segments_format tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684faaf9bba483218f5c74dcb953f6d0