### PR TITLE
Add label fix helper and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ For raw SRT captions you can perform a band-limited DTW alignment with:
 ```bash
 videocut dtw-align pdf_transcript.txt May_Board_Meeting.srt
 ```
-This generates `matched_dtw.json` and `dtw-transcript.txt` ready for
-`videocut segment`.  Token timestamps are evenly spread across each
-caption's duration for better alignment accuracy.
+This generates `matched_dtw.json`. Token timestamps are evenly spread across each
+caption's duration for better alignment accuracy. Use ``make-labeled`` to create
+a speaker-tagged transcript:
+```bash
+videocut make-labeled matched_dtw.json -o dtw_transcript_labeled.txt
+```
+The resulting ``dtw_transcript_labeled.txt`` is ready for ``videocut segment``.
 
 ### 3 · Match (NEW)
 
@@ -107,10 +111,19 @@ videocut to-txt matched.json       # ⇒ transcript.txt
 
 `transcript.txt` is the input expected by **`videocut segment`**.
 
+### 5 · Make Labeled Transcript (NEW)
+
+```bash
+videocut make-labeled matched.json -o labeled_transcript.txt
+```
+
+Use this when a matched JSON is missing speaker tags. The output can be fed
+directly to ``videocut segment``.
+
 The full pipeline is now:
 
 ```
-transcribe  →  match/dtw-align  →  to-txt  →  segment  →  generate-clips  →  concatenate
+transcribe  →  match/dtw-align  →  make-labeled  →  segment  →  generate-clips  →  concatenate
 ```
 
 ### 6 · Install / Run Cheat-sheet
@@ -118,8 +131,9 @@ transcribe  →  match/dtw-align  →  to-txt  →  segment  →  generate-clips
 ```bash
 pip install -e .
 videocut match pdf_transcript.json May_Board_Meeting.json -o matched.json
-videocut to-txt matched.json -o transcript.txt
+videocut make-labeled matched.json -o transcript.txt
 videocut dtw-align pdf_transcript.txt May_Board_Meeting.srt
+videocut make-labeled matched_dtw.json -o dtw_transcript.txt
 videocut segment transcript.txt
 videocut generate-clips transcript.txt
 videocut concatenate transcript.txt

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -8,6 +8,7 @@ import typer
 from videocut.core.align import align_pdf_to_asr
 from videocut.core.dtw_align import align_pdf_to_srt
 from videocut.core.convert import matched_to_txt
+from videocut.core.label_fix import labelify
 from .core import (
     transcription,
     segmentation,
@@ -257,6 +258,35 @@ def to_txt_cli(
     """
     matched_to_txt(matched_json, out)
     typer.echo(f"✅ wrote {out}")
+
+
+@app.command("make-labeled")
+def make_labeled(
+    matched_json: Path = typer.Argument(
+        ...,
+        exists=True,
+        readable=True,
+        help="matched_DTW.json or any match output",
+    ),
+    out_file: Path = typer.Option(
+        "labeled_transcript.txt",
+        "--out",
+        "-o",
+        help="Destination TXT file",
+    ),
+    default: str = typer.Option(
+        "Unknown",
+        help="Fallback speaker when no prior label is available",
+    ),
+) -> None:
+    """
+    Ensure every line has an explicit speaker tag.
+
+    Output line format:
+        Speaker<TAB>[start-end]<TAB>utterance
+    """
+    labelify(matched_json, out_file, default_speaker=default)
+    typer.echo(f"✅ wrote {out_file}")
 
 
 @app.command("align")

--- a/videocut/core/label_fix.py
+++ b/videocut/core/label_fix.py
@@ -1,0 +1,38 @@
+"""
+Fix speaker labels in a `matched_*.json` file produced by
+videocut dtw-align / match.  Output format (one line per utterance):
+
+    Speaker<TAB>[start-end]<TAB>utterance text
+"""
+
+from __future__ import annotations
+import json, re
+from pathlib import Path
+
+
+label_rx = re.compile(r"\s*([A-Za-z][A-Za-z0-9 .',\-]{1,50}):\s*(.*)")
+
+
+def labelify(
+    matched_json: str | Path,
+    out_path: str | Path,
+    *,
+    default_speaker: str = "Unknown",
+) -> None:
+    data = json.loads(Path(matched_json).read_text())
+    last_speaker = default_speaker
+    out_lines = []
+
+    for rec in data:
+        text = rec["text"].strip()
+        m = label_rx.match(text)
+        if m:
+            speaker, body = m.group(1).strip(), m.group(2).strip()
+            last_speaker = speaker
+        else:
+            speaker, body = last_speaker, text
+        out_lines.append(
+            f"{speaker}\t[{rec['start']:.3f}-{rec['end']:.3f}]\t{body}"
+        )
+
+    Path(out_path).write_text("\n".join(out_lines), encoding="utf-8")

--- a/videocut/segmenter.py
+++ b/videocut/segmenter.py
@@ -22,6 +22,9 @@ GLUE_LINES = 5  # glue if <=4 lines between Nicholson segments
 pat = re.compile(
     r"\[(?P<start>[^\]-]+)\s*-\s*(?P<end>[^\]]+)\]\s*(?P<spk>[^:]+):\s*(?P<txt>.*)"
 )
+pat_labeled = re.compile(
+    r"(?P<spk>[^\t]+)\t\[(?P<start>[^\]-]+)\s*-\s*(?P<end>[^\]]+)\]\t(?P<txt>.*)"
+)
 
 
 def to_sec(ts: str) -> float:
@@ -38,7 +41,10 @@ def load_rows(path: str = "transcript.txt") -> List[Dict[str, str]]:
     if not p.exists():
         return rows
     for raw in p.read_text().splitlines():
-        m = pat.match(raw.lstrip("\t"))
+        stripped = raw.lstrip("\t")
+        m = pat_labeled.match(stripped)
+        if not m:
+            m = pat.match(stripped)
         if not m:
             continue
         d = m.groupdict()


### PR DESCRIPTION
## Summary
- add `core/label_fix.py` for fixing labels in matched transcripts
- expose new `make-labeled` command in `cli.py`
- allow `segmenter.load_rows` to parse tab‑separated labeled transcripts

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684fadd4271c83218ae32fb3c871fed7