### PR TITLE
Fix dtw-align performance and speaker detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
   "pdfminer.six",
   "rapidfuzz",
   "numpy",
-  "python-dateutil"
+  "python-dateutil",
+  "fastdtw"
 ]
 
 [project.optional-dependencies]

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -225,7 +225,7 @@ def dtw_align(
     srt_path: Path = typer.Argument(..., exists=True, readable=True),
     json_out: Path = typer.Option("matched_dtw.json", "--json-out", "-j"),
     txt_out: Path = typer.Option("dtw-transcript.txt", "--txt-out", "-t"),
-    band: int = typer.Option(100, help="DTW half-band width (tokens)"),
+    band: int = typer.Option(10, help="DTW radius for fastdtw"),
 ):
     """Advanced banded-DTW word-level alignment of PDF to SRT.
 

--- a/videocut/core/dtw_align.py
+++ b/videocut/core/dtw_align.py
@@ -19,22 +19,25 @@ import re, unicodedata
 from pathlib import Path
 from typing import List, Tuple
 import numpy as np
+from fastdtw import fastdtw
 
 # ---------------------------------------------------------------------
 def _norm(tok: str) -> str:
     tok = unicodedata.normalize("NFKD", tok).lower()
     return re.sub(r"[^\w']", "", tok)
 
-def _tokenize_pdf(pdf_txt: str) -> Tuple[List[str], List[Tuple[int,int]]]:
-    """Returns tokens and sentence-start indices."""
+def _tokenize_pdf(pdf_txt: str) -> Tuple[List[str], List[str], List[Tuple[int, int]]]:
+    """Return normalized tokens, raw tokens, and sentence boundaries."""
     sentences = re.split(r'(?<=[.!?])\s+(?=[A-Z])', pdf_txt.strip())
-    tokens, sent_bounds = [], []
+    norm_tokens, raw_tokens, sent_bounds = [], [], []
     for sent in sentences:
-        start_idx = len(tokens)
-        toks = [_norm(t) for t in sent.split() if _norm(t)]
-        tokens.extend(toks)
-        sent_bounds.append((start_idx, len(tokens)-1))
-    return tokens, sent_bounds
+        start_idx = len(norm_tokens)
+        raw_toks = sent.split()
+        norm_toks = [_norm(t) for t in raw_toks if _norm(t)]
+        raw_tokens.extend(raw_toks)
+        norm_tokens.extend(norm_toks)
+        sent_bounds.append((start_idx, len(norm_tokens) - 1))
+    return norm_tokens, raw_tokens, sent_bounds
 
 def _parse_srt(path: str | Path):
     pat = re.compile(
@@ -64,74 +67,31 @@ def _hms_to_sec(hms: str) -> float:
 
 # ---------------------------------------------------------------------
 def _banded_dtw(src: List[str], ref: List[str], band: int = 100):
+    """Approximate DTW alignment using ``fastdtw``.
+
+    ``fastdtw`` runs in O(N) time and memory.  We treat token equality as
+    distance 0 and mismatch as 1.  The ``band`` parameter becomes the
+    ``radius`` used by ``fastdtw``.
     """
-    Banded DTW returning best path mapping indices of src→ref.
-    cost = 0 if words equal else 1
-    """
-    n, m = len(src), len(ref)
-    # ensure the band is wide enough to cover length differences
-    if abs(n - m) > band:
-        band = abs(n - m)
 
-    big = n + m + 1
-    dp  = np.full((n+1, 2*band+1), big, np.int32)
-    path = np.full((n+1, 2*band+1), -1, np.int16)   # 0=diag,1=up,2=left
+    # ``fastdtw`` expects numeric inputs, so map tokens to integers
+    vocab = {t: i for i, t in enumerate({*src, *ref})}
+    src_idx = [vocab[t] for t in src]
+    ref_idx = [vocab[t] for t in ref]
 
-    def idx(j,i):
-        """column offset for ref-idx j at src-idx i"""
-        return j - i + band
-
-    dp[0, band] = 0
-    for i in range(n + 1):
-        for j in range(max(0, i - band), min(m, i + band) + 1):
-            k = idx(j, i)
-            if dp[i, k] == big:
-                continue
-            # diag
-            if i < n and j < m:
-                cost = 0 if src[i] == ref[j] else 1
-                dk = idx(j + 1, i + 1)
-                if 0 <= dk <= 2 * band and dp[i, k] + cost < dp[i + 1, dk]:
-                    dp[i + 1, dk] = dp[i, k] + cost
-                    path[i + 1, dk] = 0
-            # up (src advance)
-            if i < n:
-                uk = idx(j, i + 1)
-                if 0 <= uk <= 2 * band and dp[i, k] + 1 < dp[i + 1, uk]:
-                    dp[i + 1, uk] = dp[i, k] + 1
-                    path[i + 1, uk] = 1
-            # left (ref advance)
-            if j < m:
-                lk = idx(j + 1, i)
-                if 0 <= lk <= 2 * band and dp[i, k] + 1 < dp[i, lk]:
-                    dp[i, lk] = dp[i, k] + 1
-                    path[i, lk] = 2
-
-    # back-trace
-    j_range = range(max(0, n - band), min(m, n + band) + 1)
-    i, j = n, min(j_range, key=lambda jj: dp[n, idx(jj, n)])
-    align = []
-    while i > 0 or j > 0:
-        k = idx(j, i)
-        move = path[i, k]
-        if move == 0:
-            align.append((i-1, j-1))
-            i, j = i-1, j-1
-        elif move == 1:
-            i -= 1
-        else:
-            j -= 1
-    return list(reversed(align))
+    dist = lambda a, b: 0 if a == b else 1
+    _dist, path = fastdtw(src_idx, ref_idx, radius=band, dist=dist)
+    return path
 
 # ---------------------------------------------------------------------
 def align_pdf_to_srt(pdf_txt: str | Path,
                      srt_file: str | Path,
                      *,
-                     band: int = 100) -> List[dict]:
-    pdf_tokens, pdf_bounds  = _tokenize_pdf(Path(pdf_txt).read_text())
-    srt_tokens, srt_times   = _parse_srt(srt_file)
+                     band: int = 10) -> List[dict]:
+    pdf_norm, pdf_raw, pdf_bounds = _tokenize_pdf(Path(pdf_txt).read_text())
+    srt_tokens, srt_times = _parse_srt(srt_file)
 
-    mapping = _banded_dtw(pdf_tokens, srt_tokens, band=band)
+    mapping = _banded_dtw(pdf_norm, srt_tokens, band=band)
     # mapping[i] = (pdf_idx, srt_idx)
 
     pdf2time = {}
@@ -140,7 +100,7 @@ def align_pdf_to_srt(pdf_txt: str | Path,
 
     # propagate unmatched pdf tokens forward
     last_t = 0.0
-    for i in range(len(pdf_tokens)):
+    for i in range(len(pdf_norm)):
         if i in pdf2time:
             last_t = pdf2time[i]
         else:
@@ -152,7 +112,7 @@ def align_pdf_to_srt(pdf_txt: str | Path,
     for start_tok, end_tok in pdf_bounds:
         st = pdf2time[start_tok]
         et = pdf2time[end_tok]
-        sentence = " ".join(pdf_tokens[start_tok:end_tok+1])
+        sentence = " ".join(pdf_raw[start_tok:end_tok+1])
         out.append(dict(text=sentence,
                         start=st,
                         end=et))

--- a/videocut/core/label_fix.py
+++ b/videocut/core/label_fix.py
@@ -10,7 +10,9 @@ import json, re
 from pathlib import Path
 
 
-label_rx = re.compile(r"\s*([A-Za-z][A-Za-z0-9 .',\-]{1,50}):\s*(.*)")
+# Speaker lines appear at the start of a sentence as ``Name: text``.  The
+# colon is followed by a space, which avoids matching timestamps like ``7:00``.
+label_rx = re.compile(r"^\s*([A-Za-z][A-Za-z0-9 .',\-]{1,50}):\s+(.*)")
 
 
 def labelify(


### PR DESCRIPTION
## Summary
- speed up `dtw-align` by using `fastdtw`
- keep raw tokens so speaker labels are preserved
- avoid mis-labeling timestamps with an improved regex
- tweak CLI defaults
- add `fastdtw` dependency

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb5b3806883218212ebb452372d0b