### PR TITLE
Fix dtw-align speaker labeling

### DIFF
--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -8,7 +8,7 @@ import typer
 from videocut.core.align import align_pdf_to_asr
 from videocut.core.dtw_align import align_pdf_to_srt
 from videocut.core.convert import matched_to_txt
-from videocut.core.label_fix import labelify
+from videocut.core.label_fix import labelify, pdf_labels, validate_txt_labels
 from .core import (
     transcription,
     segmentation,
@@ -233,7 +233,9 @@ def dtw_align(
     """
     aligned = align_pdf_to_srt(pdf_txt, srt_path, band=band)
     json_out.write_text(json.dumps(aligned, indent=2))
-    labelify(json_out, txt_out)
+    labels = pdf_labels(pdf_txt)
+    labelify(json_out, txt_out, valid_labels=labels)
+    validate_txt_labels(txt_out, labels)
     typer.echo(
         f"✅ wrote {json_out} and {txt_out} with {len(aligned)} sentences"
     )

--- a/videocut/core/label_fix.py
+++ b/videocut/core/label_fix.py
@@ -14,12 +14,38 @@ from pathlib import Path
 # colon is followed by a space, which avoids matching timestamps like ``7:00``.
 label_rx = re.compile(r"^\s*([A-Za-z][A-Za-z0-9 .',\-]{1,50}):\s+(.*)")
 
+def pdf_labels(pdf_path: str | Path) -> set[str]:
+    """Return the set of speaker labels found in ``pdf_path``."""
+    labels: set[str] = set()
+    for line in Path(pdf_path).read_text().splitlines():
+        m = label_rx.match(line.strip())
+        if m:
+            labels.add(m.group(1).strip())
+    return labels
+
+def validate_txt_labels(txt_path: str | Path, valid_labels: set[str]) -> bool:
+    """Return True if all speaker labels in ``txt_path`` are valid."""
+    bad: list[tuple[int, str]] = []
+    for i, line in enumerate(Path(txt_path).read_text().splitlines(), 1):
+        label = line.split("\t", 1)[0].strip()
+        if label and label not in valid_labels:
+            bad.append((i, label))
+
+    if bad:
+        print("⚠️  invalid speaker labels found:")
+        for line_no, label in bad:
+            print(f"  line {line_no}: '{label}' not in transcript")
+    else:
+        print("✅ all speaker labels valid")
+    return not bad
+
 
 def labelify(
     matched_json: str | Path,
     out_path: str | Path,
     *,
     default_speaker: str = "Unknown",
+    valid_labels: set[str] | None = None,
 ) -> None:
     data = json.loads(Path(matched_json).read_text())
     last_speaker = default_speaker
@@ -28,11 +54,21 @@ def labelify(
     for rec in data:
         text = rec["text"].strip()
         m = label_rx.match(text)
+        speaker, body = last_speaker, text
         if m:
-            speaker, body = m.group(1).strip(), m.group(2).strip()
-            last_speaker = speaker
-        else:
-            speaker, body = last_speaker, text
+            cand = m.group(1).strip()
+            remainder = m.group(2).strip()
+            if valid_labels and cand not in valid_labels:
+                for lbl in valid_labels:
+                    if cand.endswith(lbl):
+                        cand = lbl
+                        remainder = text.split(lbl + ":", 1)[1].strip()
+                        break
+                else:
+                    pass
+            if not valid_labels or cand in valid_labels:
+                speaker, body = cand, remainder
+                last_speaker = speaker
         out_lines.append(
             f"{speaker}\t[{rec['start']:.3f}-{rec['end']:.3f}]\t{body}"
         )

--- a/videos/May_Board_Meeting/dtw-transcript.txt
+++ b/videos/May_Board_Meeting/dtw-transcript.txt
@@ -1,31 +1,12 @@
-Julien Bouquet	[0.335-33.677]	I'll now call the Wednesday, May 28 RTD Board meeting to order.
-Julien Bouquet	[34.076-35.395]	We're convened as of 7:00 PM.
-Julien Bouquet	[35.839-41.349]	I would respectfully ask everyone to remain muted unless you're recognized to speak.
-Julien Bouquet	[41.848-43.987]	Thank you all for joining us this evening.
-Julien Bouquet	[44.913-57.144]	As the Board has moved to in-person meetings for monthly gatherings, please note that committee meetings of the RTD Board of Directors will still be held remotely via Zoom, and will be audio and video recorded.
-Julien Bouquet	[58.267-65.498]	The meeting recordings, along with the unofficial minutes of the meetings, will be posted as soon as practical on the Board's website.
-Julien Bouquet	[66.343-66.781]	Visit rtd-denver.com.
-Julien Bouquet	[67.220-72.918]	And a livestream of this meeting is also available via RTD's YouTube page.
-Julien Bouquet	[74.011-78.754]	During tonight's meeting, we're also providing communication access real-time translation, also known as CART.
-Julien Bouquet	[79.860-90.127]	Anyone who would like to access this service should send an email to the RTD Board Office at rtd.boardoffice@rtd-denver.com and a link will be provided.
-Julien Bouquet	[91.259-100.915]	Additionally, the CART transcript can be automatically translated into Spanish for anyone who would like access to a live transcript of this meeting in Spanish.
-Julien Bouquet	[102.243-106.302]	I'll now ask Secretary Nicholson, could you please lead us in the Pledge of Allegiance?
-Chris Nicholson	[111.963-120.340]	I pledge allegiance to the flag of the United States of America, and to the Republic for which it stands.
-Chris Nicholson	[120.781-128.872]	One nation, under God, indivisible, with liberty and justice for all.
-Julien Bouquet	[128.872-129.366]	Thank you, Secretary.
-Julien Bouquet	[130.735-133.430]	I will now read the land acknowledgment.
-Julien Bouquet	[134.660-146.636]	The RTD Board of Directors acknowledges the land on which our buses and trains operate is their traditional territory of the Ute, Cheyenne, Arapaho, and other contemporary tribal nations that are historically tied to these lands.
-Julien Bouquet	[147.759-154.738]	We honor our Indigenous elders who have traveled, inhabited, and stewarded these mountains, hills, and plains throughout generations.
-Julien Bouquet	[155.635-169.157]	May this acknowledgment demonstrate a commitment to working to dismantle the ongoing legacies of inequity of the Native and all historically oppressed peoples, and recognize their current and future contributions in the district as we move forward.
-Julien Bouquet	[170.694-171.383]	I'll now call the roll.
-Julien Bouquet	[171.856-172.156]	Treasurer Benker.
+Julien Bouquet	[0.335-106.302]	I'll now call the Wednesday, May 28 RTD Board meeting to order. We're convened as of 7:00 PM. I would respectfully ask everyone to remain muted unless you're recognized to speak. Thank you all for joining us this evening. As the Board has moved to in-person meetings for monthly gatherings, please note that committee meetings of the RTD Board of Directors will still be held remotely via Zoom, and will be audio and video recorded. The meeting recordings, along with the unofficial minutes of the meetings, will be posted as soon as practical on the Board's website. Visit rtd-denver.com. And a livestream of this meeting is also available via RTD's YouTube page. During tonight's meeting, we're also providing communication access real-time translation, also known as CART. Anyone who would like to access this service should send an email to the RTD Board Office at rtd.boardoffice@rtd-denver.com and a link will be provided. Additionally, the CART transcript can be automatically translated into Spanish for anyone who would like access to a live transcript of this meeting in Spanish. I'll now ask Secretary Nicholson, could you please lead us in the Pledge of Allegiance?
+Chris Nicholson	[111.963-128.872]	I pledge allegiance to the flag of the United States of America, and to the Republic for which it stands. One nation, under God, indivisible, with liberty and justice for all.
+Julien Bouquet	[128.872-172.156]	Thank you, Secretary. I will now read the land acknowledgment. The RTD Board of Directors acknowledges the land on which our buses and trains operate is their traditional territory of the Ute, Cheyenne, Arapaho, and other contemporary tribal nations that are historically tied to these lands. We honor our Indigenous elders who have traveled, inhabited, and stewarded these mountains, hills, and plains throughout generations. May this acknowledgment demonstrate a commitment to working to dismantle the ongoing legacies of inequity of the Native and all historically oppressed peoples, and recognize their current and future contributions in the district as we move forward. I'll now call the roll. Treasurer Benker.
 Karen Benker	[173.278-173.278]	Present.
 Julien Bouquet	[174.299-174.620]	Director Buzek.
 Vince Buzek	[175.380-175.380]	Here.
 Julien Bouquet	[175.641-176.341]	Director Catlin.
 Peggy Catlin	[176.341-177.703]	Here.
-Julien Bouquet	[179.105-181.107]	Director Chandler is an excused absence.
-Julien Bouquet	[183.125-183.495]	Director Guissinger.
+Julien Bouquet	[179.105-183.495]	Director Chandler is an excused absence. Director Guissinger.
 Lynn Guissinger	[184.247-184.247]	Here.
 Julien Bouquet	[184.627-186.430]	Director Gutschenritter.
 Chris Gutschenritter	[186.430-186.430]	Here.
@@ -41,2331 +22,547 @@ Julien Bouquet	[196.725-197.379]	First Vice Chair O'Keefe.
 Patrick O'Keefe	[197.379-198.267]	Here.
 Julien Bouquet	[198.988-201.211]	Director Paglieri.
 Brett Paglieri	[201.492-207.050]	Present.
-Julien Bouquet	[207.050-207.050]	Director Ruscha.
-Julien Bouquet	[207.050-207.050]	Director Ruscha.
+Julien Bouquet	[207.050-207.050]	Director Ruscha. Director Ruscha.
 Chris Nicholson	[211.373-213.947]	Chairman Bouquet, they're not on the Zoom.
-Julien Bouquet	[214.518-214.947]	OK.
-Julien Bouquet	[215.162-215.377]	Thank you.
-Julien Bouquet	[215.592-216.742]	And Second Vice Chair Whitmore.
+Julien Bouquet	[214.518-216.742]	OK. Thank you. And Second Vice Chair Whitmore.
 Troy Whitmore	[216.742-216.912]	I'm here.
-Julien Bouquet	[218.304-218.304]	Awesome.
-Julien Bouquet	[218.865-221.920]	We have 13 present, two absent.
-Julien Bouquet	[223.633-223.784]	Pardon me.
-Julien Bouquet	[225.817-227.185]	Moving on to our retiree awards.
-Julien Bouquet	[227.800-229.659]	There are no retiree awards for this evening.
-Julien Bouquet	[230.324-235.335]	Second quarter retiree awards will be announced at the June 24 Board of Directors meeting.
-Julien Bouquet	[236.956-241.686]	Next is our public participation period, which is open to anyone who would like to address the Board.
-Julien Bouquet	[242.886-250.079]	As we have both in-person and remote attendees, in-person comments will go first, followed by those who are participating remotely.
-Julien Bouquet	[251.881-255.545]	For those attending in person, please come up to the podium when your name is called.
-Julien Bouquet	[256.569-262.627]	If you have not already signed up to speak and would like to do so, please approach the podium, when I call for any additional speakers.
-Julien Bouquet	[263.618-270.620]	For those attending virtually, if you wish to speak and have not already done so, please raise your virtual hand or press star 9 on your phone.
-Julien Bouquet	[271.950-274.426]	Staff will unmute you when it is your turn to speak.
-Julien Bouquet	[274.694-278.219]	If you're dialed in, press star 6 to toggle your mute settings.
-Julien Bouquet	[279.421-282.880]	Please bear in mind that by participating in this process, you are being recorded.
-Julien Bouquet	[284.008-287.545]	If you do not wish to be recorded, then your comments will have to be submitted via writing.
-Julien Bouquet	[288.425-301.815]	If any speaker has documentation or reference materials for the Board, or if any member of the public would like to submit written comments, please email those materials to the Board Office at rtd.directors@rtd-denver.com.
-Julien Bouquet	[302.887-306.233]	During this time, the Board will not offer any direct comments or responses.
-Julien Bouquet	[307.033-317.187]	However, if you'd like to be contacted regarding your public comment, please email the RTD Board Office at rtd.directors@rtd- denver.com.
-Julien Bouquet	[317.187-322.534]	Speakers should begin their remarks by stating their names and will have up to three minutes to provide their comments.
-Julien Bouquet	[324.357-328.683]	Our first speaker tonight will be Joan Peck, Longmont mayor.
-Joan Peck	[335.033-335.592]	Good evening.
-Joan Peck	[336.151-345.091]	Chair Bouquet and Director Johnson and Board, thank you so much for letting me address you tonight.
-Joan Peck	[346.551-353.903]	I am here representing not only the city of Longmont, but the Front Range Passenger Rail District Board, which I am the secretary of.
-Joan Peck	[354.203-362.685]	I want you to know right off the bat that the Board has as many questions about this new draft of IGA that you do.
-Joan Peck	[363.799-375.239]	So we are looking at it, scrutinizing it as well, but are very, very excited about the prospect of being able to work together and see this rail come to completion.
-Joan Peck	[376.521-385.843]	I also want to thank this Board for the partnership that we have with our RIDE Longmont.
-Joan Peck	[386.485-395.038]	We have exceeded 27,000 rides since December, which far outpaced the parent company of Via in Seattle.
-Joan Peck	[396.254-401.002]	So we're really proud of that, and that is directly because of the partnership we are doing with you.
-Joan Peck	[401.318-402.552]	So thank you very much.
-Joan Peck	[404.661-409.004]	I am also going to ask for the LX1 to be restored.
-Joan Peck	[409.386-423.094]	I get a little frustrated when you use ridership as a reason for not restoring that, because Bustang now, which is at the Firestone hub, is packed.
-Joan Peck	[424.244-429.552]	Those buses are packed and that ridership should belong to RTD.
-Joan Peck	[430.083-443.672]	And it makes me sad that that bus was cut and our people now aren't interested that much in RTD because Bustang is taking care of it and getting our money.
-Joan Peck	[445.840-458.243]	I also want to let you know that I'm going to-- I'm switching hats here from the FRPR Board as well as city of Longmont.
-Joan Peck	[459.054-465.615]	I want you to know that I am very excited about this rail for many reasons.
-Joan Peck	[466.542-474.018]	First of all, it's an economic driver, and it is a huge project that I think that we should take pride in together.
-Joan Peck	[474.406-489.679]	And to think about-- I know the cost is huge on both sides, but when we first heard about the cost of the Northwest corridor in about 2017, it was $1.2 or $1.4 billion.
-Joan Peck	[490.119-496.873]	And now BNSF's value to you, to RTD, is 650 million.
-Joan Peck	[498.229-518.592]	So that is quite a difference, and part of that is due to the fact that the last three cities on the Northwest corridor, Westminster, Broomfield, and Louisville are being taken off of your plate and FRPR is going to operate them.
-Joan Peck	[521.456-526.204]	I don't know, as none of us know, how that funding is going to work out.
-Joan Peck	[527.382-532.726]	But what I would like to offer and invite the RTD Executive Board.
-Joan Peck	[533.171-548.019]	I think, I believe that when we sit down face to face and work out what it is we think can happen-- because our boards are the ones that are going to decide this, one way or the other.
-Joan Peck	[548.409-549.548]	We're the ones that are going to vote.
-Joan Peck	[550.512-573.436]	So if you would think about the Executive Committee and the Executive Board or Committee of FRPR and RTD sitting down together and just diving into this IGA and trying to figure out what can we vote for, what will really work for both of us, both districts.
-Joan Peck	[575.063-584.660]	For me, that would be better in being able to see people face to face, emotions, talking and just working through it.
-Joan Peck	[585.918-591.214]	Because I never like going through third parties telling us what we should or shouldn't be doing.
-Joan Peck	[592.667-596.605]	But I understand that the Joint Service is probably going to happen.
-Joan Peck	[597.523-598.794]	How do we want it to happen?
-Joan Peck	[599.748-603.018]	And it is our boards that will decide that in the end.
-Joan Peck	[604.197-609.756]	So thank you very much, and let's just keep rolling along.
-Julien Bouquet	[612.094-612.711]	Thank you, Mayor Peck.
-Julien Bouquet	[613.838-614.903]	Next up, we have Dr.
-Julien Bouquet	[615.169-615.169]	Kay Baumann.
-Kay Palmer Marsh	[615.169-625.112]	Well, good afternoon.
-Kay Palmer Marsh	[625.466-627.049]	My name is Reverend Dr.
-Kay Palmer Marsh	[627.444-629.818]	Kay Palmer Marsh, and I'm from Longmont, Colorado.
-Kay Palmer Marsh	[630.916-634.151]	And I want to congratulate-- and thank you for having us all here.
-Kay Palmer Marsh	[634.482-635.293]	I really appreciate it.
-Kay Palmer Marsh	[635.604-638.128]	Thank you, Board, for the public participation.
-Kay Palmer Marsh	[639.311-642.231]	I want to thank you for what you've done in the past.
-Kay Palmer Marsh	[643.017-649.710]	You've had courage, vision, and guts to start this FasTracks program.
-Kay Palmer Marsh	[650.731-656.197]	I mean, I remember when I first moved to Denver 40 years ago, there was no such thing.
-Kay Palmer Marsh	[656.581-657.434]	I came from Chicago.
-Kay Palmer Marsh	[657.719-664.173]	And there was no such thing, and the Board had this vision and you went forward with it.
-Kay Palmer Marsh	[664.535-672.308]	And now there's a little bit of-- I think more than a little bit of hesitation about coming in all the way up to Longmont.
-Kay Palmer Marsh	[674.508-677.372]	Well, I want you to know that Longmont is a wonderful place.
-Kay Palmer Marsh	[679.113-685.628]	We just don't trust you all that much anymore because we've been paying for all the tax-- been paying taxes since 2005.
-Kay Palmer Marsh	[687.204-704.015]	But we're looking forward to this Board having the courage and the guts and the vision to make this happen for our community and communities down the line that have been paying taxes since 2005 on this.
-Kay Palmer Marsh	[705.033-707.881]	We voted to support this, and we still support it.
-Kay Palmer Marsh	[709.117-711.108]	It's just a little touchy right now.
-Kay Palmer Marsh	[712.361-714.129]	I do want to address equity.
-Kay Palmer Marsh	[715.444-727.014]	We look at equity in Longmont as how come Highlands Ranch has access to this wonderful rail?
-Kay Palmer Marsh	[727.839-732.319]	How come Boulder has so many buses?
-Kay Palmer Marsh	[733.086-736.113]	And in Longmont, we don't have so many buses.
-Kay Palmer Marsh	[736.551-737.272]	We keep getting cut.
-Kay Palmer Marsh	[737.913-740.630]	And of course, we don't have our rail yet either.
-Kay Palmer Marsh	[741.578-744.592]	And so we look at equity in a different way than you do.
-Kay Palmer Marsh	[744.863-764.366]	I also know that you have looked at equity in terms of-- in a different way that doesn't really make sense to us when we look at Boulder being very high income and having all their buses and good transportation.
-Kay Palmer Marsh	[765.483-771.874]	Highlands Ranch is another good example of a fairly high income community that has access to passenger rail.
-Kay Palmer Marsh	[772.933-780.090]	We, in Longmont, look for a more-- shall I say, a looser version of the equity argument.
-Kay Palmer Marsh	[781.290-786.326]	Right now it looks like the equity argument is being used so that we won't get it.
-Kay Palmer Marsh	[788.144-788.879]	On the other hand.
-Kay Palmer Marsh	[789.124-790.104]	I've heard some good things.
-Kay Palmer Marsh	[790.509-793.449]	I'm excited about what could happen.
-Kay Palmer Marsh	[794.017-801.489]	Again, Longmont is still-- we're developing trust, I hope, with the RTD.
-Kay Palmer Marsh	[802.228-804.043]	My neighbors don't particularly trust you.
-Kay Palmer Marsh	[804.406-812.736]	When I was walking around with one petition or another, they didn't want to even let me in the door when I said RTD.
-Kay Palmer Marsh	[813.090-820.501]	So thank you for this opportunity and I strongly support the Northwest Rail and I hope you will too.
-Julien Bouquet	[822.603-823.668]	Thank you, Reverend Dr.
-Julien Bouquet	[824.023-825.797]	Madelyn Marsh is our next speaker.
-Madelyn Marsh	[829.602-832.706]	Thank you, Board members, for allowing us to speak tonight.
-Madelyn Marsh	[833.091-833.877]	My name is Madelyn Marsh.
-Madelyn Marsh	[834.094-840.476]	I'm also from Longmont, and I voted for FasTracks in my very first election.
-Madelyn Marsh	[840.933-856.879]	I was a brand new 18- year-old in 2004, and here we are 21 years later, and we still don't-- instead of a train to Longmont or more dedicated bus services, even, you have cut services to Longmont.
-Madelyn Marsh	[857.259-869.915]	And so it's frustrating to be here asking for more or for what we voted for and what you're legally obligated to provide based on the results of that election.
-Madelyn Marsh	[871.221-877.194]	In the 21 years since I voted for that, I ended up living in Chicago for a few years.
-Madelyn Marsh	[877.546-880.635]	I enjoyed a robust public transit system.
-Madelyn Marsh	[881.910-885.213]	I enjoyed the-- I took the bus, I took trains to work.
-Madelyn Marsh	[885.473-886.595]	I took trains to play.
-Madelyn Marsh	[886.935-889.123]	I took trains to the suburbs, to the city.
-Madelyn Marsh	[889.377-892.278]	And it was an economic driver for every community that was involved.
-Madelyn Marsh	[892.963-895.453]	There's bustling downtowns wherever you go.
-Madelyn Marsh	[896.349-910.032]	And like others have said, the people in Longmont are not inclined to trust RTD because the trust has been broken, that we keep getting pushed off and pushed off and pushed off.
-Madelyn Marsh	[910.252-932.079]	And so I would ask that you vote in favor of the Northwest Rail expansion, but also that you don't limit it to three trips every weekday, but that you have the vision to allow us to bring our money to Denver, to other communities for entertainment purposes as well as work purposes.
-Madelyn Marsh	[933.667-935.319]	Thank you very much for your time.
-Julien Bouquet	[936.274-936.701]	Thank you, Madelyn.
-Julien Bouquet	[937.555-939.359]	I have Connor Shea as our next speaker.
-Connor Shea	[952.692-953.186]	Good evening, Board.
-Connor Shea	[954.495-956.969]	My name is Connor Shea and I live in the Baker neighborhood of Denver.
-Connor Shea	[957.720-961.831]	I'm here representing the Baker Historic Neighborhood Association as a member of its board.
-Connor Shea	[962.688-967.300]	I live a few blocks from the Alameda station, and I use RTD's bus and rail services pretty frequently.
-Connor Shea	[968.557-977.475]	As you're probably aware, Denver is in the process of considering a women's soccer league stadium at the former Gates Rubber Factory site, just west of the I-25 and Broadway Station.
-Connor Shea	[978.528-993.692]	As the stadium will be across from the freight rail tracks-- across the freight rail tracks from the RTD station, transit riders need to cross over the FasTracks to reach the stadium from the various RTD bus and rail stations-- bus and rail connections at the station.
-Connor Shea	[995.224-1001.434]	Currently, the only pedestrian access route from the Broadway Station is the Southern Bridge, sometimes referred to as the bridge to nowhere.
-Connor Shea	[1001.770-1013.193]	That path will be about 3/4 of a mile going from the station to the stadium, and then the same distance going back after a soccer game or other event at the venue.
-Connor Shea	[1014.652-1020.112]	As a neighborhood, we intend to push for a North Bridge to the site connecting the station and stadium as directly as possible.
-Connor Shea	[1020.740-1027.457]	And I'm here to ask for RTD's cooperation on this, since a bridge would require the use of RTD land on the Broadway Station.
-Connor Shea	[1029.778-1039.567]	North Bridge has been in most past plans for development of the site but is considered optional as part of the non-binding agreement between the city and the stadium owners that city council passed a few weeks ago.
-Connor Shea	[1041.093-1048.419]	The North Bridge connection would mean only one quarter mile of walking to go from the RTD station to the stadium.
-Connor Shea	[1049.947-1059.037]	In total, the bridge would-- a North Bridge would save a full mile of walking, about 20 minutes, when going to the stadium and then back after an event ends.
-Connor Shea	[1059.713-1067.757]	We believe that the shorter distance with the North Pedestrian Bridge would encourage significantly more transit usage when going to events at the stadium.
-Connor Shea	[1068.029-1073.745]	The Broadway Station is accessible from the D, E, and H lines without a transfer, and all other lines with only one transfer.
-Connor Shea	[1074.819-1077.104]	It's also accessible from a variety of bus routes.
-Connor Shea	[1077.390-1082.246]	That would reduce traffic and emissions coming through our neighborhood and the other neighborhoods adjacent to the stadium.
-Connor Shea	[1084.553-1098.626]	North Bridge would be good for our neighborhood, for the safety of pedestrians and transit users, as they won't have to cross as many streets when accessing the stadium, and would be good for RTD and extra fares and customers from events at the stadium.
-Connor Shea	[1099.687-1103.080]	The extra bridge would provide better connections and redundancy for pedestrians.
-Connor Shea	[1103.420-1106.474]	It would especially improve accessibility for folks with limited mobility.
-Connor Shea	[1108.455-1117.899]	I'm here to ask for RTD's cooperation and support on getting this included in the stadium project, as we work on negotiating a community benefits agreement with the developer over the next few months.
-Connor Shea	[1119.378-1129.322]	I sent an email to the Board and CEO Johnson about this on Friday and would be happy to receive any emails from the Board or CEO if anyone has any further questions about that.
-Connor Shea	[1130.255-1131.062]	Thank you very much for your time.
-Julien Bouquet	[1132.258-1133.025]	Thank you for your comments, sir.
-Julien Bouquet	[1134.681-1137.546]	I will now move to online participants, Mr.
-Julien Bouquet	[1137.866-1140.110]	Kroll, does anyone have their virtual hand raised?
-Jack Kroll	[1141.203-1141.203]	Yes.
-Jack Kroll	[1141.419-1144.011]	At this time, we have a number of folks with their hands raised.
-Jack Kroll	[1144.647-1147.468]	The first is former RTD Director Claudia Folska.
-Julien Bouquet	[1150.594-1150.594]	Ms.
-Julien Bouquet	[1150.754-1150.754]	Folska.
-Jack Kroll	[1161.627-1161.847]	So, Ms.
-Jack Kroll	[1162.128-1165.454]	Folska, it looks like you briefly came off mute and then went right back on.
-Jack Kroll	[1166.792-1167.356]	You are unmuted.
-Claudia Folska	[1167.961-1169.371]	Whew.
-Claudia Folska	[1169.371-1171.184]	This is a huge achievement, guys.
-Claudia Folska	[1172.742-1173.332]	Oh, God.
-Claudia Folska	[1174.564-1179.183]	I was so thrilled to hear the earlier special session.
-Claudia Folska	[1179.697-1185.343]	And kudos to all of you, especially General Manager/CEO Debra Johnson.
-Claudia Folska	[1186.196-1187.848]	What a great accomplishment.
-Claudia Folska	[1188.538-1190.167]	Lisa Kaufman, Diane.
-Claudia Folska	[1191.782-1194.356]	And now I'm forgetting her last name.
-Claudia Folska	[1194.785-1197.359]	But I mean, everybody was really amazing.
-Claudia Folska	[1197.768-1214.843]	I would ask the Chair to afford me a little bit more time, as it's customary for former Directors to be granted additional time as they have institutional knowledge to share and inform the Board.
-Claudia Folska	[1215.746-1217.067]	Would that be OK with you, Mr.
-Claudia Folska	[1217.287-1217.287]	Chair?
+Julien Bouquet	[218.304-328.683]	Awesome. We have 13 present, two absent. Pardon me. Moving on to our retiree awards. There are no retiree awards for this evening. Second quarter retiree awards will be announced at the June 24 Board of Directors meeting. Next is our public participation period, which is open to anyone who would like to address the Board. As we have both in-person and remote attendees, in-person comments will go first, followed by those who are participating remotely. For those attending in person, please come up to the podium when your name is called. If you have not already signed up to speak and would like to do so, please approach the podium, when I call for any additional speakers. For those attending virtually, if you wish to speak and have not already done so, please raise your virtual hand or press star 9 on your phone. Staff will unmute you when it is your turn to speak. If you're dialed in, press star 6 to toggle your mute settings. Please bear in mind that by participating in this process, you are being recorded. If you do not wish to be recorded, then your comments will have to be submitted via writing. If any speaker has documentation or reference materials for the Board, or if any member of the public would like to submit written comments, please email those materials to the Board Office at rtd.directors@rtd-denver.com. During this time, the Board will not offer any direct comments or responses. However, if you'd like to be contacted regarding your public comment, please email the RTD Board Office at rtd.directors@rtd- denver.com. Speakers should begin their remarks by stating their names and will have up to three minutes to provide their comments. Our first speaker tonight will be Joan Peck, Longmont mayor.
+Joan Peck	[335.033-609.756]	Good evening. Chair Bouquet and Director Johnson and Board, thank you so much for letting me address you tonight. I am here representing not only the city of Longmont, but the Front Range Passenger Rail District Board, which I am the secretary of. I want you to know right off the bat that the Board has as many questions about this new draft of IGA that you do. So we are looking at it, scrutinizing it as well, but are very, very excited about the prospect of being able to work together and see this rail come to completion. I also want to thank this Board for the partnership that we have with our RIDE Longmont. We have exceeded 27,000 rides since December, which far outpaced the parent company of Via in Seattle. So we're really proud of that, and that is directly because of the partnership we are doing with you. So thank you very much. I am also going to ask for the LX1 to be restored. I get a little frustrated when you use ridership as a reason for not restoring that, because Bustang now, which is at the Firestone hub, is packed. Those buses are packed and that ridership should belong to RTD. And it makes me sad that that bus was cut and our people now aren't interested that much in RTD because Bustang is taking care of it and getting our money. I also want to let you know that I'm going to-- I'm switching hats here from the FRPR Board as well as city of Longmont. I want you to know that I am very excited about this rail for many reasons. First of all, it's an economic driver, and it is a huge project that I think that we should take pride in together. And to think about-- I know the cost is huge on both sides, but when we first heard about the cost of the Northwest corridor in about 2017, it was $1.2 or $1.4 billion. And now BNSF's value to you, to RTD, is 650 million. So that is quite a difference, and part of that is due to the fact that the last three cities on the Northwest corridor, Westminster, Broomfield, and Louisville are being taken off of your plate and FRPR is going to operate them. I don't know, as none of us know, how that funding is going to work out. But what I would like to offer and invite the RTD Executive Board. I think, I believe that when we sit down face to face and work out what it is we think can happen-- because our boards are the ones that are going to decide this, one way or the other. We're the ones that are going to vote. So if you would think about the Executive Committee and the Executive Board or Committee of FRPR and RTD sitting down together and just diving into this IGA and trying to figure out what can we vote for, what will really work for both of us, both districts. For me, that would be better in being able to see people face to face, emotions, talking and just working through it. Because I never like going through third parties telling us what we should or shouldn't be doing. But I understand that the Joint Service is probably going to happen. How do we want it to happen? And it is our boards that will decide that in the end. So thank you very much, and let's just keep rolling along.
+Julien Bouquet	[612.094-615.169]	Thank you, Mayor Peck. Next up, we have Dr. Kay Baumann.
+Kay Palmer Marsh	[615.169-820.501]	Well, good afternoon. My name is Reverend Dr. Kay Palmer Marsh, and I'm from Longmont, Colorado. And I want to congratulate-- and thank you for having us all here. I really appreciate it. Thank you, Board, for the public participation. I want to thank you for what you've done in the past. You've had courage, vision, and guts to start this FasTracks program. I mean, I remember when I first moved to Denver 40 years ago, there was no such thing. I came from Chicago. And there was no such thing, and the Board had this vision and you went forward with it. And now there's a little bit of-- I think more than a little bit of hesitation about coming in all the way up to Longmont. Well, I want you to know that Longmont is a wonderful place. We just don't trust you all that much anymore because we've been paying for all the tax-- been paying taxes since 2005. But we're looking forward to this Board having the courage and the guts and the vision to make this happen for our community and communities down the line that have been paying taxes since 2005 on this. We voted to support this, and we still support it. It's just a little touchy right now. I do want to address equity. We look at equity in Longmont as how come Highlands Ranch has access to this wonderful rail? How come Boulder has so many buses? And in Longmont, we don't have so many buses. We keep getting cut. And of course, we don't have our rail yet either. And so we look at equity in a different way than you do. I also know that you have looked at equity in terms of-- in a different way that doesn't really make sense to us when we look at Boulder being very high income and having all their buses and good transportation. Highlands Ranch is another good example of a fairly high income community that has access to passenger rail. We, in Longmont, look for a more-- shall I say, a looser version of the equity argument. Right now it looks like the equity argument is being used so that we won't get it. On the other hand. I've heard some good things. I'm excited about what could happen. Again, Longmont is still-- we're developing trust, I hope, with the RTD. My neighbors don't particularly trust you. When I was walking around with one petition or another, they didn't want to even let me in the door when I said RTD. So thank you for this opportunity and I strongly support the Northwest Rail and I hope you will too.
+Julien Bouquet	[822.603-825.797]	Thank you, Reverend Dr. Madelyn Marsh is our next speaker.
+Madelyn Marsh	[829.602-935.319]	Thank you, Board members, for allowing us to speak tonight. My name is Madelyn Marsh. I'm also from Longmont, and I voted for FasTracks in my very first election. I was a brand new 18- year-old in 2004, and here we are 21 years later, and we still don't-- instead of a train to Longmont or more dedicated bus services, even, you have cut services to Longmont. And so it's frustrating to be here asking for more or for what we voted for and what you're legally obligated to provide based on the results of that election. In the 21 years since I voted for that, I ended up living in Chicago for a few years. I enjoyed a robust public transit system. I enjoyed the-- I took the bus, I took trains to work. I took trains to play. I took trains to the suburbs, to the city. And it was an economic driver for every community that was involved. There's bustling downtowns wherever you go. And like others have said, the people in Longmont are not inclined to trust RTD because the trust has been broken, that we keep getting pushed off and pushed off and pushed off. And so I would ask that you vote in favor of the Northwest Rail expansion, but also that you don't limit it to three trips every weekday, but that you have the vision to allow us to bring our money to Denver, to other communities for entertainment purposes as well as work purposes. Thank you very much for your time.
+Julien Bouquet	[936.274-939.359]	Thank you, Madelyn. I have Connor Shea as our next speaker.
+Connor Shea	[952.692-1131.062]	Good evening, Board. My name is Connor Shea and I live in the Baker neighborhood of Denver. I'm here representing the Baker Historic Neighborhood Association as a member of its board. I live a few blocks from the Alameda station, and I use RTD's bus and rail services pretty frequently. As you're probably aware, Denver is in the process of considering a women's soccer league stadium at the former Gates Rubber Factory site, just west of the I-25 and Broadway Station. As the stadium will be across from the freight rail tracks-- across the freight rail tracks from the RTD station, transit riders need to cross over the FasTracks to reach the stadium from the various RTD bus and rail stations-- bus and rail connections at the station. Currently, the only pedestrian access route from the Broadway Station is the Southern Bridge, sometimes referred to as the bridge to nowhere. That path will be about 3/4 of a mile going from the station to the stadium, and then the same distance going back after a soccer game or other event at the venue. As a neighborhood, we intend to push for a North Bridge to the site connecting the station and stadium as directly as possible. And I'm here to ask for RTD's cooperation on this, since a bridge would require the use of RTD land on the Broadway Station. North Bridge has been in most past plans for development of the site but is considered optional as part of the non-binding agreement between the city and the stadium owners that city council passed a few weeks ago. The North Bridge connection would mean only one quarter mile of walking to go from the RTD station to the stadium. In total, the bridge would-- a North Bridge would save a full mile of walking, about 20 minutes, when going to the stadium and then back after an event ends. We believe that the shorter distance with the North Pedestrian Bridge would encourage significantly more transit usage when going to events at the stadium. The Broadway Station is accessible from the D, E, and H lines without a transfer, and all other lines with only one transfer. It's also accessible from a variety of bus routes. That would reduce traffic and emissions coming through our neighborhood and the other neighborhoods adjacent to the stadium. North Bridge would be good for our neighborhood, for the safety of pedestrians and transit users, as they won't have to cross as many streets when accessing the stadium, and would be good for RTD and extra fares and customers from events at the stadium. The extra bridge would provide better connections and redundancy for pedestrians. It would especially improve accessibility for folks with limited mobility. I'm here to ask for RTD's cooperation and support on getting this included in the stadium project, as we work on negotiating a community benefits agreement with the developer over the next few months. I sent an email to the Board and CEO Johnson about this on Friday and would be happy to receive any emails from the Board or CEO if anyone has any further questions about that. Thank you very much for your time.
+Julien Bouquet	[1132.258-1140.110]	Thank you for your comments, sir. I will now move to online participants, Mr. Kroll, does anyone have their virtual hand raised?
+Jack Kroll	[1141.203-1147.468]	Yes. At this time, we have a number of folks with their hands raised. The first is former RTD Director Claudia Folska.
+Julien Bouquet	[1150.594-1150.754]	Ms. Folska.
+Jack Kroll	[1161.627-1167.356]	So, Ms. Folska, it looks like you briefly came off mute and then went right back on. You are unmuted.
+Claudia Folska	[1167.961-1217.287]	Whew. This is a huge achievement, guys. Oh, God. I was so thrilled to hear the earlier special session. And kudos to all of you, especially General Manager/CEO Debra Johnson. What a great accomplishment. Lisa Kaufman, Diane. And now I'm forgetting her last name. But I mean, everybody was really amazing. I would ask the Chair to afford me a little bit more time, as it's customary for former Directors to be granted additional time as they have institutional knowledge to share and inform the Board. Would that be OK with you, Mr. Chair?
 Julien Bouquet	[1218.188-1218.438]	Of course.
-Claudia Folska	[1219.529-1220.100]	Thank you very much.
-Claudia Folska	[1220.310-1222.339]	I appreciate that.
-Claudia Folska	[1223.992-1241.873]	So I was reflecting on my early days on the Board, and we were desperately trying to find the money to do the R line, which goes through district B and F, I think.
-Claudia Folska	[1242.435-1243.146]	I don't remember.
-Claudia Folska	[1243.502-1250.983]	But anyway, and Phil Washington was our Executive Director then, and he had this brilliant motto.
-Claudia Folska	[1251.954-1258.669]	He always said, every day, practically, we will build as much as we can as fast as we can, no matter what.
-Claudia Folska	[1259.650-1267.633]	But when it came time to find the money for the R line, he would pick up any nickel under any rock.
-Claudia Folska	[1268.064-1268.965]	And you can ask him that.
-Claudia Folska	[1269.946-1271.019]	And those are his words.
-Claudia Folska	[1271.307-1281.354]	And he opened up a meeting, a luncheon for all business leaders, small and large, to figure out, this is what we have to work with.
-Claudia Folska	[1281.977-1282.697]	How can we do it?
-Claudia Folska	[1283.578-1287.487]	And it took a series of IGAs to get this thing done.
-Claudia Folska	[1288.342-1288.729]	Lots of them.
-Claudia Folska	[1288.983-1291.038]	So we're on the way, we're moving along.
-Claudia Folska	[1291.385-1291.986]	Everything is great.
-Claudia Folska	[1293.047-1302.420]	And then Bruce Benson, who was the president of the University of Colorado, comes over to the Board and says, hey, hey.
-Claudia Folska	[1303.663-1303.663]	No, no, no.
-Claudia Folska	[1304.077-1313.609]	We need you to change the alignment of the R line and take it off of Montview Boulevard, right through Anschutz Medical Center campus.
-Claudia Folska	[1314.188-1317.186]	Now, you can imagine-- we're like, what?
-Claudia Folska	[1317.714-1322.929]	How is this-- I mean, this was a huge shock, blow to all of us.
-Claudia Folska	[1323.623-1324.757]	And what were we going to do?
-Claudia Folska	[1324.966-1326.468]	Well, you know what that means?
-Claudia Folska	[1327.209-1329.046]	It requires 10 votes.
-Claudia Folska	[1329.659-1330.884]	A super majority.
-Claudia Folska	[1331.536-1332.337]	And guess what?
-Claudia Folska	[1333.299-1336.887]	Those folks in Longmont, in the north, they weren't having it.
-Claudia Folska	[1337.947-1339.715]	They were not going to do it.
-Claudia Folska	[1339.990-1353.742]	But it required all of us, each and every one of us, to have those one on one discussions and promise, promise the people in the north, let's just get this one thing done and then we can move on to the north.
-Claudia Folska	[1354.927-1356.218]	Now it's their turn.
-Claudia Folska	[1357.210-1361.134]	Now it's time to finish the Northwest Rail.
-Claudia Folska	[1361.675-1365.274]	And those numbers, the finances and all of that, they'll come out.
-Claudia Folska	[1366.041-1367.126]	You guys will figure it out.
-Claudia Folska	[1367.904-1368.971]	Everybody is coming together.
-Claudia Folska	[1369.346-1379.270]	All those different entities, and then IGA is so critical to proceed and move forward and do what the voters elected to have done.
-Claudia Folska	[1380.182-1381.987]	FasTracks, they elected you to finish it.
-Claudia Folska	[1382.726-1385.196]	You may not even like it, but it's not you.
-Claudia Folska	[1385.510-1387.467]	It's the people that voted for it.
-Claudia Folska	[1387.973-1389.881]	It's the RTD's obligation.
-Claudia Folska	[1391.645-1402.859]	And by the way, of the 3.1 million people living in the district, 97% of them don't even use RTD and they're paying for that train.
-Claudia Folska	[1403.845-1412.712]	And now you have this wonderful, exciting, incredible opportunity to finish it and even connect beyond the district into Fort Collins.
-Claudia Folska	[1413.215-1417.711]	What a boon for everybody and for the entire state, quite frankly.
-Claudia Folska	[1418.681-1424.212]	So I'm like, you can probably tell I'm so excited and proud of you guys.
-Claudia Folska	[1424.868-1425.789]	It's like, whew.
-Claudia Folska	[1426.249-1426.710]	About time.
-Claudia Folska	[1428.263-1433.385]	Now, the other topic that's on my mind is Access-on-Demand.
-Claudia Folska	[1436.235-1439.892]	Your annual operating budget is $1.32 billion.
-Claudia Folska	[1441.242-1460.711]	And if you're thinking about equity and 20% of the population, roughly, a little more, little less, are people with disabilities, then 20% of that operating budget is closer to $264 million, and Access-on-Demand isn't anywhere close to that.
-Claudia Folska	[1462.056-1470.487]	I don't think either one of these recommendations to the Board makes sense at all, and I would encourage you to look at it again.
-Claudia Folska	[1470.913-1477.836]	I mean, the numbers keep changing, by the way, for the subsidies, $16 to now $22 for Access-on-Demand.
-Claudia Folska	[1479.050-1480.768]	Now it's 100 for Access-a-Ride.
-Claudia Folska	[1482.639-1493.412]	And why not think-- like, Einstein said you can get from point A to B with logic, but you can get everywhere with your imagination.
-Claudia Folska	[1494.110-1501.002]	What if you applied the Access-on-Demand model to Access-a-Ride using those vehicles?
-Claudia Folska	[1501.962-1505.028]	You could start with a little pilot and see how it worked.
-Claudia Folska	[1505.908-1507.873]	You could even use it to pick up other people.
-Claudia Folska	[1508.492-1518.488]	There's no prohibition from other people using those paratransit vehicles, and most of the time they're sitting in a parking lot with a driver sleeping.
-Claudia Folska	[1519.675-1521.421]	So of course, I haven't seen that.
-But I've been told-- Julien Bouquet	[1521.713-1525.779]	Former Director Folska, if you could wrap up your comments.
-But I've been told-- Julien Bouquet	[1526.034-1527.567]	You're about double the time right now.
-Claudia Folska	[1528.344-1528.624]	OK.
-Claudia Folska	[1528.624-1529.185]	I appreciate it.
-Claudia Folska	[1529.545-1529.725]	Thank you.
-Claudia Folska	[1529.925-1531.156]	I think that's it.
-Claudia Folska	[1531.647-1534.528]	So I would encourage you, sign the IGA.
-Claudia Folska	[1534.940-1536.175]	Go forward with that.
-Claudia Folska	[1536.586-1537.821]	Vote yes on it.
-Claudia Folska	[1538.233-1545.230]	And ask staff to go back and start using their imagination for better Access-on-Demand for everybody.
-Claudia Folska	[1545.722-1546.889]	Thank you very much for your time.
-Julien Bouquet	[1548.160-1549.364]	Thank you, Former Director Folska.
-Julien Bouquet	[1550.006-1550.006]	Mr.
-Julien Bouquet	[1550.291-1551.145]	Kroll, our next participant.
+Claudia Folska	[1219.529-1523.168]	Thank you very much. I appreciate that. So I was reflecting on my early days on the Board, and we were desperately trying to find the money to do the R line, which goes through district B and F, I think. I don't remember. But anyway, and Phil Washington was our Executive Director then, and he had this brilliant motto. He always said, every day, practically, we will build as much as we can as fast as we can, no matter what. But when it came time to find the money for the R line, he would pick up any nickel under any rock. And you can ask him that. And those are his words. And he opened up a meeting, a luncheon for all business leaders, small and large, to figure out, this is what we have to work with. How can we do it? And it took a series of IGAs to get this thing done. Lots of them. So we're on the way, we're moving along. Everything is great. And then Bruce Benson, who was the president of the University of Colorado, comes over to the Board and says, hey, hey. No, no, no. We need you to change the alignment of the R line and take it off of Montview Boulevard, right through Anschutz Medical Center campus. Now, you can imagine-- we're like, what? How is this-- I mean, this was a huge shock, blow to all of us. And what were we going to do? Well, you know what that means? It requires 10 votes. A super majority. And guess what? Those folks in Longmont, in the north, they weren't having it. They were not going to do it. But it required all of us, each and every one of us, to have those one on one discussions and promise, promise the people in the north, let's just get this one thing done and then we can move on to the north. Now it's their turn. Now it's time to finish the Northwest Rail. And those numbers, the finances and all of that, they'll come out. You guys will figure it out. Everybody is coming together. All those different entities, and then IGA is so critical to proceed and move forward and do what the voters elected to have done. FasTracks, they elected you to finish it. You may not even like it, but it's not you. It's the people that voted for it. It's the RTD's obligation. And by the way, of the 3.1 million people living in the district, 97% of them don't even use RTD and they're paying for that train. And now you have this wonderful, exciting, incredible opportunity to finish it and even connect beyond the district into Fort Collins. What a boon for everybody and for the entire state, quite frankly. So I'm like, you can probably tell I'm so excited and proud of you guys. It's like, whew. About time. Now, the other topic that's on my mind is Access-on-Demand. Your annual operating budget is $1.32 billion. And if you're thinking about equity and 20% of the population, roughly, a little more, little less, are people with disabilities, then 20% of that operating budget is closer to $264 million, and Access-on-Demand isn't anywhere close to that. I don't think either one of these recommendations to the Board makes sense at all, and I would encourage you to look at it again. I mean, the numbers keep changing, by the way, for the subsidies, $16 to now $22 for Access-on-Demand. Now it's 100 for Access-a-Ride. And why not think-- like, Einstein said you can get from point A to B with logic, but you can get everywhere with your imagination. What if you applied the Access-on-Demand model to Access-a-Ride using those vehicles? You could start with a little pilot and see how it worked. You could even use it to pick up other people. There's no prohibition from other people using those paratransit vehicles, and most of the time they're sitting in a parking lot with a driver sleeping. So of course, I haven't seen that. But I've been told--
+Julien Bouquet	[1523.479-1527.567]	Former Director Folska, if you could wrap up your comments. You're about double the time right now.
+Claudia Folska	[1528.344-1546.889]	OK. I appreciate it. Thank you. I think that's it. So I would encourage you, sign the IGA. Go forward with that. Vote yes on it. And ask staff to go back and start using their imagination for better Access-on-Demand for everybody. Thank you very much for your time.
+Julien Bouquet	[1548.160-1551.145]	Thank you, Former Director Folska. Mr. Kroll, our next participant.
 Jack Kroll	[1551.892-1554.736]	Yes. next We have Former Director Doug Tisdale.
-Julien Bouquet	[1555.584-1556.659]	Former Director Tisdale.
-Julien Bouquet	[1557.197-1557.734]	You're recognized.
-Doug Tisdale	[1560.901-1561.682]	Thank you very much.
-Doug Tisdale	[1562.102-1566.138]	I appreciate the opportunity to visit with you this evening.
-Doug Tisdale	[1566.606-1571.477]	I am Doug Tisdale, Former Director for District H.
-Doug Tisdale	[1572.086-1580.337]	And I apologize, you're only seeing a picture of me instead of my face in person, but I guess that's the restriction.
-Doug Tisdale	[1580.693-1584.225]	In any event, I'll try to keep this within the time constraints.
-Doug Tisdale	[1586.284-1589.665]	The comment was made during public participation earlier.
-Doug Tisdale	[1590.584-1593.972]	Highlands Ranch has access to rail.
-Doug Tisdale	[1595.991-1608.309]	At the risk of being struck by lightning for contesting the testimony of a Reverend, Highlands Ranch does not have access to rail.
-Doug Tisdale	[1609.770-1618.522]	The Southwest rail extension, what I affectionately refer to as the SWRE is one of the unfinished corridors of FasTracks.
-Doug Tisdale	[1619.795-1629.767]	My successor, as District H Director, made a reference to that in the special meeting earlier today, many hours ago.
-Doug Tisdale	[1630.933-1644.260]	The legislature, at the urging of the governor, only prioritize service for the Northwest Rail, with no reference to the Southwest Rail extension, the SWRE.
-Doug Tisdale	[1645.476-1652.944]	I must confess that I must have been an inadequate voice on behalf of the SWRE.
-Doug Tisdale	[1654.223-1665.408]	I apologize to my former constituents, and can only hope that my successor, as Vice Chair of this Board, will be more impactful.
-Doug Tisdale	[1666.697-1674.224]	That said, kudos to all of you for proceeding with the steps toward Northwest Rail completion.
-Doug Tisdale	[1675.427-1685.688]	I can only hope that we find the political will, the political courage to address the SWRE with the same kind of passion.
-Doug Tisdale	[1686.991-1688.392]	Thank you very much, Mr.
-Doug Tisdale	[1688.743-1688.743]	Chairman.
-Julien Bouquet	[1689.434-1691.657]	Thank you, Former Director Tisdale Mr.
-Julien Bouquet	[1691.932-1692.483]	Kroll, our next speaker.
-Jack Kroll	[1696.883-1696.883]	Yes.
-Jack Kroll	[1697.657-1700.755]	Next we have Maitri Lazaroff.
-Maitri Lazaroff	[1700.755-1701.589]	Hello.
-Maitri Lazaroff	[1702.482-1707.787]	I'm Maitri Lazaroff, and I am not here to talk about Northwest Rail.
-Maitri Lazaroff	[1709.210-1713.775]	I am an RTD rider, and I was formerly a regular rider of the E line.
-Maitri Lazaroff	[1713.775-1723.860]	And the reason I say former is, like many other riders, I was pushed off the light rail a year ago due to the fact that I could no longer rely on it as reliable transportation.
-Maitri Lazaroff	[1724.448-1729.329]	And now that issue that caused me to be pushed off of the train is solved.
-Maitri Lazaroff	[1729.634-1732.205]	And I know there's already been a little bit of outreach on this.
-Maitri Lazaroff	[1732.439-1740.635]	There's an article on your website, but it is my opinion that RTD needs to be as loud as possible with this.
-Maitri Lazaroff	[1742.677-1756.487]	It's a sad fact that the majority of people in the metro don't ride transit, and we need to yell to get news like this out, because it's hard for it to spread with light announcements and word of mouth.
-Maitri Lazaroff	[1757.140-1765.981]	We have lost, as of 2024, 21.6% of E line riders and 31.4% of H line riders.
-Maitri Lazaroff	[1767.254-1777.612]	And not only is that a massive hit to the light rail system, but it bleeds to the rest of the system by people not being able to make those transfers.
-Maitri Lazaroff	[1777.977-1781.862]	We saw ridership decreases on all three of our rail lines last year.
-Maitri Lazaroff	[1783.178-1787.725]	And it's just, Directors making Reddit posts just really isn't enough.
-Maitri Lazaroff	[1790.462-1804.727]	Could we maybe give two weeks of free fares to try and really get eyes back on the system to try and really make an effort to undo this ridership destruction that we've seen on our light rail?
-Maitri Lazaroff	[1805.067-1806.765]	And especially on the Southeast corridor.
-Maitri Lazaroff	[1808.020-1808.193]	Thank you.
-Maitri Lazaroff	[1808.407-1809.021]	That's my time.
-Julien Bouquet	[1810.349-1810.803]	Thank you, Maitri.
-Julien Bouquet	[1811.530-1811.530]	Mr.
-Julien Bouquet	[1811.810-1812.652]	Kroll, our next speaker.
-Jack Kroll	[1813.672-1813.672]	Yes.
-Jack Kroll	[1814.046-1815.542]	Next, we have Richard Bamber.
+Julien Bouquet	[1555.584-1557.734]	Former Director Tisdale. You're recognized.
+Doug Tisdale	[1560.901-1688.743]	Thank you very much. I appreciate the opportunity to visit with you this evening. I am Doug Tisdale, Former Director for District H. And I apologize, you're only seeing a picture of me instead of my face in person, but I guess that's the restriction. In any event, I'll try to keep this within the time constraints. The comment was made during public participation earlier. Highlands Ranch has access to rail. At the risk of being struck by lightning for contesting the testimony of a Reverend, Highlands Ranch does not have access to rail. The Southwest rail extension, what I affectionately refer to as the SWRE is one of the unfinished corridors of FasTracks. My successor, as District H Director, made a reference to that in the special meeting earlier today, many hours ago. The legislature, at the urging of the governor, only prioritize service for the Northwest Rail, with no reference to the Southwest Rail extension, the SWRE. I must confess that I must have been an inadequate voice on behalf of the SWRE. I apologize to my former constituents, and can only hope that my successor, as Vice Chair of this Board, will be more impactful. That said, kudos to all of you for proceeding with the steps toward Northwest Rail completion. I can only hope that we find the political will, the political courage to address the SWRE with the same kind of passion. Thank you very much, Mr. Chairman.
+Julien Bouquet	[1689.434-1692.483]	Thank you, Former Director Tisdale Mr. Kroll, our next speaker.
+Jack Kroll	[1696.883-1700.755]	Yes. Next we have Maitri Lazaroff.
+Maitri Lazaroff	[1700.755-1809.021]	Hello. I'm Maitri Lazaroff, and I am not here to talk about Northwest Rail. I am an RTD rider, and I was formerly a regular rider of the E line. And the reason I say former is, like many other riders, I was pushed off the light rail a year ago due to the fact that I could no longer rely on it as reliable transportation. And now that issue that caused me to be pushed off of the train is solved. And I know there's already been a little bit of outreach on this. There's an article on your website, but it is my opinion that RTD needs to be as loud as possible with this. It's a sad fact that the majority of people in the metro don't ride transit, and we need to yell to get news like this out, because it's hard for it to spread with light announcements and word of mouth. We have lost, as of 2024, 21.6% of E line riders and 31.4% of H line riders. And not only is that a massive hit to the light rail system, but it bleeds to the rest of the system by people not being able to make those transfers. We saw ridership decreases on all three of our rail lines last year. And it's just, Directors making Reddit posts just really isn't enough. Could we maybe give two weeks of free fares to try and really get eyes back on the system to try and really make an effort to undo this ridership destruction that we've seen on our light rail? And especially on the Southeast corridor. Thank you. That's my time.
+Julien Bouquet	[1810.349-1812.652]	Thank you, Maitri. Mr. Kroll, our next speaker.
+Jack Kroll	[1813.672-1815.542]	Yes. Next, we have Richard Bamber.
 Julien Bouquet	[1817.239-1817.813]	Richard, you're recognized.
-Richard Bamber	[1820.665-1824.618]	Good evening, and thank you for the opportunity to speak tonight.
-Richard Bamber	[1825.033-1830.847]	I'd like to talk about the Title VI changes, which are up for approval tonight.
-Richard Bamber	[1832.138-1844.141]	GBT is generally in support of these changes, although we know a yes vote, needs to be carried out against the backdrop that a review of the methodology is needed in the medium term.
-Richard Bamber	[1844.485-1852.504]	Currently, RTD's only reliable data source uses Census data about what sort of populations demographics live in certain neighborhoods.
-Richard Bamber	[1853.648-1867.394]	So we make lots of effort to ensure service outside the front doors of equity populations is sufficiently good that they're not left behind when service is improved and they're not unfairly targeted when service has to be cut.
-Richard Bamber	[1868.648-1873.957]	However, this approach only assumes equity populations only travel locally within the communities they reside.
-Richard Bamber	[1875.158-1880.283]	A good transit network can level up communities and spread wealth across its entire metro area.
-Richard Bamber	[1881.026-1896.091]	There's no point in running 15 minute frequency buses past the doorsteps of a low income or BIPOC community if they then have to transfer onto another bus which runs every 60 minutes and drops you a mile away from that well-paying employer.
-Richard Bamber	[1897.372-1910.964]	The current Title VI process fails to consider how a local transit network either succeeds or fails to service equity populations effectively, and it is because it considers the routes basically in silos.
-Richard Bamber	[1911.788-1926.196]	And this is why, while we support the Title VI, we support the agency's efforts, we believe that it could be made a much more effective process if new data sources are considered and the methodology is reviewed.
-Richard Bamber	[1926.565-1928.079]	Thank you very much for letting me speak tonight.
-Julien Bouquet	[1929.350-1930.603]	Thank you for your comments, Richard.
-Julien Bouquet	[1930.873-1931.667]	Our next speaker, Mr.
-Julien Bouquet	[1931.931-1931.931]	Kroll?
+Richard Bamber	[1820.665-1928.079]	Good evening, and thank you for the opportunity to speak tonight. I'd like to talk about the Title VI changes, which are up for approval tonight. GBT is generally in support of these changes, although we know a yes vote, needs to be carried out against the backdrop that a review of the methodology is needed in the medium term. Currently, RTD's only reliable data source uses Census data about what sort of populations demographics live in certain neighborhoods. So we make lots of effort to ensure service outside the front doors of equity populations is sufficiently good that they're not left behind when service is improved and they're not unfairly targeted when service has to be cut. However, this approach only assumes equity populations only travel locally within the communities they reside. A good transit network can level up communities and spread wealth across its entire metro area. There's no point in running 15 minute frequency buses past the doorsteps of a low income or BIPOC community if they then have to transfer onto another bus which runs every 60 minutes and drops you a mile away from that well-paying employer. The current Title VI process fails to consider how a local transit network either succeeds or fails to service equity populations effectively, and it is because it considers the routes basically in silos. And this is why, while we support the Title VI, we support the agency's efforts, we believe that it could be made a much more effective process if new data sources are considered and the methodology is reviewed. Thank you very much for letting me speak tonight.
+Julien Bouquet	[1929.350-1931.931]	Thank you for your comments, Richard. Our next speaker, Mr. Kroll?
 Jack Kroll	[1932.216-1934.169]	Yes, next is Jo Elizabeth Pinto.
 Julien Bouquet	[1935.823-1940.873]	Jo, you are recognized.
 Jo Elizabeth Pinto	[1942.796-1943.464]	Am I unmuted?
 Jack Kroll	[1944.419-1945.216]	We hear you, Jo.
-Jo Elizabeth Pinto	[1945.501-1945.711]	Thank you.
-Jo Elizabeth Pinto	[1946.642-1950.716]	I would like to talk quickly about two issues.
-Jo Elizabeth Pinto	[1951.349-1954.571]	The first is the Rockies Ride.
-Jo Elizabeth Pinto	[1955.275-1971.748]	My family went to the Rockies game last week, and we looked up how to get there on the RTD website, and there's a whole page dedicated to the Rockies Ride.
-Jo Elizabeth Pinto	[1973.222-1981.944]	But when we got to the stop, there were no buses, no people, no cars, no nothing.
-Jo Elizabeth Pinto	[1982.855-1994.236]	So we called the RTD, 299-6000, and the woman laughed and said, oh, we haven't had those buses for years.
-Jo Elizabeth Pinto	[1995.854-2021.358]	So the RTD needs to take down the Rockies Ride info from its website if it is no longer running those services, and it needs to keep its website updated about the services that are provided because people depend on that website to be accurate.
-Jo Elizabeth Pinto	[2023.630-2029.505]	The other thing that I need to talk about is Access-on-Demand.
-Jo Elizabeth Pinto	[2031.328-2055.618]	And my issue is that when you look at the Access-on-Demand and when you are talking about cutting services-- which, again, if we are 20% to 25% of the population that have disabilities, a little more, a little less, like Ms.
-Jo Elizabeth Pinto	[2056.158-2089.519]	Folska said, the idea to cut services based on the RTD schedule will leave people with no services on the weekends if the bus doesn't run on weekends to that part of the service area, or at night, or if they live more than 3/4 of a mile from a bus stop.
-Jo Elizabeth Pinto	[2090.051-2092.711]	And that will leave people stranded.
-Jo Elizabeth Pinto	[2094.826-2100.470]	And people with disabilities go places after 5 o'clock.
-Jo Elizabeth Pinto	[2101.735-2103.388]	They go places on the weekends.
-Jo Elizabeth Pinto	[2104.099-2104.099]	They go places.
-Jo Elizabeth Pinto	[2104.099-2110.983]	They don't just go to doctors that are open in the daytime.
-Jo Elizabeth Pinto	[2111.649-2118.069]	They go to shows, they go to restaurants, they go to malls on the weekends.
-Jo Elizabeth Pinto	[2118.778-2121.757]	They go all the same places you do.
-Jo Elizabeth Pinto	[2122.163-2130.995]	And it becomes really difficult when they get stranded in their homes except from 9:00 to 5:00, weekdays.
-Jo Elizabeth Pinto	[2132.316-2153.895]	So just take that into consideration when you make these cuts and imagine people who are disabled going to the same places you do, and imagine being stranded at home because you cut so that they can only go from 9:00 to 5:00 on weekdays.
-Also-- Julien Bouquet	[2155.746-2158.447]	Jo, if you could wrap up your comments.
-Also-- Julien Bouquet	[2158.785-2160.135]	You're about 10 seconds over.
-Jo Elizabeth Pinto	[2160.493-2160.493]	OK.
-Jo Elizabeth Pinto	[2160.493-2160.684]	Thank you.
-Jo Elizabeth Pinto	[2161.334-2170.063]	The other thing is remember that these people with disabilities pay taxes to RTD the same way you do.
-Jo Elizabeth Pinto	[2170.568-2171.059]	Thank you.
-Jo Elizabeth Pinto	[2171.570-2172.788]	That's all I have to say.
-Julien Bouquet	[2173.092-2174.194]	Thank you for your comments, Jo.
-Julien Bouquet	[2175.055-2175.752]	Our next speaker, Mr.
-Julien Bouquet	[2175.985-2175.985]	Kroll?
-Jack Kroll	[2176.670-2176.670]	Yes.
-Jack Kroll	[2177.057-2178.606]	Next we have Tim Keenan.
+Jo Elizabeth Pinto	[1945.501-2155.746]	Thank you. I would like to talk quickly about two issues. The first is the Rockies Ride. My family went to the Rockies game last week, and we looked up how to get there on the RTD website, and there's a whole page dedicated to the Rockies Ride. But when we got to the stop, there were no buses, no people, no cars, no nothing. So we called the RTD, 299-6000, and the woman laughed and said, oh, we haven't had those buses for years. So the RTD needs to take down the Rockies Ride info from its website if it is no longer running those services, and it needs to keep its website updated about the services that are provided because people depend on that website to be accurate. The other thing that I need to talk about is Access-on-Demand. And my issue is that when you look at the Access-on-Demand and when you are talking about cutting services-- which, again, if we are 20% to 25% of the population that have disabilities, a little more, a little less, like Ms. Folska said, the idea to cut services based on the RTD schedule will leave people with no services on the weekends if the bus doesn't run on weekends to that part of the service area, or at night, or if they live more than 3/4 of a mile from a bus stop. And that will leave people stranded. And people with disabilities go places after 5 o'clock. They go places on the weekends. They go places. They don't just go to doctors that are open in the daytime. They go to shows, they go to restaurants, they go to malls on the weekends. They go all the same places you do. And it becomes really difficult when they get stranded in their homes except from 9:00 to 5:00, weekdays. So just take that into consideration when you make these cuts and imagine people who are disabled going to the same places you do, and imagine being stranded at home because you cut so that they can only go from 9:00 to 5:00 on weekdays. Also--
+Julien Bouquet	[2156.084-2160.135]	Jo, if you could wrap up your comments. You're about 10 seconds over.
+Jo Elizabeth Pinto	[2160.493-2172.788]	OK. Thank you. The other thing is remember that these people with disabilities pay taxes to RTD the same way you do. Thank you. That's all I have to say.
+Julien Bouquet	[2173.092-2175.985]	Thank you for your comments, Jo. Our next speaker, Mr. Kroll?
+Jack Kroll	[2176.670-2178.606]	Yes. Next we have Tim Keenan.
 Julien Bouquet	[2179.841-2180.406]	Tim, you're recognized.
-Jack Kroll	[2194.135-2194.950]	Tim?
-Looks like-- Tim Keenan	[2194.950-2196.254]	Can you hear me now?
-Julien Bouquet	[2196.819-2197.470]	We can hear you, Tim.
-Julien Bouquet	[2197.620-2197.800]	Thank you.
-Tim Keenan	[2198.601-2199.843]	Alrighty.
-Tim Keenan	[2199.843-2200.684]	I'm Tim Keenan.
-Tim Keenan	[2201.145-2201.692]	Thanks for listening.
-Tim Keenan	[2202.767-2206.657]	I am a totally blind user of Access-a-Ride.
-Tim Keenan	[2207.253-2207.753]	I'm sorry.
-Tim Keenan	[2208.274-2210.934]	Of Access-- I'm not sure if you caught the beginning of that.
-Tim Keenan	[2211.138-2211.525]	I'm Tim Keenan.
-Tim Keenan	[2211.739-2224.241]	I'm a totally blind user of Access-on-Demand, and I live in Baker and work a fluctuating schedule out at Amazon in Aurora, which includes night and overnight shifts.
-Tim Keenan	[2224.852-2236.681]	So if you were to follow any of these recommendations, me and people like me, because I know there are a lot of people with disabilities who work out there, would not be able to use Access-on-Demand for at least one leg of their trip.
-Tim Keenan	[2238.112-2242.018]	In my case, that would eat into my paycheck by close to a third.
-Tim Keenan	[2243.592-2252.713]	And when you look at the numbers here, Access-on-Demand is probably the most efficient of your services.
-Tim Keenan	[2253.133-2259.862]	With fixed routes costing $19 per boarding, Access-on-Demand at $16 and Access-a-Ride at $60.
-Tim Keenan	[2261.345-2271.688]	So this is really working well, and to cut it, I think you need to decide whether this is in fact sustainable.
-Tim Keenan	[2272.199-2278.906]	I know there was-- the use was just blowing up and people got worried, and so they commissioned this review and all that.
-Tim Keenan	[2279.689-2290.473]	But really, it's helping a lot of people, and at 1.13% of your annual budget, it sounds pretty sustainable to me.
-Tim Keenan	[2290.844-2301.035]	Now, all that said, I don't know anyone who wouldn't-- I don't know anybody who would be against paying a fare.
-Tim Keenan	[2301.485-2315.452]	So if you add a $4.50 fare and that's $2.8 million of savings from the current numbers.
-Tim Keenan	[2320.888-2323.232]	That's doing something to put more money back into the system.
-Tim Keenan	[2324.214-2326.475]	And we certainly don't mind paying our way.
-Tim Keenan	[2328.200-2340.663]	But to cut the area in hours is going to leave some people who don't even have bus service in their area anymore, but used to, it's going to leave those people totally stranded without any kind of affordable transit option.
-Tim Keenan	[2342.583-2349.297]	So my ask would be that you keep the limit at 60 trips a month.
-Tim Keenan	[2349.652-2355.757]	This allows full time workers, 40 trips, and then 20 trips to do whatever they want or need to do.
-Tim Keenan	[2356.096-2358.131]	Get groceries and participate in the community.
-Tim Keenan	[2360.895-2383.662]	Maintain the current service area and hours so you're not creating transit deserts, and implement pricing that's fair that stays constant at $4.50 or $2.25 for RTD live that doesn't punish people for taking more trips like a tiered system would do, and it also doesn't have the added overhead that that system would have.
-Tim Keenan	[2384.810-2399.877]	So basically you can keep the program as it is now, add a fare, and keep this program doing what it does best, which is connect people with disabilities with their community.
+Jack Kroll	[2194.135-2195.377]	Tim? Looks like--
+Tim Keenan	[2195.487-2196.254]	Can you hear me now?
+Julien Bouquet	[2196.819-2197.800]	We can hear you, Tim. Thank you.
+Tim Keenan	[2198.601-2399.877]	Alrighty. I'm Tim Keenan. Thanks for listening. I am a totally blind user of Access-a-Ride. I'm sorry. Of Access-- I'm not sure if you caught the beginning of that. I'm Tim Keenan. I'm a totally blind user of Access-on-Demand, and I live in Baker and work a fluctuating schedule out at Amazon in Aurora, which includes night and overnight shifts. So if you were to follow any of these recommendations, me and people like me, because I know there are a lot of people with disabilities who work out there, would not be able to use Access-on-Demand for at least one leg of their trip. In my case, that would eat into my paycheck by close to a third. And when you look at the numbers here, Access-on-Demand is probably the most efficient of your services. With fixed routes costing $19 per boarding, Access-on-Demand at $16 and Access-a-Ride at $60. So this is really working well, and to cut it, I think you need to decide whether this is in fact sustainable. I know there was-- the use was just blowing up and people got worried, and so they commissioned this review and all that. But really, it's helping a lot of people, and at 1.13% of your annual budget, it sounds pretty sustainable to me. Now, all that said, I don't know anyone who wouldn't-- I don't know anybody who would be against paying a fare. So if you add a $4.50 fare and that's $2.8 million of savings from the current numbers. That's doing something to put more money back into the system. And we certainly don't mind paying our way. But to cut the area in hours is going to leave some people who don't even have bus service in their area anymore, but used to, it's going to leave those people totally stranded without any kind of affordable transit option. So my ask would be that you keep the limit at 60 trips a month. This allows full time workers, 40 trips, and then 20 trips to do whatever they want or need to do. Get groceries and participate in the community. Maintain the current service area and hours so you're not creating transit deserts, and implement pricing that's fair that stays constant at $4.50 or $2.25 for RTD live that doesn't punish people for taking more trips like a tiered system would do, and it also doesn't have the added overhead that that system would have. So basically you can keep the program as it is now, add a fare, and keep this program doing what it does best, which is connect people with disabilities with their community.
 Julien Bouquet	[2400.178-2401.096]	Tim, if you could wrap up your comments.
-Tim Keenan	[2402.121-2402.332]	All set.
-Tim Keenan	[2402.582-2403.033]	Thank you very much.
-Julien Bouquet	[2403.944-2404.745]	Thank you for your comments, Tim.
-Julien Bouquet	[2405.326-2408.312]	For the sake of the record, I'd like to note that Director Ruscha has joined us.
-Julien Bouquet	[2409.793-2410.502]	Our next speaker, Mr.
-Julien Bouquet	[2410.739-2410.739]	Kroll.
-Jack Kroll	[2410.739-2411.376]	Yes.
-Jack Kroll	[2411.650-2412.745]	Next we have Nate Trela.
+Tim Keenan	[2402.121-2403.033]	All set. Thank you very much.
+Julien Bouquet	[2403.944-2410.739]	Thank you for your comments, Tim. For the sake of the record, I'd like to note that Director Ruscha has joined us. Our next speaker, Mr. Kroll.
+Jack Kroll	[2410.739-2412.745]	Yes. Next we have Nate Trela.
 Julien Bouquet	[2413.860-2414.434]	Nate, you're recognized.
-Nate Trela	[2419.830-2419.830]	Yeah.
-Nate Trela	[2419.830-2419.830]	Hi.
-Nate Trela	[2420.054-2420.728]	This is Nate Trela.
-Nate Trela	[2420.992-2423.075]	Thank you once again for the chance to speak.
-Nate Trela	[2424.698-2443.258]	Hopefully we're down the home stretch here in terms of finding a sustainable path forward for Access-on-Demand that still maintains this robust level of service and utility for the district residents that cannot use a fixed route service independently.
-Nate Trela	[2444.662-2456.445]	I implore you to recognize a few facts that are in the staff's presentation that you're going to-- the public's going to hear tonight and that was in the agenda packet for this meeting and for the operations meeting a couple weeks ago.
-Nate Trela	[2457.440-2467.624]	And there's some unanswered questions that you may already have as Board members, information that you should definitely, in my opinion, make sure as you're making decisions about the future of this program.
-Nate Trela	[2468.736-2481.719]	In the agenda packet, it already talks about how the cost of an Access trip is just a fraction of the cost of a traditional access ride service.
-Nate Trela	[2482.986-2506.092]	And I don't know if there has been any effort made to see if it's possible to try to encourage people to use Access-on-Demand instead of Access-a-Ride, if people are fully aware of the capabilities of it, if people are aware of how to use it, converting a few of those access ride trips to Access-on-Demand could yield significant savings in this whole process.
-Nate Trela	[2507.437-2515.603]	Also, it's worth pointing out that you're more than doubling the number of trips provided to people who cannot use fixed route service with Access-on-Demand, as opposed to Access-a-Ride.
-Nate Trela	[2516.150-2516.671]	That's a success.
-Nate Trela	[2517.532-2523.540]	You're helping people make connections, get around, participate in the workforce, participate in society.
-Nate Trela	[2524.703-2531.539]	As we've heard people talk about, shop, go out and get some entertainment, whether it's movies or music or what have you.
-Nate Trela	[2531.836-2533.620]	Things have become possible with this program.
-Nate Trela	[2534.588-2543.873]	Some of the answered questions in these proposals is in the tiered fare concept, it talks about needing to hire additional staff.
-Nate Trela	[2544.467-2548.251]	Perhaps this is already going to be discussed later tonight, but it's not clear what that staff would do.
-Nate Trela	[2549.216-2566.855]	And it's hard to fathom what would need to be added to-- what would need to be handled by added staff that couldn't be automated, couldn't be handled with a spreadsheet wizard and a knowledge of how to write some stuff in SQL.
-Nate Trela	[2568.325-2577.675]	There are ways to gather a lot of different data and process a lot of numbers, analyze the numbers to make that tiered fare approach work.
-Nate Trela	[2578.101-2581.725]	So it'd be good to know what those new hires would need to do.
-Nate Trela	[2582.429-2588.716]	Both proposals call for cutting back, as we've talked about, the service area hours back to match Access-a-Ride.
-Nate Trela	[2591.337-2593.793]	This isn't required as a supplemental premium service.
-Nate Trela	[2594.144-2597.301]	Access-on-Demand doesn't have to line up with Access-a-Ride.
-Nate Trela	[2598.023-2598.924]	That is a choice that's made.
-Nate Trela	[2601.106-2614.971]	What's the question is, how would Access-a-Ride enforce the restricted hours proposed and contained both these plans because when the National Federation of the Blind of Colorado has spoken with RTD staff before, we've been told that, yes, geofencing to define the boundaries can be done.
+Nate Trela	[2419.830-2614.971]	Yeah. Hi. This is Nate Trela. Thank you once again for the chance to speak. Hopefully we're down the home stretch here in terms of finding a sustainable path forward for Access-on-Demand that still maintains this robust level of service and utility for the district residents that cannot use a fixed route service independently. I implore you to recognize a few facts that are in the staff's presentation that you're going to-- the public's going to hear tonight and that was in the agenda packet for this meeting and for the operations meeting a couple weeks ago. And there's some unanswered questions that you may already have as Board members, information that you should definitely, in my opinion, make sure as you're making decisions about the future of this program. In the agenda packet, it already talks about how the cost of an Access trip is just a fraction of the cost of a traditional access ride service. And I don't know if there has been any effort made to see if it's possible to try to encourage people to use Access-on-Demand instead of Access-a-Ride, if people are fully aware of the capabilities of it, if people are aware of how to use it, converting a few of those access ride trips to Access-on-Demand could yield significant savings in this whole process. Also, it's worth pointing out that you're more than doubling the number of trips provided to people who cannot use fixed route service with Access-on-Demand, as opposed to Access-a-Ride. That's a success. You're helping people make connections, get around, participate in the workforce, participate in society. As we've heard people talk about, shop, go out and get some entertainment, whether it's movies or music or what have you. Things have become possible with this program. Some of the answered questions in these proposals is in the tiered fare concept, it talks about needing to hire additional staff. Perhaps this is already going to be discussed later tonight, but it's not clear what that staff would do. And it's hard to fathom what would need to be added to-- what would need to be handled by added staff that couldn't be automated, couldn't be handled with a spreadsheet wizard and a knowledge of how to write some stuff in SQL. There are ways to gather a lot of different data and process a lot of numbers, analyze the numbers to make that tiered fare approach work. So it'd be good to know what those new hires would need to do. Both proposals call for cutting back, as we've talked about, the service area hours back to match Access-a-Ride. This isn't required as a supplemental premium service. Access-on-Demand doesn't have to line up with Access-a-Ride. That is a choice that's made. What's the question is, how would Access-a-Ride enforce the restricted hours proposed and contained both these plans because when the National Federation of the Blind of Colorado has spoken with RTD staff before, we've been told that, yes, geofencing to define the boundaries can be done.
 Julien Bouquet	[2615.232-2617.294]	Nate, if you could wrap up your comments.
-Nate Trela	[2617.978-2617.978]	Sure.
-Nate Trela	[2617.978-2617.978]	Sure.
-Nate Trela	[2619.040-2631.503]	Just saying that the cutback of the hours is going to be incredibly complex to manage, and it's unclear how you could expect somebody to do that, especially when, again, the point of RTD is to be helping people make connections.
-Nate Trela	[2632.137-2634.904]	Adding these layers of complexity to it does the exact opposite.
-Julien Bouquet	[2636.763-2637.110]	Thank you, Nate.
-Julien Bouquet	[2638.105-2638.742]	Our next speaker, Mr.
-Julien Bouquet	[2638.954-2638.954]	Kroll.
-Jack Kroll	[2639.298-2639.298]	Yes.
-Jack Kroll	[2639.618-2640.900]	Next we have Cody Bair.
+Nate Trela	[2617.978-2634.904]	Sure. Sure. Just saying that the cutback of the hours is going to be incredibly complex to manage, and it's unclear how you could expect somebody to do that, especially when, again, the point of RTD is to be helping people make connections. Adding these layers of complexity to it does the exact opposite.
+Julien Bouquet	[2636.763-2638.954]	Thank you, Nate. Our next speaker, Mr. Kroll.
+Jack Kroll	[2639.298-2640.900]	Yes. Next we have Cody Bair.
 Julien Bouquet	[2642.103-2642.690]	Cody, you're recognized.
-Cody Bair	[2646.470-2648.050]	Good evening and thank you RTD Board.
-Cody Bair	[2648.353-2659.654]	I am also here to talk about Access-a-Ride-- Access-on-Demand service, and have spoken about the topic at a few meetings before.
-Cody Bair	[2660.577-2666.504]	Tonight I want to say that I agree with you what Dr.
-Cody Bair	[2666.998-2670.949]	Folska and Tim Keenan said about this.
-Cody Bair	[2671.443-2676.382]	Access-on-Demand cost is really a fraction of RTD's budget.
-Cody Bair	[2676.876-2701.402]	At just 1.13% and just north of, I think $10 million, this is not a huge opportunity for RTD to save significantly on the budget and would be a huge loss of service for many Coloradoans in the RTD district with disabilities.
-Cody Bair	[2702.326-2705.920]	Speaking to the current proposals that are out there.
-Cody Bair	[2706.369-2720.746]	With the tiered proposal, one thing that I would urge the RTD Board to think about and questions to ask would be, how would we actually enforce the fares of the tiered proposal?
-Cody Bair	[2721.255-2733.145]	This service is offered amongst Uber, Lyft, and a couple of other taxi platforms, neither of which share information or communicate with each other at all.
-Cody Bair	[2733.769-2749.689]	To that point, even in the current system as a user, if I want to see how many trips I've used, I have to open each platform and count the number that have been taken in the month on that platform.
-Cody Bair	[2750.403-2766.005]	I just don't see an administratively effective way to make the fare thing work without putting that burden on the rider, which would inherently cause issues for people keeping track of it.
-Cody Bair	[2767.489-2772.582]	Second, to follow up on Nate's comments about the hours.
-Cody Bair	[2773.148-2791.188]	You look at somebody who's a full time employee at Amazon like Tim and many others who would be affected by this, that's taking-- by cutting people's ability to use the service, we're taking tax revenue out of the Colorado economy.
-Cody Bair	[2791.636-2796.306]	I'm not sure that that's something that makes a lot of sense for RTD.
-Cody Bair	[2796.665-2815.453]	And people have built their lives around being able to access this service in its current state and any reduction and change of the service area or hours is a reduction in service, in my mind, and something that I would completely be against.
-Cody Bair	[2816.164-2819.930]	Appreciate your guys' time tonight, and that concludes my comments.
-Julien Bouquet	[2821.410-2822.328]	Thank you for your comments, Cody.
-Julien Bouquet	[2822.871-2822.871]	Mr.
-Julien Bouquet	[2823.127-2823.638]	Kroll, our next speaker.
-Jack Kroll	[2824.273-2824.273]	Yes.
-Jack Kroll	[2824.713-2827.517]	The last speaker we have in the queue is Maryann Migliorelli.
+Cody Bair	[2646.470-2819.930]	Good evening and thank you RTD Board. I am also here to talk about Access-a-Ride-- Access-on-Demand service, and have spoken about the topic at a few meetings before. Tonight I want to say that I agree with you what Dr. Folska and Tim Keenan said about this. Access-on-Demand cost is really a fraction of RTD's budget. At just 1.13% and just north of, I think $10 million, this is not a huge opportunity for RTD to save significantly on the budget and would be a huge loss of service for many Coloradoans in the RTD district with disabilities. Speaking to the current proposals that are out there. With the tiered proposal, one thing that I would urge the RTD Board to think about and questions to ask would be, how would we actually enforce the fares of the tiered proposal? This service is offered amongst Uber, Lyft, and a couple of other taxi platforms, neither of which share information or communicate with each other at all. To that point, even in the current system as a user, if I want to see how many trips I've used, I have to open each platform and count the number that have been taken in the month on that platform. I just don't see an administratively effective way to make the fare thing work without putting that burden on the rider, which would inherently cause issues for people keeping track of it. Second, to follow up on Nate's comments about the hours. You look at somebody who's a full time employee at Amazon like Tim and many others who would be affected by this, that's taking-- by cutting people's ability to use the service, we're taking tax revenue out of the Colorado economy. I'm not sure that that's something that makes a lot of sense for RTD. And people have built their lives around being able to access this service in its current state and any reduction and change of the service area or hours is a reduction in service, in my mind, and something that I would completely be against. Appreciate your guys' time tonight, and that concludes my comments.
+Julien Bouquet	[2821.410-2823.638]	Thank you for your comments, Cody. Mr. Kroll, our next speaker.
+Jack Kroll	[2824.273-2827.517]	Yes. The last speaker we have in the queue is Maryann Migliorelli.
 Julien Bouquet	[2828.798-2829.729]	Maryann, you're recognized.
-Maryann Migliorelli	[2832.955-2834.141]	Good evening, ladies and gentlemen.
-Maryann Migliorelli	[2834.678-2836.913]	Thank you so much for your time and your attention.
-Maryann Migliorelli	[2837.983-2850.658]	Tonight I would like to speak to you briefly about equity and the Access-on-Demand system and in RTD in general.
-Maryann Migliorelli	[2852.364-2864.428]	We have been told by RTD members that we cannot have the multiple stop situation because that would not be equitable.
-Maryann Migliorelli	[2865.558-2869.950]	We have been told that we can have certain things, but we can't have others.
-Maryann Migliorelli	[2871.345-2879.659]	One of the things that we are now being told is that with this tiered system, we can have inequity in pricing.
-Maryann Migliorelli	[2880.656-2887.515]	There is no place in the RTD system where riding more costs more per trip.
-Maryann Migliorelli	[2888.829-2890.603]	This does not happen on Access-a-Ride.
-Maryann Migliorelli	[2891.318-2899.216]	It does not happen anywhere in the fixed route system, on any light rail, on any bus.
-Maryann Migliorelli	[2899.730-2908.543]	As a matter of fact, RTD went out of its way to remove the barriers to regional transit by removing the price barrier.
-Maryann Migliorelli	[2909.384-2923.883]	But with the ideas of this tiered system, we are saying-- and you would be saying if you approve it-- that anybody who does more than 30 trips per month should have to pay more in order to use a system.
-Maryann Migliorelli	[2924.890-2927.043]	That, ladies and gentlemen, is inequity.
-Maryann Migliorelli	[2928.074-2933.299]	And that is not something that RTD should even have been entertaining that proposal.
-Maryann Migliorelli	[2934.462-2942.020]	But you will do what is necessary, and I will thank you for the hard work that is involved in keeping our program alive.
-Maryann Migliorelli	[2943.875-2969.044]	The other thought is in removing and putting the boundaries in that are the same for Access-a-Ride, there are many people who will be affected whose life plans, the places they live, the places they work, the places they choose to do business and entertain will all be affected.
-Maryann Migliorelli	[2970.993-2986.890]	People have been provided a service, have been able to make these decisions about their lives because of the service that is provided, and taking service away creates further inequity and transit deficits.
-Maryann Migliorelli	[2988.348-3002.947]	That is not something RTD should be looking for doing, and I sincerely hope that in every way that you can, you find a way to keep the Access-on-Demand program as open as it is right now.
-Maryann Migliorelli	[3003.691-3011.792]	I personally do not know anybody who would object to paying the 4.50 or 2.25 fare as proposed.
-Maryann Migliorelli	[3012.268-3019.416]	But adding additional fares and cutting service will make transit deficits that should not be considered.
-Maryann Migliorelli	[3020.213-3029.957]	Right now, this program is moving people who have never had a chance to participate in public transit life in the way that we can right now.
-Maryann Migliorelli	[3030.871-3033.165]	Please consider this when you're making your decisions.
-Maryann Migliorelli	[3033.914-3040.535]	Thank you so much for your time and those who remember me before, if I was there, I would bring you warm chocolate cookies.
-Julien Bouquet	[3042.541-3043.942]	Thank you for your comments, Maryann.
-Julien Bouquet	[3045.384-3049.127]	Are there any members of the public who would like to-- excuse me.
-Julien Bouquet	[3049.467-3049.467]	Mr.
-Julien Bouquet	[3049.808-3051.169]	Kroll, any further online participants?
+Maryann Migliorelli	[2832.955-3040.535]	Good evening, ladies and gentlemen. Thank you so much for your time and your attention. Tonight I would like to speak to you briefly about equity and the Access-on-Demand system and in RTD in general. We have been told by RTD members that we cannot have the multiple stop situation because that would not be equitable. We have been told that we can have certain things, but we can't have others. One of the things that we are now being told is that with this tiered system, we can have inequity in pricing. There is no place in the RTD system where riding more costs more per trip. This does not happen on Access-a-Ride. It does not happen anywhere in the fixed route system, on any light rail, on any bus. As a matter of fact, RTD went out of its way to remove the barriers to regional transit by removing the price barrier. But with the ideas of this tiered system, we are saying-- and you would be saying if you approve it-- that anybody who does more than 30 trips per month should have to pay more in order to use a system. That, ladies and gentlemen, is inequity. And that is not something that RTD should even have been entertaining that proposal. But you will do what is necessary, and I will thank you for the hard work that is involved in keeping our program alive. The other thought is in removing and putting the boundaries in that are the same for Access-a-Ride, there are many people who will be affected whose life plans, the places they live, the places they work, the places they choose to do business and entertain will all be affected. People have been provided a service, have been able to make these decisions about their lives because of the service that is provided, and taking service away creates further inequity and transit deficits. That is not something RTD should be looking for doing, and I sincerely hope that in every way that you can, you find a way to keep the Access-on-Demand program as open as it is right now. I personally do not know anybody who would object to paying the 4.50 or 2.25 fare as proposed. But adding additional fares and cutting service will make transit deficits that should not be considered. Right now, this program is moving people who have never had a chance to participate in public transit life in the way that we can right now. Please consider this when you're making your decisions. Thank you so much for your time and those who remember me before, if I was there, I would bring you warm chocolate cookies.
+Julien Bouquet	[3042.541-3051.169]	Thank you for your comments, Maryann. Are there any members of the public who would like to-- excuse me. Mr. Kroll, any further online participants?
 Jack Kroll	[3052.189-3053.600]	No further online participants.
-Julien Bouquet	[3054.091-3058.101]	Any members of the public who would like to make comments?
-Julien Bouquet	[3058.355-3060.139]	Feel free to come up to the podium.
-Julien Bouquet	[3063.879-3065.734]	Seeing none, were there any emailed comments, Mr.
-Julien Bouquet	[3065.988-3065.988]	Kroll?
-Jack Kroll	[3066.423-3066.949]	There were a number.
-Jack Kroll	[3067.144-3070.084]	I am not going to go through all 46 and read the names.
-Jack Kroll	[3070.509-3089.239]	However, you received 36 letters with respect to Northwest Rail and the IGA conversation that you held earlier today, five letters with respect to the ETOD policy you will consider later this evening, three letters with respect to Title VI policy or the program update that you all will consider later this evening.
-Jack Kroll	[3090.268-3100.289]	One regarding the National Women's Soccer League proposed stadium that was discussed earlier here in person, and one regarding paratransit AOD program modifications.
-Jack Kroll	[3101.346-3103.618]	All will be appended to the transcript of this meeting.
-Jack Kroll	[3104.170-3116.478]	And just as a reminder to Directors, a majority of these written public comment comments were submitted to the rtd.directors email group, which you all have access to and can see in real time.
-Julien Bouquet	[3117.732-3118.183]	Thank you, Mr.
-Julien Bouquet	[3118.409-3118.409]	Kroll.
-Julien Bouquet	[3118.934-3122.711]	With no other participants in the queue, we will now close public participation at this time.
-Julien Bouquet	[3124.203-3126.802]	Moving on to our next item, external entities report.
-Julien Bouquet	[3127.147-3130.197]	We have no external entity reports this month.
-Julien Bouquet	[3131.812-3133.151]	Moving on to our next item.
-Julien Bouquet	[3133.418-3133.686]	Discussion items.
-Julien Bouquet	[3134.354-3141.669]	We have one discussion item on the agenda this evening, which is a holdover from last week's Operation Safety and Security Committee meeting.
-Julien Bouquet	[3142.021-3144.509]	It is the Access-on-Demand program modifications.
-Julien Bouquet	[3145.565-3151.104]	I would like to offer the floor to GM/CEO Debra Johnson for some opening remarks before introducing Ms.
-Julien Bouquet	[3151.750-3151.750]	Vallejos.
-Debra Johnson	[3153.632-3154.659]	Thank you very much, Mr.
-Debra Johnson	[3154.916-3154.916]	Chair.
-Debra Johnson	[3155.654-3157.355]	Good afternoon or evening, Board members.
-Debra Johnson	[3157.696-3160.078]	Debra Johnson, General Manager and Chief Executive Officer.
-Debra Johnson	[3161.073-3168.966]	I am joined by Erin Vallejos, who serves as the Acting Assistant or Deputy Assistant General Manager of Bus Operations.
-Debra Johnson	[3169.885-3185.515]	And as indicated in your remarks, sir, we are here referencing the previous agendized topic at the Operations Safety and Security Committee that we did not get to and wanted to have this conversation with you all this evening.
-Debra Johnson	[3186.095-3194.211]	The intent of this presentation is to ground all Board members in our paratransit programs.
-Debra Johnson	[3194.811-3212.265]	But more specifically, what we are seeking from this body is some guidance relative to Access-on-Demand, which is a supplemental premium service as it relates to paratransit services, not the Americans with Disabilities Act of 1990 complementary paratransit services.
-Debra Johnson	[3212.693-3218.092]	And in doing so, this conversation will help us guide our path forward.
-Debra Johnson	[3219.603-3229.472]	Specifically, I think what's notable for everybody to understand that the current paratransit contracts that we have for Access-on-Demand do sunset at the end of December.
-Debra Johnson	[3230.399-3232.821]	We have had conversations relative to modifications.
-Debra Johnson	[3233.225-3243.997]	In absence of having some guidance, we run the risk of not having any type of services, and hence why it's so imperative is that we adhere to open and fair competition.
-Debra Johnson	[3244.332-3255.015]	In order to do a solicitation relative to services, we have to have some guidance relative to the specifications that would be included in a solicitation for a request for proposal.
-Debra Johnson	[3255.898-3268.640]	So this is not for you to make a decision relative to where we are, but provide guidance, because what we anticipate doing with said guidance and bringing forward these scenarios after meeting with some board members, i.e.
-Debra Johnson	[3269.880-3284.635]	Chair Ruscha and Director Chandler, that are both on the Operation Safety and Security Committee, is to seek that direction so we can then go out to the customer segments and garner a better understanding.
-Debra Johnson	[3284.980-3305.247]	While we've heard comments here, we have taken part in a myriad of different public participation engagements and want to ensure that we are being good fiscal stewards, but also ensuring that we are providing the independence and ability for all aspects of our population to be able to travel and move about to and fro.
-Debra Johnson	[3305.619-3308.667]	So with that being said, I will yield the floor to Ms.
-Debra Johnson	[3309.024-3311.261]	Vallejos to commence with the presentation.
-Debra Johnson	[3311.748-3315.096]	If we could have Board Office staff pull that up, that would be appreciated.
-Debra Johnson	[3315.574-3315.765]	Thank you.
-Erin Vallejos	[3334.801-3336.360]	It's been a while since I've used these microphones.
-Erin Vallejos	[3337.183-3337.730]	Good evening, everyone.
-Erin Vallejos	[3338.244-3349.731]	As GM/CEO Johnson said, I'm Erin Vallejos, the Acting Deputy Assistant General Manager for Bus Operations, and we are just going to go over just a quick overview.
-Erin Vallejos	[3350.056-3354.012]	I think it's a lot of information that you've already seen, so we won't spend too much time on that.
-Erin Vallejos	[3354.961-3365.748]	Just kind of hit on what the initial recommendation was that we made talk about some revised recommendations, and then again, open it up for discussion to get an idea of some direction.
-Julien Bouquet	[3366.593-3366.593]	Ms.
-Julien Bouquet	[3366.793-3369.299]	Vallejos, before, could you speak a little closer to the microphone?
+Julien Bouquet	[3054.091-3065.988]	Any members of the public who would like to make comments? Feel free to come up to the podium. Seeing none, were there any emailed comments, Mr. Kroll?
+Jack Kroll	[3066.423-3116.478]	There were a number. I am not going to go through all 46 and read the names. However, you received 36 letters with respect to Northwest Rail and the IGA conversation that you held earlier today, five letters with respect to the ETOD policy you will consider later this evening, three letters with respect to Title VI policy or the program update that you all will consider later this evening. One regarding the National Women's Soccer League proposed stadium that was discussed earlier here in person, and one regarding paratransit AOD program modifications. All will be appended to the transcript of this meeting. And just as a reminder to Directors, a majority of these written public comment comments were submitted to the rtd.directors email group, which you all have access to and can see in real time.
+Julien Bouquet	[3117.732-3151.750]	Thank you, Mr. Kroll. With no other participants in the queue, we will now close public participation at this time. Moving on to our next item, external entities report. We have no external entity reports this month. Moving on to our next item. Discussion items. We have one discussion item on the agenda this evening, which is a holdover from last week's Operation Safety and Security Committee meeting. It is the Access-on-Demand program modifications. I would like to offer the floor to GM/CEO Debra Johnson for some opening remarks before introducing Ms. Vallejos.
+Debra Johnson	[3153.632-3315.765]	Thank you very much, Mr. Chair. Good afternoon or evening, Board members. Debra Johnson, General Manager and Chief Executive Officer. I am joined by Erin Vallejos, who serves as the Acting Assistant or Deputy Assistant General Manager of Bus Operations. And as indicated in your remarks, sir, we are here referencing the previous agendized topic at the Operations Safety and Security Committee that we did not get to and wanted to have this conversation with you all this evening. The intent of this presentation is to ground all Board members in our paratransit programs. But more specifically, what we are seeking from this body is some guidance relative to Access-on-Demand, which is a supplemental premium service as it relates to paratransit services, not the Americans with Disabilities Act of 1990 complementary paratransit services. And in doing so, this conversation will help us guide our path forward. Specifically, I think what's notable for everybody to understand that the current paratransit contracts that we have for Access-on-Demand do sunset at the end of December. We have had conversations relative to modifications. In absence of having some guidance, we run the risk of not having any type of services, and hence why it's so imperative is that we adhere to open and fair competition. In order to do a solicitation relative to services, we have to have some guidance relative to the specifications that would be included in a solicitation for a request for proposal. So this is not for you to make a decision relative to where we are, but provide guidance, because what we anticipate doing with said guidance and bringing forward these scenarios after meeting with some board members, i.e. Chair Ruscha and Director Chandler, that are both on the Operation Safety and Security Committee, is to seek that direction so we can then go out to the customer segments and garner a better understanding. While we've heard comments here, we have taken part in a myriad of different public participation engagements and want to ensure that we are being good fiscal stewards, but also ensuring that we are providing the independence and ability for all aspects of our population to be able to travel and move about to and fro. So with that being said, I will yield the floor to Ms. Vallejos to commence with the presentation. If we could have Board Office staff pull that up, that would be appreciated. Thank you.
+Erin Vallejos	[3334.801-3365.748]	It's been a while since I've used these microphones. Good evening, everyone. As GM/CEO Johnson said, I'm Erin Vallejos, the Acting Deputy Assistant General Manager for Bus Operations, and we are just going to go over just a quick overview. I think it's a lot of information that you've already seen, so we won't spend too much time on that. Just kind of hit on what the initial recommendation was that we made talk about some revised recommendations, and then again, open it up for discussion to get an idea of some direction.
+Julien Bouquet	[3366.593-3369.299]	Ms. Vallejos, before, could you speak a little closer to the microphone?
 Erin Vallejos	[3369.917-3370.398]	Yes, I can.
 Julien Bouquet	[3370.658-3371.109]	Thank you so much.
-Erin Vallejos	[3371.279-3371.689]	Of course.
-Erin Vallejos	[3372.140-3378.453]	OK, so just to highlight on this, again, as GM/CEO Johnson said.
-Erin Vallejos	[3378.904-3383.864]	Access-a- Ride and Access-on-Demand are the two programs that we have.
-Erin Vallejos	[3384.535-3390.444]	Access-a-Ride is RTD's federally required ADA complementary paratransit service.
-Erin Vallejos	[3391.163-3393.826]	It does supplement our fixed route services.
-Erin Vallejos	[3394.851-3406.545]	There is a fare payment required for these services and customers must meet the criteria set forth by the Americans with Disabilities Act of 1990 to be eligible.
-Erin Vallejos	[3406.958-3413.237]	This is provided with all RTD branded Access-a-Ride vehicles that are all 100% accessible.
-Erin Vallejos	[3414.507-3418.930]	And then Access-on-Demand is our supplemental premium paratransit service.
-Erin Vallejos	[3420.153-3423.594]	It is a curb-to-curb taxi and rideshare service.
-Erin Vallejos	[3424.638-3434.954]	It is available to current paratransit customers, so they must meet those eligibility criteria to qualify for Access-a-Ride to then use Access-on-Demand.
-Erin Vallejos	[3436.372-3442.494]	And as it stands today, RTD pays the first $25 of the trip and the remaining portion is paid by the customer.
-Erin Vallejos	[3443.668-3447.160]	And again, ability today to take 60 total trips.
-Erin Vallejos	[3448.336-3450.256]	So just some quick operating statistics.
-Erin Vallejos	[3450.820-3458.337]	The annual operating cost in 2024 for Access-a-Ride was just over 53 million, and the customer trips were just over 500,000.
-Erin Vallejos	[3458.835-3467.824]	And again, these are RTD owned vehicles, and the contractors that operate this service have over 500 drivers, mechanics, and other staff.
-Erin Vallejos	[3468.232-3468.853]	And then Access-on-Demand.
-Erin Vallejos	[3469.164-3473.512]	Last year it was about just over $15.3 million for the budget.
-Erin Vallejos	[3476.008-3477.201]	Just over 685,000 trips.
-Erin Vallejos	[3477.599-3480.780]	And these are all provided by third party vehicles.
-Erin Vallejos	[3483.031-3488.359]	So again, as we touched on, you must be eligible for Access-a-Ride to also use Access-on-Demand.
-Erin Vallejos	[3490.639-3499.744]	There is a process that customers must go through that determines if a customer has a disabling condition that would prevent them from using our regular fixed route service.
-Erin Vallejos	[3501.050-3507.759]	There's an application process, a medical verification process, and then an in-person assessment that customers must complete.
-Erin Vallejos	[3508.158-3512.269]	And there are a couple of different types of eligibility that a customer could receive.
-Erin Vallejos	[3512.744-3517.920]	Unconditional means you can have access to the full service for up to four years.
-Erin Vallejos	[3518.831-3518.831]	Temporary.
-Erin Vallejos	[3519.154-3524.315]	You might have a condition that's going to improve, recovering from surgery or something along those lines.
-Erin Vallejos	[3525.239-3535.520]	And then conditional would be when there was something-- maybe you're sensitive to extreme hot or extreme cold, so you would be able to use it at those times, but not the full year.
-Erin Vallejos	[3537.537-3537.537]	OK.
-Erin Vallejos	[3537.914-3543.187]	And as we have touched on, this is something that you've probably seen as well.
-Erin Vallejos	[3544.324-3548.142]	We are continuing to see an increase in Access-on-Demand usage.
-Erin Vallejos	[3549.030-3555.771]	This is through 2024, but we continue to see that Access- on-Demand trend line going up into the start of this year.
-Erin Vallejos	[3556.097-3565.368]	And Access-a-Ride, when you look at the trend line, while it is staying a little bit more stable, we are still seeing an increase in usage there as well.
-Erin Vallejos	[3567.862-3571.216]	And as we've talked about, average monthly trips per customer.
-Erin Vallejos	[3571.588-3576.805]	The majority of customers are falling into the category of taking up to 50 trips.
-Erin Vallejos	[3577.198-3586.653]	That is about 90% of the customers when we last did the analysis, and about 10% of the customers again fall into that 51 to 60 category.
-Erin Vallejos	[3588.989-3593.957]	So now I'm going to just remind everyone of what our initial recommendations were back in 2024.
-Erin Vallejos	[3594.367-3599.998]	As it stands today again, quickly, there's a $0 base customer fare.
-Erin Vallejos	[3600.768-3602.613]	The trip cap is 60 per month.
-Erin Vallejos	[3602.921-3604.766]	Subsidy is up to $25 per trip.
-Erin Vallejos	[3606.416-3609.976]	It is available within the entire district and it is available 24/7.
-Erin Vallejos	[3611.384-3625.446]	Back when we came to you in November of 2024, we had proposed making changes, and this involved having a $4.50 base customer fare, which would be $2.25 for our LiVE eligible customers.
-Erin Vallejos	[3626.466-3628.781]	We proposed a trip cap of $40 per month.
-Erin Vallejos	[3630.282-3637.938]	The subsidy would go to $20 per trip, and then it was proposed to mirror both the current service area and the service hours.
-Erin Vallejos	[3640.233-3648.446]	With this recommendation, there were going to be cost savings that the District would realize, and that was going to be about $5.8 million.
-Erin Vallejos	[3650.184-3657.831]	So instead of the projected yearly spend being a little bit over 15 million, we would go down to about 9.4.
-Erin Vallejos	[3661.957-3669.140]	OK, and as a result of some of the feedback and comments that we've heard, we did put together two additional revised scenarios.
-Erin Vallejos	[3669.487-3672.619]	So scenario one is what I'm going to touch on first.
-Erin Vallejos	[3673.152-3676.447]	So this has to do with an increased trip cap approach.
-Erin Vallejos	[3677.659-3685.643]	So what we were proposing in this scenario is increasing the trip cap to 50 per month from the original 40 that was proposed.
-Erin Vallejos	[3685.970-3697.694]	We are proposing as this is, again, as we've said, a premium supplemental service, a fare of $6.50 per trip, which would be $3.25 for our LiVE customers.
-Erin Vallejos	[3699.229-3701.339]	Then the remainder of the proposal does remain the same.
-Erin Vallejos	[3701.713-3713.108]	We were still proposing a subsidy per trip of $20, and we are proposing mirroring the current service area and service hours as that of our Access-a-Ride program.
-Erin Vallejos	[3714.303-3729.584]	With this program, we did see actually a little bit of the yearly impact would be a cost savings of about 6.1 million, bringing our total spend to about a little over 9.1.
-Erin Vallejos	[3730.013-3747.122]	With the 50 trips, that does allow for customers to still have-- given there's about 20 week days in a month that does allow for customers to still travel to work, but then does allow for some ancillary trips throughout the month.
-Erin Vallejos	[3749.977-3756.159]	And then another scenario that we had put together is the tiered approach that we have discussed.
-Erin Vallejos	[3757.206-3764.389]	With this approach, we would still maintain a trip cap of up to 60 trips per month, which matches what we have currently.
-Erin Vallejos	[3765.676-3776.593]	There would be a $4.50 base customer fare for up to 30 trips, $5.50 for 31 to 50, and $6.50 for 51 to 60.
-Erin Vallejos	[3777.804-3780.874]	And the remainder of the recommendation would remain the same.
-Erin Vallejos	[3782.613-3800.063]	With this program, as some people have noted, due to the program structure and some of the manual aspects that exist with monitoring today, there would be a pretty big an increase in staff oversight that would result in additional staff headcount.
-Erin Vallejos	[3800.500-3806.989]	Again, that had been noted, but as it stands today, the program does require quite a bit of manual intervention.
-Erin Vallejos	[3808.347-3816.088]	There is also, as someone mentioned, the customers would need to be keeping a little bit closer track of their trips, and that could lead to confusion.
-Erin Vallejos	[3816.867-3822.599]	It is something a customer would have to be regularly thinking, all right, where am I at for the month?
-Erin Vallejos	[3823.362-3824.551]	Have I hit that 30 trips?
-Erin Vallejos	[3824.789-3826.692]	So they know what to expect for their costs.
-Erin Vallejos	[3828.749-3833.298]	With this program, we would see some reductions of just over $5 million.
-Erin Vallejos	[3833.757-3844.097]	So it is a little bit less than some of the other recommendations that we've put forth, and it would bring our projected yearly spend to about $10.28 million a year.
-Erin Vallejos	[3848.341-3848.671]	Oh, and actually.
-Erin Vallejos	[3849.860-3851.001]	So proposed next steps.
-Erin Vallejos	[3851.381-3860.126]	We are here, as GM/CEO Johnson has said, to just garner everyone's feedback and get some guidance on a path forward.
-Erin Vallejos	[3861.067-3867.368]	The intent is to do outreach and engagement in June based on some of that guidance and engage with the community.
-Erin Vallejos	[3867.663-3878.138]	We would be coming back for Board consideration in July with an actual recommended action to the committee, and then provided the committee advanced it at the Board meeting.
-Erin Vallejos	[3878.572-3883.692]	And we would begin implementation in August with full implementation in October.
-Erin Vallejos	[3884.197-3887.490]	And with that, I will open it up.
-Julien Bouquet	[3889.082-3889.082]	Perfect.
-Julien Bouquet	[3889.982-3891.489]	Thank you very much for your presentation, Ms.
-Julien Bouquet	[3891.744-3891.744]	Vallejos.
-Julien Bouquet	[3893.165-3893.165]	OK.
-Julien Bouquet	[3893.401-3895.051]	I'm going to open it up for Directors.
-Julien Bouquet	[3895.567-3896.258]	Second Vice Chair Whitmore.
-Troy Whitmore	[3896.258-3902.035]	Thank you for the presentation and the ease of absorbing the proposed changes.
-Troy Whitmore	[3903.264-3915.259]	Erin, looking at the second proposal, the tiered approach, one of our commenters talked about the complications of keeping up with number of trips.
-Troy Whitmore	[3916.522-3928.466]	Is that something that the new staff would be able to be a clearinghouse, if you will, to where you have one call to RTD instead of calling a taxi and a Lyft and an Uber?
-Troy Whitmore	[3928.776-3931.569]	That seems to be the most difficult part of that.
-Troy Whitmore	[3931.879-3938.395]	I'm just curious if you think our staff would be handling that in a way that would be handy for our customers.
-Erin Vallejos	[3938.706-3947.083]	It's definitely something I think we could assist with, but I do think there would still be some burden on the customer for having some of that responsibility.
-Erin Vallejos	[3948.207-3953.467]	Again, as I mentioned, as it stands today, there is just a very manual aspect of the program.
-Erin Vallejos	[3954.317-3962.355]	And so while we're always looking at things to improve, I do think there would still be some responsibility that would live with the customer.
-Julien Bouquet	[3964.934-3965.255]	Thank you.
-Julien Bouquet	[3967.360-3967.360]	Director Catlin.
-Peggy Catlin	[3967.360-3967.660]	Thank you.
-Peggy Catlin	[3967.981-3970.014]	And thank you for a very clear presentation.
-Peggy Catlin	[3970.384-3973.578]	Although I have one question of clarification.
-Peggy Catlin	[3974.490-3976.891]	You talk about mirroring the existing service area.
-Peggy Catlin	[3978.496-3993.036]	One of the things that appealed to me about this service was that I don't think that the customers were restricted to the 3/4 mile within a fixed route.
-Peggy Catlin	[3994.225-3997.368]	Would that change with this, any of these proposals?
-Peggy Catlin	[3997.755-4001.626]	Or would it still be over the entire RTD service area?
+Erin Vallejos	[3371.279-3887.490]	Of course. OK, so just to highlight on this, again, as GM/CEO Johnson said. Access-a- Ride and Access-on-Demand are the two programs that we have. Access-a-Ride is RTD's federally required ADA complementary paratransit service. It does supplement our fixed route services. There is a fare payment required for these services and customers must meet the criteria set forth by the Americans with Disabilities Act of 1990 to be eligible. This is provided with all RTD branded Access-a-Ride vehicles that are all 100% accessible. And then Access-on-Demand is our supplemental premium paratransit service. It is a curb-to-curb taxi and rideshare service. It is available to current paratransit customers, so they must meet those eligibility criteria to qualify for Access-a-Ride to then use Access-on-Demand. And as it stands today, RTD pays the first $25 of the trip and the remaining portion is paid by the customer. And again, ability today to take 60 total trips. So just some quick operating statistics. The annual operating cost in 2024 for Access-a-Ride was just over 53 million, and the customer trips were just over 500,000. And again, these are RTD owned vehicles, and the contractors that operate this service have over 500 drivers, mechanics, and other staff. And then Access-on-Demand. Last year it was about just over $15.3 million for the budget. Just over 685,000 trips. And these are all provided by third party vehicles. So again, as we touched on, you must be eligible for Access-a-Ride to also use Access-on-Demand. There is a process that customers must go through that determines if a customer has a disabling condition that would prevent them from using our regular fixed route service. There's an application process, a medical verification process, and then an in-person assessment that customers must complete. And there are a couple of different types of eligibility that a customer could receive. Unconditional means you can have access to the full service for up to four years. Temporary. You might have a condition that's going to improve, recovering from surgery or something along those lines. And then conditional would be when there was something-- maybe you're sensitive to extreme hot or extreme cold, so you would be able to use it at those times, but not the full year. OK. And as we have touched on, this is something that you've probably seen as well. We are continuing to see an increase in Access-on-Demand usage. This is through 2024, but we continue to see that Access- on-Demand trend line going up into the start of this year. And Access-a-Ride, when you look at the trend line, while it is staying a little bit more stable, we are still seeing an increase in usage there as well. And as we've talked about, average monthly trips per customer. The majority of customers are falling into the category of taking up to 50 trips. That is about 90% of the customers when we last did the analysis, and about 10% of the customers again fall into that 51 to 60 category. So now I'm going to just remind everyone of what our initial recommendations were back in 2024. As it stands today again, quickly, there's a $0 base customer fare. The trip cap is 60 per month. Subsidy is up to $25 per trip. It is available within the entire district and it is available 24/7. Back when we came to you in November of 2024, we had proposed making changes, and this involved having a $4.50 base customer fare, which would be $2.25 for our LiVE eligible customers. We proposed a trip cap of $40 per month. The subsidy would go to $20 per trip, and then it was proposed to mirror both the current service area and the service hours. With this recommendation, there were going to be cost savings that the District would realize, and that was going to be about $5.8 million. So instead of the projected yearly spend being a little bit over 15 million, we would go down to about 9.4. OK, and as a result of some of the feedback and comments that we've heard, we did put together two additional revised scenarios. So scenario one is what I'm going to touch on first. So this has to do with an increased trip cap approach. So what we were proposing in this scenario is increasing the trip cap to 50 per month from the original 40 that was proposed. We are proposing as this is, again, as we've said, a premium supplemental service, a fare of $6.50 per trip, which would be $3.25 for our LiVE customers. Then the remainder of the proposal does remain the same. We were still proposing a subsidy per trip of $20, and we are proposing mirroring the current service area and service hours as that of our Access-a-Ride program. With this program, we did see actually a little bit of the yearly impact would be a cost savings of about 6.1 million, bringing our total spend to about a little over 9.1. With the 50 trips, that does allow for customers to still have-- given there's about 20 week days in a month that does allow for customers to still travel to work, but then does allow for some ancillary trips throughout the month. And then another scenario that we had put together is the tiered approach that we have discussed. With this approach, we would still maintain a trip cap of up to 60 trips per month, which matches what we have currently. There would be a $4.50 base customer fare for up to 30 trips, $5.50 for 31 to 50, and $6.50 for 51 to 60. And the remainder of the recommendation would remain the same. With this program, as some people have noted, due to the program structure and some of the manual aspects that exist with monitoring today, there would be a pretty big an increase in staff oversight that would result in additional staff headcount. Again, that had been noted, but as it stands today, the program does require quite a bit of manual intervention. There is also, as someone mentioned, the customers would need to be keeping a little bit closer track of their trips, and that could lead to confusion. It is something a customer would have to be regularly thinking, all right, where am I at for the month? Have I hit that 30 trips? So they know what to expect for their costs. With this program, we would see some reductions of just over $5 million. So it is a little bit less than some of the other recommendations that we've put forth, and it would bring our projected yearly spend to about $10.28 million a year. Oh, and actually. So proposed next steps. We are here, as GM/CEO Johnson has said, to just garner everyone's feedback and get some guidance on a path forward. The intent is to do outreach and engagement in June based on some of that guidance and engage with the community. We would be coming back for Board consideration in July with an actual recommended action to the committee, and then provided the committee advanced it at the Board meeting. And we would begin implementation in August with full implementation in October. And with that, I will open it up.
+Julien Bouquet	[3889.082-3896.258]	Perfect. Thank you very much for your presentation, Ms. Vallejos. OK. I'm going to open it up for Directors. Second Vice Chair Whitmore.
+Troy Whitmore	[3896.258-3938.395]	Thank you for the presentation and the ease of absorbing the proposed changes. Erin, looking at the second proposal, the tiered approach, one of our commenters talked about the complications of keeping up with number of trips. Is that something that the new staff would be able to be a clearinghouse, if you will, to where you have one call to RTD instead of calling a taxi and a Lyft and an Uber? That seems to be the most difficult part of that. I'm just curious if you think our staff would be handling that in a way that would be handy for our customers.
+Erin Vallejos	[3938.706-3962.355]	It's definitely something I think we could assist with, but I do think there would still be some burden on the customer for having some of that responsibility. Again, as I mentioned, as it stands today, there is just a very manual aspect of the program. And so while we're always looking at things to improve, I do think there would still be some responsibility that would live with the customer.
+Julien Bouquet	[3964.934-3967.360]	Thank you. Director Catlin.
+Peggy Catlin	[3967.360-4001.626]	Thank you. And thank you for a very clear presentation. Although I have one question of clarification. You talk about mirroring the existing service area. One of the things that appealed to me about this service was that I don't think that the customers were restricted to the 3/4 mile within a fixed route. Would that change with this, any of these proposals? Or would it still be over the entire RTD service area?
 Erin Vallejos	[4002.033-4010.720]	As the proposals are presented, we are proposing mirroring the 3/4 of a mile boundary that exists today for our Access-a-Ride customers.
-Peggy Catlin	[4014.645-4020.895]	That presents some problems for me, but we can talk about that later.
-Peggy Catlin	[4021.372-4021.562]	Thank you.
-Julien Bouquet	[4023.993-4023.993]	OK.
-Julien Bouquet	[4023.993-4024.524]	Secretary Nicholson.
-Chris Nicholson	[4024.524-4028.153]	Thank you very much.
-Chris Nicholson	[4028.805-4035.567]	I think I first want to echo and perhaps be a little bit more direct about what Director Catlin said.
-Chris Nicholson	[4037.407-4043.146]	We have bus routes in this system that don't qualify for the ADA service, but they're bus routes anyway.
-Chris Nicholson	[4044.508-4055.680]	They're our commuter routes, and I would not vote personally for a change that would cut off the people who live within 3/4 of a mile of those routes.
-Chris Nicholson	[4056.126-4062.318]	So at least for me, you guys want to get this through, you're going to need to change that because it's just a matter of basic equity.
-Chris Nicholson	[4062.596-4068.258]	Otherwise Peggy has two places in her district that get service, and that's just not reasonable.
-Chris Nicholson	[4068.566-4071.434]	There are a lot of older folks that live up in those areas.
-Chris Nicholson	[4072.675-4090.693]	I think the second issue that I have with what's being proposed is that the needs of-- not call it rural, but mountainous Jefferson County, when it comes to AOD, are very different than the needs of central Denver.
-Chris Nicholson	[4091.911-4101.254]	I can get to most places that I need to go, in terms of grocery stores, medical, et cetera, in a $15 Uber.
-Chris Nicholson	[4102.473-4109.378]	I don't think there's anywhere that you can get to for $15 in Peggy's district, or yours.
-Chris Nicholson	[4109.784-4109.784]	Exactly.
-Chris Nicholson	[4111.490-4116.089]	But creating a system where the trip cap is $40 doesn't work for me.
-Chris Nicholson	[4116.497-4121.605]	Creating a trip cap where it's $15 doesn't work for the people in her district.
-Chris Nicholson	[4122.005-4133.286]	It strikes me that the right approach would be to have different levels of financial cap and different levels of trip cap to go along with them and let people pick.
-Chris Nicholson	[4133.762-4136.493]	You want 60 trips at $15 per?
-Chris Nicholson	[4137.505-4137.505]	Great.
-Chris Nicholson	[4137.826-4140.025]	You want 50 trips at $20 per?
-Chris Nicholson	[4140.511-4140.511]	Great.
-Chris Nicholson	[4140.792-4143.317]	You want 40 trips at $30 per?
-Chris Nicholson	[4144.098-4144.098]	Great.
-Chris Nicholson	[4144.399-4147.288]	Depends on where you live, depends on the types of trips you're going to be taking.
-Chris Nicholson	[4147.545-4166.445]	But making people all fit into one size is either going to leave her people paying $20 for every single trip that they take, or it's going to put people in my district in a reduced number of rides, because very few trips are going to cost $20 or $25.
-Chris Nicholson	[4167.137-4168.670]	Those are my two pieces of feedback.
-Chris Nicholson	[4168.946-4170.178]	Thank you.
-Julien Bouquet	[4171.430-4171.951]	Thank you, Secretary.
-Julien Bouquet	[4173.013-4173.354]	Director Ruscha.
-Joyann Ruscha	[4173.354-4178.673]	Thank you, Mr.
-Joyann Ruscha	[4178.843-4178.843]	Chair.
-Joyann Ruscha	[4180.174-4184.264]	So I just wanted to offer a bit of context.
-Joyann Ruscha	[4184.739-4189.236]	And the General Manager, please interrupt me if I'm framing this wrong.
-Joyann Ruscha	[4190.025-4195.893]	But the conversation that we're having tonight is a framework of a potential path forward.
-Joyann Ruscha	[4196.993-4209.940]	And because our OSS meeting went so long, we weren't able to get to the discussion and that also, I think, impacted our ability to have some interim discussions.
-Joyann Ruscha	[4210.254-4218.739]	So I just want folks to keep an open mind to what staff is saying and definitely share that feedback because we're on a timeline.
-Joyann Ruscha	[4219.053-4223.453]	But also just recognize that-- and please, if I'm saying this wrong, interrupt me.
-Joyann Ruscha	[4223.453-4225.967]	But what is being presented is a concept framework.
-Joyann Ruscha	[4227.853-4240.573]	So we'll get Board feedback, and then of course, staff is going to be working very closely with our existing customers and advocacy organizations to make further refinements and give us some more stuff to look at.
-Joyann Ruscha	[4241.005-4247.721]	So I hope I didn't speak out of turn, but I just wanted to offer that for context.
-Joyann Ruscha	[4248.877-4252.921]	And I'm also listening and taking notes, and I know staff is.
-Joyann Ruscha	[4253.289-4264.709]	So I would just urge, if anyone has thoughts, one way or another, please share them tonight since we are also on a timeline with our existing partners and those contracts as well.
-Joyann Ruscha	[4265.631-4265.811]	Thank you.
-Julien Bouquet	[4267.114-4268.577]	Thank you, Director.
-Julien Bouquet	[4268.577-4268.908]	Director Larsen.
-Matt Larsen	[4272.886-4273.096]	Thank you.
-Matt Larsen	[4273.447-4275.457]	I just have a question for Ms.
-Matt Larsen	[4275.812-4275.812]	Vallejos.
-Matt Larsen	[4277.596-4288.194]	So I seen one of these slides that it says in December of 2024, there were about 2,900 total active customers of Access-on-Demand.
-Matt Larsen	[4290.982-4295.732]	So there were 2,900 people, roughly, who used it in all of December?
-Matt Larsen	[4296.929-4297.262]	Is that right?
-Erin Vallejos	[4298.751-4301.130]	No, that would be for the year, I believe.
-Let me-- Matt Larsen	[4302.736-4303.076]	As of.
-Let me-- Matt Larsen	[4303.076-4303.076]	OK.
-Let me-- Matt Larsen	[4304.017-4304.017]	As of.
-Let me-- Matt Larsen	[4304.017-4308.324]	So 2,900 people used this service for the whole year.
-Let me-- Matt Larsen	[4309.084-4309.294]	That's it?
-Let me-- Matt Larsen	[4311.201-4328.260]	And so I guess what I'm trying to just understand is so if we were going to spend, say $10 million or $15 million on 2,900 people, what do we think the equivalent is for just our regular riders?
-Let me-- Matt Larsen	[4328.959-4329.713]	Do we have any guess?
-Let me-- Matt Larsen	[4330.521-4332.649]	I mean, I know people have different ridership.
-Let me-- Matt Larsen	[4332.925-4350.901]	I'm just trying to get-- I mean, if we have a million customers a year and it's the majority of our budget, I'm just trying to get a sense of how the per person spend for a regular rider compares to the per person spend for Access-on-Demand Erin Vallejos: And I-- go ahead, Debra.
-Let me-- Matt Larsen	[4353.393-4353.393]	Oh.
-Debra Johnson	[4353.393-4354.384]	So if I can, Mr.
-Debra Johnson	[4354.632-4356.613]	Chair, and thank you, Director Larsen, for the question.
-Debra Johnson	[4357.162-4359.318]	I would not want us to conjecture and speculate.
-Debra Johnson	[4359.668-4361.290]	We could double back and give you those numbers.
-Debra Johnson	[4362.375-4364.946]	As we talk about, you use the term regular rider.
-Debra Johnson	[4365.231-4367.802]	You're talking about those that are using fixed route service.
-Debra Johnson	[4368.129-4371.010]	I just want to be clear and intentional with the language we're using going forward.
-Debra Johnson	[4371.196-4375.425]	So we need to assess that, because it's a different level of service.
-Debra Johnson	[4375.777-4379.654]	Because with fixed route bus, we're not providing curb to curb service.
-Debra Johnson	[4380.366-4389.099]	And so we can double back and share that information with the Board, but I think it wouldn't be fruitful for us to guesstimate because this is critically important.
-Debra Johnson	[4389.736-4394.933]	But as we come back and we have some guidance, we could provide that detailed information, if you will.
-Debra Johnson	[4395.642-4395.812]	Thank you.
-Julien Bouquet	[4397.965-4398.495]	Thank you.
-Julien Bouquet	[4400.356-4401.905]	Any other Directors, comments?
-Julien Bouquet	[4402.441-4402.976]	Yeah, Director Guzman.
-Michael Guzman	[4404.185-4411.185]	I am concerned with the aligning with the ADA for the service area.
-Michael Guzman	[4414.230-4427.176]	District C is fairly blessed with multiple forms of transit and fixed route where this is not a particular problem, but it is an issue in the suburban areas of the region.
-Michael Guzman	[4427.961-4441.252]	And it is highly concerning that we would restrict it so much where people would be left off of the system that live within a quarter mile of a commuter bus, and still not be able to access this.
-Michael Guzman	[4444.113-4456.051]	I also think that as we proceed into the future after the demographer's presentation to the Finance and Planning Committee, a big concern will be our aging population in the region.
-Michael Guzman	[4457.310-4462.170]	And somebody said that this is a drop in the bucket for our budget.
-Michael Guzman	[4463.698-4470.192]	Maybe right now, but eventually, this is going to catch up with us, which is why we're having this conversation.
-Michael Guzman	[4470.533-4487.682]	And Access-on-Demand and folks that are able to, or out of need, utilize this system need to be considered as humans first and how we serve them, which is our mission.
-Michael Guzman	[4488.812-4503.945]	They need connection as well, and not every one of them will be able to jump from a-- jump, roll, walk, shuffle to a fixed route form of transportation to get them to their destinations.
-Michael Guzman	[4505.334-4510.620]	I have a question about the time on this.
-Michael Guzman	[4512.363-4519.914]	If it's mirroring regular service provision for the whole region, it kind of makes sense.
-Michael Guzman	[4520.285-4525.849]	But I would still be concerned for the reasons that emergencies don't happen on RTD's schedule.
-Michael Guzman	[4527.221-4535.842]	And so somebody who already has a specific need for this type of transportation usage might need to go to the doctor.
-Michael Guzman	[4536.774-4539.207]	And what do they do if they're unable to drive.
-Michael Guzman	[4539.980-4544.039]	And regular bus service is not something that they can use because the buses aren't running?
-Michael Guzman	[4544.891-4550.246]	At 2 o'clock in the morning, emergency room visit is not unheard of and not uncommon in anybody's life.
-Michael Guzman	[4551.085-4553.685]	And yet, what do we do to take care of those that are most vulnerable?
-Michael Guzman	[4555.234-4559.561]	So for me, I would really want to see some clarity around those two areas.
-Michael Guzman	[4561.044-4566.034]	I am frankly less concerned about minimal difference of cost savings.
-Michael Guzman	[4567.474-4569.211]	I mean, we're talking $5 million.
-Michael Guzman	[4570.039-4576.883]	This is not really the top priority for me on that part right now.
-Michael Guzman	[4577.235-4581.108]	It will eventually get there because this will likely continue to grow.
-Michael Guzman	[4581.500-4588.503]	But I do want to make sure that we are basing ourselves in reality to serve the taxpayers' needs.
-Michael Guzman	[4589.714-4591.477]	And this is a need.
-Michael Guzman	[4592.378-4596.352]	This is not a desire, as some of the other services we want to grow and create are.
-Michael Guzman	[4596.586-4597.754]	This one is an actual need.
-Michael Guzman	[4598.749-4604.374]	And so I want to be clear in my language on that and why I'm depositing these comments within that framework.
-Michael Guzman	[4605.106-4606.109]	So that would be my feedback.
-Michael Guzman	[4606.351-4610.632]	I'd like to see something a little bit different on those two things, the service area and the time for service.
-Michael Guzman	[4611.027-4611.177]	Thank you.
-Julien Bouquet	[4611.910-4613.275]	Thank you, Director.
-Julien Bouquet	[4613.275-4613.636]	Director Harwick.
-Ian Harwick	[4613.636-4616.798]	Well, thank you, Director Guzman.
-Ian Harwick	[4617.275-4619.386]	I'm just going to pretty much replicate everything you just said.
-Ian Harwick	[4619.617-4628.207]	I represent Arvada, and Arvada is actually the fastest growing aging population.
-Ian Harwick	[4629.189-4631.228]	However I said that, I'm not sure I said it right.
-Ian Harwick	[4632.012-4637.138]	And a lot of our service is not in the areas where we have those aging people.
-Ian Harwick	[4638.039-4642.932]	So I'd really like to see just the boundary kept the same.
-Ian Harwick	[4643.392-4647.614]	I'm also really, again, with Director Guzman, keeping it at a full 24/7.
-Ian Harwick	[4649.364-4663.047]	I have a friend in a wheelchair and I just think about her trying-- like if she didn't live where she lived, if she lived where I lived, she would have such a difficult time getting around her community.
-Ian Harwick	[4663.389-4669.720]	And I would just-- especially if the service is outside of that time period, it's just precluding her life.
-Ian Harwick	[4670.278-4681.707]	I know we don't all have the same abilities when we're riding a bus, but for a person with disability that's blind or in a wheelchair, I think that we can extend them the grace that they deserve.
-Ian Harwick	[4682.843-4685.083]	I also would like to see the cap stay at 60.
-Ian Harwick	[4685.327-4692.501]	I think that, again, I know that less than 10% of the population go above the 50 rides.
-Ian Harwick	[4692.843-4698.308]	But I think it's still, we're giving them access to a free and full life.
-Ian Harwick	[4699.712-4704.291]	And I think if we are going to go the 6.50, I think that that, to me is fine.
-Ian Harwick	[4704.532-4712.910]	But I also think that it would be imperative that we really put out the LiVE program and let those riders know that there is another option.
-Ian Harwick	[4713.245-4715.590]	I was with someone the other day.
-Ian Harwick	[4715.925-4722.289]	She lives about 3 miles away from where she works, and she can afford it, but just barely.
-Ian Harwick	[4722.624-4724.969]	And she didn't know about the LiVE program.
-Ian Harwick	[4725.304-4730.506]	So I think that we're missing an opportunity there specifically with these riders.
-Ian Harwick	[4731.260-4733.344]	And then my last one is just a request.
-Ian Harwick	[4733.624-4741.024]	Is it possible to get a map, sort of like a density map, of where AOD is highly being used?
-Ian Harwick	[4741.377-4749.835]	To go with that thinking about West Jefferson County versus central Denver, just kind see what that looks like.
-Ian Harwick	[4750.267-4757.480]	Obviously, we want to anonymize the data, but I think it just would be interesting for us to know where the hotspots of usage are.
-Ian Harwick	[4758.393-4758.563]	Thank you.
-Julien Bouquet	[4758.753-4759.294]	Thank you, Director Harwick.
-Julien Bouquet	[4759.655-4759.655]	Ms.
-Julien Bouquet	[4759.875-4759.875]	Johnson.
-Debra Johnson	[4759.875-4761.397]	Yes.
-Debra Johnson	[4761.730-4779.406]	Director Harwick, if I understood you correctly, because I'm taking copious notes here, you are in support, for all intents and purposes, of what I hear, modification of scenario one, keeping it at 60 trips with 6.50, and then want information relative to what the current usage is from a geographic vantage point.
-Debra Johnson	[4780.259-4780.259]	OK.
-Debra Johnson	[4780.700-4780.870]	Thank you.
+Peggy Catlin	[4014.645-4021.562]	That presents some problems for me, but we can talk about that later. Thank you.
+Julien Bouquet	[4023.993-4024.524]	OK. Secretary Nicholson.
+Chris Nicholson	[4024.524-4170.178]	Thank you very much. I think I first want to echo and perhaps be a little bit more direct about what Director Catlin said. We have bus routes in this system that don't qualify for the ADA service, but they're bus routes anyway. They're our commuter routes, and I would not vote personally for a change that would cut off the people who live within 3/4 of a mile of those routes. So at least for me, you guys want to get this through, you're going to need to change that because it's just a matter of basic equity. Otherwise Peggy has two places in her district that get service, and that's just not reasonable. There are a lot of older folks that live up in those areas. I think the second issue that I have with what's being proposed is that the needs of-- not call it rural, but mountainous Jefferson County, when it comes to AOD, are very different than the needs of central Denver. I can get to most places that I need to go, in terms of grocery stores, medical, et cetera, in a $15 Uber. I don't think there's anywhere that you can get to for $15 in Peggy's district, or yours. Exactly. But creating a system where the trip cap is $40 doesn't work for me. Creating a trip cap where it's $15 doesn't work for the people in her district. It strikes me that the right approach would be to have different levels of financial cap and different levels of trip cap to go along with them and let people pick. You want 60 trips at $15 per? Great. You want 50 trips at $20 per? Great. You want 40 trips at $30 per? Great. Depends on where you live, depends on the types of trips you're going to be taking. But making people all fit into one size is either going to leave her people paying $20 for every single trip that they take, or it's going to put people in my district in a reduced number of rides, because very few trips are going to cost $20 or $25. Those are my two pieces of feedback. Thank you.
+Julien Bouquet	[4171.430-4173.354]	Thank you, Secretary. Director Ruscha.
+Joyann Ruscha	[4173.354-4265.811]	Thank you, Mr. Chair. So I just wanted to offer a bit of context. And the General Manager, please interrupt me if I'm framing this wrong. But the conversation that we're having tonight is a framework of a potential path forward. And because our OSS meeting went so long, we weren't able to get to the discussion and that also, I think, impacted our ability to have some interim discussions. So I just want folks to keep an open mind to what staff is saying and definitely share that feedback because we're on a timeline. But also just recognize that-- and please, if I'm saying this wrong, interrupt me. But what is being presented is a concept framework. So we'll get Board feedback, and then of course, staff is going to be working very closely with our existing customers and advocacy organizations to make further refinements and give us some more stuff to look at. So I hope I didn't speak out of turn, but I just wanted to offer that for context. And I'm also listening and taking notes, and I know staff is. So I would just urge, if anyone has thoughts, one way or another, please share them tonight since we are also on a timeline with our existing partners and those contracts as well. Thank you.
+Julien Bouquet	[4267.114-4268.908]	Thank you, Director. Director Larsen.
+Matt Larsen	[4272.886-4297.262]	Thank you. I just have a question for Ms. Vallejos. So I seen one of these slides that it says in December of 2024, there were about 2,900 total active customers of Access-on-Demand. So there were 2,900 people, roughly, who used it in all of December? Is that right?
+Erin Vallejos	[4298.751-4302.823]	No, that would be for the year, I believe. Let me--
+Matt Larsen	[4302.909-4346.515]	As of. OK. As of. So 2,900 people used this service for the whole year. That's it? And so I guess what I'm trying to just understand is so if we were going to spend, say $10 million or $15 million on 2,900 people, what do we think the equivalent is for just our regular riders? Do we have any guess? I mean, I know people have different ridership. I'm just trying to get-- I mean, if we have a million customers a year and it's the majority of our budget, I'm just trying to get a sense of how the per person spend for a regular rider compares to the per person spend for Access-on-Demand
+Erin Vallejos	[4346.771-4353.393]	And I-- go ahead, Debra. Oh.
+Debra Johnson	[4353.393-4395.812]	So if I can, Mr. Chair, and thank you, Director Larsen, for the question. I would not want us to conjecture and speculate. We could double back and give you those numbers. As we talk about, you use the term regular rider. You're talking about those that are using fixed route service. I just want to be clear and intentional with the language we're using going forward. So we need to assess that, because it's a different level of service. Because with fixed route bus, we're not providing curb to curb service. And so we can double back and share that information with the Board, but I think it wouldn't be fruitful for us to guesstimate because this is critically important. But as we come back and we have some guidance, we could provide that detailed information, if you will. Thank you.
+Julien Bouquet	[4397.965-4402.976]	Thank you. Any other Directors, comments? Yeah, Director Guzman.
+Michael Guzman	[4404.185-4611.177]	I am concerned with the aligning with the ADA for the service area. District C is fairly blessed with multiple forms of transit and fixed route where this is not a particular problem, but it is an issue in the suburban areas of the region. And it is highly concerning that we would restrict it so much where people would be left off of the system that live within a quarter mile of a commuter bus, and still not be able to access this. I also think that as we proceed into the future after the demographer's presentation to the Finance and Planning Committee, a big concern will be our aging population in the region. And somebody said that this is a drop in the bucket for our budget. Maybe right now, but eventually, this is going to catch up with us, which is why we're having this conversation. And Access-on-Demand and folks that are able to, or out of need, utilize this system need to be considered as humans first and how we serve them, which is our mission. They need connection as well, and not every one of them will be able to jump from a-- jump, roll, walk, shuffle to a fixed route form of transportation to get them to their destinations. I have a question about the time on this. If it's mirroring regular service provision for the whole region, it kind of makes sense. But I would still be concerned for the reasons that emergencies don't happen on RTD's schedule. And so somebody who already has a specific need for this type of transportation usage might need to go to the doctor. And what do they do if they're unable to drive. And regular bus service is not something that they can use because the buses aren't running? At 2 o'clock in the morning, emergency room visit is not unheard of and not uncommon in anybody's life. And yet, what do we do to take care of those that are most vulnerable? So for me, I would really want to see some clarity around those two areas. I am frankly less concerned about minimal difference of cost savings. I mean, we're talking $5 million. This is not really the top priority for me on that part right now. It will eventually get there because this will likely continue to grow. But I do want to make sure that we are basing ourselves in reality to serve the taxpayers' needs. And this is a need. This is not a desire, as some of the other services we want to grow and create are. This one is an actual need. And so I want to be clear in my language on that and why I'm depositing these comments within that framework. So that would be my feedback. I'd like to see something a little bit different on those two things, the service area and the time for service. Thank you.
+Julien Bouquet	[4611.910-4613.636]	Thank you, Director. Director Harwick.
+Ian Harwick	[4613.636-4758.563]	Well, thank you, Director Guzman. I'm just going to pretty much replicate everything you just said. I represent Arvada, and Arvada is actually the fastest growing aging population. However I said that, I'm not sure I said it right. And a lot of our service is not in the areas where we have those aging people. So I'd really like to see just the boundary kept the same. I'm also really, again, with Director Guzman, keeping it at a full 24/7. I have a friend in a wheelchair and I just think about her trying-- like if she didn't live where she lived, if she lived where I lived, she would have such a difficult time getting around her community. And I would just-- especially if the service is outside of that time period, it's just precluding her life. I know we don't all have the same abilities when we're riding a bus, but for a person with disability that's blind or in a wheelchair, I think that we can extend them the grace that they deserve. I also would like to see the cap stay at 60. I think that, again, I know that less than 10% of the population go above the 50 rides. But I think it's still, we're giving them access to a free and full life. And I think if we are going to go the 6.50, I think that that, to me is fine. But I also think that it would be imperative that we really put out the LiVE program and let those riders know that there is another option. I was with someone the other day. She lives about 3 miles away from where she works, and she can afford it, but just barely. And she didn't know about the LiVE program. So I think that we're missing an opportunity there specifically with these riders. And then my last one is just a request. Is it possible to get a map, sort of like a density map, of where AOD is highly being used? To go with that thinking about West Jefferson County versus central Denver, just kind see what that looks like. Obviously, we want to anonymize the data, but I think it just would be interesting for us to know where the hotspots of usage are. Thank you.
+Julien Bouquet	[4758.753-4759.875]	Thank you, Director Harwick. Ms. Johnson.
+Debra Johnson	[4759.875-4780.870]	Yes. Director Harwick, if I understood you correctly, because I'm taking copious notes here, you are in support, for all intents and purposes, of what I hear, modification of scenario one, keeping it at 60 trips with 6.50, and then want information relative to what the current usage is from a geographic vantage point. OK. Thank you.
 Julien Bouquet	[4782.221-4782.572]	Thank you.
-Ian Harwick	[4782.942-4786.715]	Yeah, but I also want to keep the service areas the same as they are today.
-Ian Harwick	[4787.508-4787.508]	Yeah.
-Julien Bouquet	[4789.713-4789.713]	Excellent.
-Julien Bouquet	[4791.637-4794.171]	Director Nicholson, then Director Ruscha.
-Chris Nicholson	[4794.884-4798.093]	Yeah, just a quick follow up onto that.
-Chris Nicholson	[4799.533-4802.115]	When it comes to-- go to Director Ruscha.
-Chris Nicholson	[4802.483-4806.540]	My brain-- I lost my train of thought for a second, so.
-Julien Bouquet	[4808.151-4808.351]	All right.
-Julien Bouquet	[4808.552-4808.752]	Director Ruscha.
-Joyann Ruscha	[4808.752-4814.762]	Thank you for the Red Rover.
-Joyann Ruscha	[4815.022-4815.543]	I wasn't prepared.
-Joyann Ruscha	[4815.824-4816.575]	I went back to my notes.
-Joyann Ruscha	[4817.206-4817.206]	OK.
-Joyann Ruscha	[4817.784-4831.884]	So anyway, so some of this feedback I did share with staff and I don't want to be repetitive, but I also just want to be really transparent with my colleagues because we haven't had this public conversation yet.
-Joyann Ruscha	[4832.609-4849.636]	And just high level, some of the things that I had shared was, first of all, we don't want to put one proposal out before the community and get feedback, like the one that we've had out for several months, and then come back with something else that looks like less than what we originally proposed.
-Joyann Ruscha	[4850.016-4856.955]	And so one of the pain points that I had was just the idea of going up to 6.50 for the initial fare, because that's not what we originally put out there.
-Joyann Ruscha	[4857.526-4867.960]	So one of the things that I urge is that if we put an offer on the table, so to speak, we don't take it back.
-Joyann Ruscha	[4868.958-4870.193]	That's our baseline now.
-Joyann Ruscha	[4871.200-4890.354]	And another piece of feedback I had is that where something is not-- for every change we make, which essentially results in a reduction of a service of some kind or an increase in price, we really have to justify that line by line.
-Joyann Ruscha	[4891.121-4899.569]	So, for example, if we decide that we are going to strictly align with service hours, then we have to justify it.
-Joyann Ruscha	[4899.569-4900.838]	It doesn't cost us any more money.
-Joyann Ruscha	[4901.230-4910.892]	It's not going to save us a penny if somebody uses on-Demand 15 or 20 minutes or an hour before fixed route starts.
-Joyann Ruscha	[4912.961-4922.312]	Likewise, it's not costing us, that I could see, a lot of money, if any, for us to offer service outside of our general service area.
-Joyann Ruscha	[4923.801-4926.383]	I know that was flagged in the peer review.
-Joyann Ruscha	[4927.855-4945.651]	Because this idea has been on the table for so many months, I also want to caution us about the service area idea, because if we restrict this service, that means there are people who currently are using AOD and they're going to lose it.
-Joyann Ruscha	[4950.410-4958.432]	I mean, that was just a kind of high level theme that I had in the feedback.
-Joyann Ruscha	[4959.925-4974.874]	And also, I going back to the initial affair, we also want to be really careful about what we think is inexpensive, because it's really relative.
-Joyann Ruscha	[4975.240-4990.251]	So for some folks using this service and they have a fixed income or very limited income, if we even do 4.50, which would be parity with Access-a-Ride-- and I think I could accept that.
-Joyann Ruscha	[4990.617-5004.423]	But say we go up to 6.50 or we do this tiered system, then for some folks they are not going to be able to ride or they're going to be choosing, do I get to the doctor or do I buy food for tonight.
-Joyann Ruscha	[5004.865-5008.139]	So I just wanted to put that out there.
-Joyann Ruscha	[5008.969-5017.360]	And finally-- well, actually, I'll stop there.
-Joyann Ruscha	[5018.778-5038.646]	I concurred with what a lot of other Directors said in terms of keeping the program as-is as much as we can, But I also just want to commend staff, because we are at a much different place than where we were several months ago.
-Joyann Ruscha	[5039.724-5041.211]	This was a totally different conversation.
-Joyann Ruscha	[5042.230-5047.455]	We're talking about really slashing this program, and staff did a lot of work and we spent several months.
-Joyann Ruscha	[5047.715-5058.636]	We almost voted on this a few months ago, and they listened to us as Directors and they listened to community because, as you know, we've had hundreds of public comments over several months on this.
-Joyann Ruscha	[5059.605-5064.381]	And they said, OK, we can take a timeout, we can reassess, we can get some different data.
-Joyann Ruscha	[5064.662-5067.191]	We can present a new paradigm.
-Joyann Ruscha	[5067.492-5070.014]	So again, what's before us today is a sketch of ideas.
-Joyann Ruscha	[5070.266-5076.258]	The feedback is good, but I really do want to commend staff for listening and working with us in partnership.
-Joyann Ruscha	[5076.592-5078.462]	So thank you and thank you.
-Julien Bouquet	[5080.098-5080.745]	Thank you, Director Ruscha.
-Julien Bouquet	[5081.160-5081.521]	Director Nicholson.
-Chris Nicholson	[5081.521-5083.925]	Thank you.
-Chris Nicholson	[5085.953-5100.431]	Is there any step during enrollment of AAR and AOD where we ask people if they are enrolled in the LiVE program and ask them, hey, we're taking 14 other pieces of documentation from you?
-Chris Nicholson	[5100.877-5104.429]	I mean, AOD or AAR is remarkably complicated to sign up for.
-Chris Nicholson	[5104.884-5111.393]	Is there any part of that process where we try to enroll them in the LiVE program as well?
-Chris Nicholson	[5111.795-5112.812]	And then I have a quick follow up.
+Ian Harwick	[4782.942-4787.508]	Yeah, but I also want to keep the service areas the same as they are today. Yeah.
+Julien Bouquet	[4789.713-4794.171]	Excellent. Director Nicholson, then Director Ruscha.
+Chris Nicholson	[4794.884-4806.540]	Yeah, just a quick follow up onto that. When it comes to-- go to Director Ruscha. My brain-- I lost my train of thought for a second, so.
+Julien Bouquet	[4808.151-4808.752]	All right. Director Ruscha.
+Joyann Ruscha	[4808.752-5078.462]	Thank you for the Red Rover. I wasn't prepared. I went back to my notes. OK. So anyway, so some of this feedback I did share with staff and I don't want to be repetitive, but I also just want to be really transparent with my colleagues because we haven't had this public conversation yet. And just high level, some of the things that I had shared was, first of all, we don't want to put one proposal out before the community and get feedback, like the one that we've had out for several months, and then come back with something else that looks like less than what we originally proposed. And so one of the pain points that I had was just the idea of going up to 6.50 for the initial fare, because that's not what we originally put out there. So one of the things that I urge is that if we put an offer on the table, so to speak, we don't take it back. That's our baseline now. And another piece of feedback I had is that where something is not-- for every change we make, which essentially results in a reduction of a service of some kind or an increase in price, we really have to justify that line by line. So, for example, if we decide that we are going to strictly align with service hours, then we have to justify it. It doesn't cost us any more money. It's not going to save us a penny if somebody uses on-Demand 15 or 20 minutes or an hour before fixed route starts. Likewise, it's not costing us, that I could see, a lot of money, if any, for us to offer service outside of our general service area. I know that was flagged in the peer review. Because this idea has been on the table for so many months, I also want to caution us about the service area idea, because if we restrict this service, that means there are people who currently are using AOD and they're going to lose it. I mean, that was just a kind of high level theme that I had in the feedback. And also, I going back to the initial affair, we also want to be really careful about what we think is inexpensive, because it's really relative. So for some folks using this service and they have a fixed income or very limited income, if we even do 4.50, which would be parity with Access-a-Ride-- and I think I could accept that. But say we go up to 6.50 or we do this tiered system, then for some folks they are not going to be able to ride or they're going to be choosing, do I get to the doctor or do I buy food for tonight. So I just wanted to put that out there. And finally-- well, actually, I'll stop there. I concurred with what a lot of other Directors said in terms of keeping the program as-is as much as we can, But I also just want to commend staff, because we are at a much different place than where we were several months ago. This was a totally different conversation. We're talking about really slashing this program, and staff did a lot of work and we spent several months. We almost voted on this a few months ago, and they listened to us as Directors and they listened to community because, as you know, we've had hundreds of public comments over several months on this. And they said, OK, we can take a timeout, we can reassess, we can get some different data. We can present a new paradigm. So again, what's before us today is a sketch of ideas. The feedback is good, but I really do want to commend staff for listening and working with us in partnership. So thank you and thank you.
+Julien Bouquet	[5080.098-5081.521]	Thank you, Director Ruscha. Director Nicholson.
+Chris Nicholson	[5081.521-5112.812]	Thank you. Is there any step during enrollment of AAR and AOD where we ask people if they are enrolled in the LiVE program and ask them, hey, we're taking 14 other pieces of documentation from you? I mean, AOD or AAR is remarkably complicated to sign up for. Is there any part of that process where we try to enroll them in the LiVE program as well? And then I have a quick follow up.
 Erin Vallejos	[5117.678-5125.342]	I will have to find out about that as part of the process, and we will confirm if that is how that is handled as part of the process.
-Chris Nicholson	[5126.708-5126.708]	Yeah.
-Chris Nicholson	[5126.988-5147.165]	So yeah, as a first thing, I would say that since we're going to be updating this to offer the LiVE discount and not make it free, it should be required as part of the process if you're going through to sign up for AOD or AAR, some point in that process, to ask someone to affirm that they are either already signed up or haven't signed up or whatever.
-Chris Nicholson	[5147.437-5148.795]	And then give them the opportunity.
-Chris Nicholson	[5149.338-5156.724]	Make it super easy because we only have 15,000 people signed up for LiVE right now, and we have 180 something thousand boardings every day.
-Chris Nicholson	[5157.193-5163.405]	And I think only about half the people in AOD are currently signed up for-- or AAR are currently signed up for LiVE.
-Chris Nicholson	[5163.761-5165.846]	So definitely something I'd like to see there.
-Chris Nicholson	[5166.164-5167.262]	The second thing.
-Chris Nicholson	[5167.811-5177.633]	I want to echo what Director Ruscha said about the effect on people who are low income to having these fares.
-Chris Nicholson	[5177.897-5195.237]	But I want to take it from the other side, which is if you don't have a lot of money and you need to get around to a lot of places, then 40 trips may be, or whatever the number ends up being, not nearly enough in a way that someone who makes more money can probably have some discretionary to be like, oh, I've run out of trips.
-Chris Nicholson	[5195.576-5198.532]	I can afford to take an extra three or five or whatever.
-Chris Nicholson	[5198.841-5202.673]	So I'm not sure that needs to be fit into the policy here.
-Chris Nicholson	[5203.028-5205.300]	I'm wary about trying to do too much too quickly.
-Chris Nicholson	[5205.892-5216.069]	But I do think we need to get a report from you after, I don't know, six months, a year, that looks at how many trips are people on LiVE using.
-Chris Nicholson	[5216.629-5217.666]	Are they maxing out?
-Chris Nicholson	[5218.031-5223.817]	Or are we seeing the same curve from LiVE users as we do from regular users right now?
-Chris Nicholson	[5224.179-5232.511]	And that might inform us to take action a year from now to try to offer the right service for people who need it.
-Chris Nicholson	[5232.913-5236.797]	Some LiVE people make decent incomes, some of them are literally broke.
-Chris Nicholson	[5237.133-5242.172]	And we need to recognize that those two groups of people have very different lived experiences.
-Julien Bouquet	[5243.209-5243.796]	Thank you, Secretary.
-Julien Bouquet	[5244.170-5244.170]	Ms.
-Julien Bouquet	[5244.371-5244.371]	Johnson.
-Debra Johnson	[5244.371-5246.997]	Yes, thank you very much, Director Nicholson.
-Debra Johnson	[5247.717-5248.248]	Thank you, Mr.
-Debra Johnson	[5248.514-5248.514]	Chair.
-Debra Johnson	[5248.799-5250.636]	Thank you, Director Nicholson, for the comments.
-Debra Johnson	[5251.403-5253.713]	And what I will say in reference to your request.
-Debra Johnson	[5253.969-5258.263]	It appeared to be a directive, but I would just offer this up to you.
-Debra Johnson	[5258.565-5267.812]	That once we collectively agree upon the path forward and this Board acts, we can then assess what might be most prudent, because at this point in time, we don't know what we don't know.
-Debra Johnson	[5268.068-5273.532]	And relative to what you just asked, I can't commit to that without knowing what we intend to do.
-Debra Johnson	[5273.996-5277.153]	So I just had to say that for the record, because it seems as if Ms.
-Debra Johnson	[5277.401-5280.372]	Vallejos was getting direction, and I don't think that's appropriate at this juncture.
-Debra Johnson	[5280.640-5280.990]	Thank you.
-Julien Bouquet	[5282.862-5283.012]	Thank you.
-Julien Bouquet	[5283.263-5283.563]	Director Larsen.
-Matt Larsen	[5285.605-5285.815]	Thank you.
-Matt Larsen	[5286.922-5292.175]	I was just kind of doing some stuff on my calculator.
-Matt Larsen	[5293.185-5307.103]	So if we only have 3,000 people who use Access-on-Demand , I mean, it seems like the disabled population might be 300,000 people in Denver or
-Matt Larsen	[5308.576-5308.944]	something. Much, much
-Matt Larsen	[5311.789-5317.112]	larger. How confident are we of our projection that it will stay at around, I mean, or however much we think it will
-Matt Larsen	[5317.386-5322.550]	increase? I mean, what do we think the total number of active users might
-Matt Larsen	[5322.947-5328.509]	become? And why won't it become many multiples more than 3,000 or
-Matt Larsen	[5334.522-5335.623]	so? Debra Johnson: First, if I
-Matt Larsen	[5335.990-5342.966]	may. Just for everyone's edification, probably you have heard this over the course of several months in the public comment
-Matt Larsen	[5344.034-5358.753]	discussions. When we talk about Access-on-Demand, currently as it's configured, recognizing that we're using private entities, transportation network companies in particular, not all of the vehicles are outfitted to be wheelchair
-Matt Larsen	[5359.497-5366.834]	accessible. So that's a critical element when we're talking about the population, because there's different disabilities that individuals
-Matt Larsen	[5367.366-5368.582]	have. Some may have
-Matt Larsen	[5368.987-5373.850]	cognitive. Somebody may be using a mobility device which can't be accommodated going
-Matt Larsen	[5374.275-5376.932]	forward. So I just wanted to provide that context prior to
-Matt Larsen	[5377.218-5383.271]	Ms. Vallejos answering the question, because that has not been factored in to this conversation this evening, and I believe it's a germane
-point. Julien Bouquet	[5385.508-5385.922]	Thank you,
-Director. Erin Vallejos	[5386.632-5388.488]	And I don't think I need to add
-Director. Erin Vallejos	[5388.720-5390.807]	anything. That was really exactly what I was going to
-Director. Erin Vallejos	[5391.059-5396.355]	say. Not everyone is able to use the Access-on-Demand service that is eligible for
-Director. Erin Vallejos	[5397.109-5398.183]	Access-a-Ride. There is a difference
-there. Matt Larsen	[5399.152-5399.890]	Can I just follow
-there. Matt Larsen	[5400.094-5406.636]	up? But I mean, surely many more people than 3,000 in the metro area would be eligible,
-there. Matt Larsen	[5408.547-5408.547]	though. I
-mean. Erin Vallejos	[5408.547-5417.755]	Well, and again, we have continued to see substantial growth in the number of customers that are beginning to use the
-mean. Erin Vallejos	[5418.585-5422.563]	service. Again, the trips that we are seeing continue to grow even into this
-mean. Erin Vallejos	[5422.929-5427.869]	year. So we are seeing quite significant growth
-still. Julien Bouquet	[5428.595-5428.755]	Thank
-you. Matt Larsen	[5429.095-5429.275]	Thank
-you. Julien Bouquet	[5429.476-5429.996]	Thank
-you. Julien Bouquet	[5431.758-5432.854]	you. Any further questions,
-you. Julien Bouquet	[5434.861-5434.861]	comments?
-you. Julien Bouquet	[5435.702-5436.209]	Ms. Johnson and
-you. Julien Bouquet	[5436.483-5438.235]	Ms. Vallejos, thank you very much for the
-you. Julien Bouquet	[5438.525-5440.571]	presentation. I hope this was helpful feedback for going
-you. Julien Bouquet	[5441.247-5441.728]	forward. So thank
-you. Julien Bouquet	[5442.573-5442.573]	you. Debra Johnson:
-you. Julien Bouquet	[5442.777-5443.186]	Yes. Thank you,
-you. Julien Bouquet	[5443.391-5443.391]	Mr.
-you. Julien Bouquet	[5443.695-5446.082]	Chair. This was in the sense that we do have some
-you. Julien Bouquet	[5446.320-5449.357]	guidance. Now we know what we need to do as we do further
-you. Julien Bouquet	[5449.624-5451.725]	outreach. So thank you all very much for the
-you. Julien Bouquet	[5452.028-5461.568]	opportunity. And when we come back in July with a recommended action, hopefully we can all rally around that, recognizing the public comments that we heard and the direction in which you
-you. Julien Bouquet	[5462.204-5462.395]	provided. Thank
-you. Julien Bouquet	[5462.845-5463.006]	Thank
-you. Julien Bouquet	[5463.666-5463.947]	you. Director
-Guzman. Michael Guzman	[5463.947-5467.723]	Will that recommended action be going through Operation Safety and
-Guzman. Michael Guzman	[5469.756-5469.756]	Security. Julien Bouquet:
-Guzman. Michael Guzman	[5469.936-5469.936]	Ms.
-Guzman. Michael Guzman	[5469.936-5470.619]	Johnson. Debra Johnson:
-Guzman. Michael Guzman	[5470.998-5472.515]	Yes. Thank you very much,
-Guzman. Michael Guzman	[5472.894-5472.894]	Mr.
-Guzman. Michael Guzman	[5473.273-5477.150]	Chair. And thank you, Director "Guz-min--" Guzman, I apologize, for the
-Guzman. Michael Guzman	[5477.855-5480.154]	question. Most definitely, we will go through the committee
-Guzman. Michael Guzman	[5480.461-5482.848]	procedure. The only reason why this didn't happen because it's time
-Guzman. Michael Guzman	[5483.548-5483.909]	sensitive. So thank
-you. Julien Bouquet	[5484.931-5485.427]	Thank you very
-you. Julien Bouquet	[5486.775-5486.945]	much. All
-you. Julien Bouquet	[5487.196-5488.046]	right. Well, thank you again,
-you. Julien Bouquet	[5488.299-5488.299]	Ms.
-you. Julien Bouquet	[5489.637-5490.503]	Vallejos. All right, moving
-you. Julien Bouquet	[5490.792-5492.812]	on. Thank you, Directors, for the questions and
-you. Julien Bouquet	[5493.602-5496.204]	conversations. We're going to be moving to our committee
-you. Julien Bouquet	[5496.575-5499.177]	reports. Not to be the time police or
-you. Julien Bouquet	[5499.589-5502.787]	anything. We are at 8:31 PM and we've been going at this since
-you. Julien Bouquet	[5503.613-5507.051]	3:30. If committee reports could be less than a minute, that'd be greatly
-you. Julien Bouquet	[5507.938-5508.893]	appreciated. Audit Committee Chair
-you. Julien Bouquet	[5509.212-5510.804]	Buzek. What would you like to
-you. Julien Bouquet	[5512.064-5512.465]	share? Vince Buzek: Thank you,
-you. Julien Bouquet	[5512.666-5512.666]	Mr.
-you. Julien Bouquet	[5512.906-5514.326]	Chair. We did not meet in April or
-you. Julien Bouquet	[5514.549-5516.559]	May. Our next meeting is June 12,
-you. Julien Bouquet	[5516.994-5517.790]	2025. That concludes my
-you. Julien Bouquet	[5518.437-5518.788]	report. Thank
-you. Julien Bouquet	[5519.158-5519.684]	Thank you very
-you. Julien Bouquet	[5521.804-5523.087]	much. Finance and Planning Committee
-you. Julien Bouquet	[5523.407-5524.048]	report. Committee Chair
-Guzman. Michael Guzman	[5524.048-5524.953]	Thank you,
-Guzman. Michael Guzman	[5525.128-5525.128]	Mr.
-Guzman. Michael Guzman	[5526.504-5533.738]	Chair. The Finance Planning Committee met Tuesday, May 13, discussed a handful of items, received a report from our state demographer, which was really
-Guzman. Michael Guzman	[5534.794-5542.756]	awesome. Directors are reminded to email the Board Office if you had any follow up questions or things specific to your sub district, so we can send that all at once to receive an answer to the whole
-Guzman. Michael Guzman	[5543.684-5552.552]	Board. Received an update from Doti for the East Colfax BRT, and three items came out of committee which will be before us
-Guzman. Michael Guzman	[5553.526-5555.308]	tonight. Just want to thank the committee for all of the hard
-Guzman. Michael Guzman	[5556.292-5565.050]	work. And the next meeting for the Finance and Planning Committee is scheduled for Tuesday, June 10 at 10:25-- or sorry, at 5:30
-Guzman. Michael Guzman	[5565.050-5565.210]	PM. Thank
-you. Julien Bouquet	[5566.613-5566.987]	Thank you,
-you. Julien Bouquet	[5568.357-5572.677]	Director . Committee Chair Ruscha or Committee Chair Harwick, what would you like to share
-you. Julien Bouquet	[5573.962-5574.413]	for OSS? Joyann Ruscha: I'll take
-you. Julien Bouquet	[5575.484-5575.655]	it, sir.
-you. Julien Bouquet	[5575.865-5578.301]	Thank you. So we met remotely on Wednesday,
-you. Julien Bouquet	[5579.490-5584.271]	May 14. We gaveled in at 5:34 PM and wrapped up at
-you. Julien Bouquet	[5585.319-5589.786]	9:44 PM. We had extensive public comments, the most I've ever seen at any
-you. Julien Bouquet	[5591.087-5591.448]	OSS meeting. That
-you. Julien Bouquet	[5591.708-5592.639]	was great. Come visit
-you. Julien Bouquet	[5594.012-5598.084]	us anytime. It's always nice to know that people are listening to our podcast, and by that I mean our
-you. Julien Bouquet	[5598.278-5603.762]	YouTube channel. But two major items that went on the consent calendar for
-you. Julien Bouquet	[5604.220-5606.962]	tonight's meeting. Is the 2025, 2028 Title VI
-you. Julien Bouquet	[5607.419-5620.673]	program update. Just ensuring that we stay in compliance with federal law, Civil Rights protections, and meet the needs of our customers, as well as the Allied Universal Security Services
-you. Julien Bouquet	[5621.110-5625.596]	Contract Extension. F&P authorized a budget transfer which had no
-you. Julien Bouquet	[5626.195-5627.887]	financial impact. It was just moving from one department
-you. Julien Bouquet	[5628.598-5636.552]	to another. And then we followed that up with a vote to extend that contract for another year, with the cost of up to just a little over
-you. Julien Bouquet	[5637.628-5640.821]	22 million. And we did have four discussion items, two of which
-you. Julien Bouquet	[5642.133-5645.882]	were heard. So we had the Vision Zero update from GM
-you. Julien Bouquet	[5646.693-5651.455]	CEO Johnson. As you might recall, we passed a Vision Zero resolution last year and so that planning process
-you. Julien Bouquet	[5652.541-5654.428]	is underway. We had a customer
-you. Julien Bouquet	[5655.506-5665.384]	communications update. Stuart Summers led an excellent presentation discussing how we handle communications, some tech updates, customer
-you. Julien Bouquet	[5665.981-5668.990]	service aspects. It was real-time information and service alerts and things
-you. Julien Bouquet	[5670.088-5673.383]	like that. Unfortunately, we did hit our four hour mark before we could finish our
-you. Julien Bouquet	[5673.637-5677.186]	agenda items. And even though the Nuggets weren't playing, folks wanted to go and we
-you. Julien Bouquet	[5678.020-5683.630]	were tired. So we moved the on-Demand item to tonight's meeting, which we
-you. Julien Bouquet	[5684.062-5688.677]	just heard. And then we'll be hearing paratransit legacy customer protections proposal
-you. Julien Bouquet	[5689.599-5701.066]	next month. So for those of you who have been tracking what we're doing with paratransit, I strongly encourage you to come visit us at OSS next month and weigh in so we get your feedback before we come back with something
-you. Julien Bouquet	[5702.214-5706.050]	more final. Our next meeting is Wednesday, June 11
-you. Julien Bouquet	[5706.529-5710.365]	at 5:30. Same time, same place, online or on
-you. Julien Bouquet	[5711.625-5711.775]	the phone.
-Thank you. Julien Bouquet	[5712.406-5713.458]	Thank you,
-Thank you. Julien Bouquet	[5714.562-5716.576]	Committee Chair. Now to for Performance Committee
-Chair Guzman. Michael Guzman	[5716.576-5717.712]	I
-Chair Guzman. Michael Guzman	[5718.573-5719.014]	got it. Thank
-Chair Guzman. Michael Guzman	[5719.234-5719.234]	you,
-Chair Guzman. Michael Guzman	[5719.895-5721.458]	Mr. Chair. Performance committee met Monday, May
-Chair Guzman. Michael Guzman	[5722.423-5749.617]	12, 2025. I, the Committee Chair, presented a draft proposal that I had worked on previously with Vice Chair Gutschenritter for the 2025 General Manager/CEO performance assessment form and process that needed to be updated to seek input from the committee and other Directors to find a way forward for the rest of the year based on the current 2025 General Manager/CEO short term goals and the respective adjustments made to the scoring points based on our votes
-Chair Guzman. Michael Guzman	[5750.508-5751.515]	in January. I've received
-Chair Guzman. Michael Guzman	[5752.031-5754.934]	some feedback. I continue to invite Directors to submit
-Chair Guzman. Michael Guzman	[5755.337-5760.342]	their feedback. If you have not reviewed that meeting, please do so, and any questions you may have, please email me or
-Chair Guzman. Michael Guzman	[5760.868-5762.867]	call me. I am happy to engage in
-Chair Guzman. Michael Guzman	[5763.894-5771.908]	that conversation. Of course, we are doing that with participation and a lot of communication with the General Manager/CEO,
-Chair Guzman. Michael Guzman	[5772.698-5777.564]	Debra Johnson. The next meeting of the Performance Committee is scheduled for June 2, 2025 at
-Chair Guzman. Michael Guzman	[5778.469-5783.313]	8:30 AM. I really want to encourage all of you Directors to please participate in
-Chair Guzman. Michael Guzman	[5784.401-5784.651]	that meeting.
-Chair Guzman. Michael Guzman	[5785.042-5800.420]	Two reasons. One, we are going to receive-- I hope I don't get this wrong because I don't have my work plan in front of me, but the employee survey results in the beginning of that meeting, and then we will adjourn into executive session for the second quarterly one-on-one opportunity with our
-Chair Guzman. Michael Guzman	[5801.724-5815.004]	General Manager/CEO. And that is part of our contracted agreement with the General Manager/CEO to receive information from her and provide feedback regarding
-Chair Guzman. Michael Guzman	[5816.962-5823.827]	personnel matters. Additionally, the Performance Committee is set to have a second meeting in June because of that
-Chair Guzman. Michael Guzman	[5825.192-5839.238]	quarterly check-in. The second meeting is planned, I believe, for June 23 at 8:30 AM, and that is in order to do a deep dive into our community and customer surveys, which align with our community value and customer excellence
-Chair Guzman. Michael Guzman	[5840.170-5851.183]	strategic initiatives. And I would again encourage all Directors to participate in that meeting as well, which is the overview of the current status of the agency's surveys and where we're at with regard
-Chair Guzman. Michael Guzman	[5851.949-5859.392]	to public. It will inform the process for setting goals and priorities for the 2026 year which we are also doing all at the
-Chair Guzman. Michael Guzman	[5859.916-5873.174]	same time. So prioritizing what is important for our customers, the survey reports are a great opportunity to engage with direct feedback from our constituents in all areas of
-Chair Guzman. Michael Guzman	[5874.100-5880.304]	the agency. And I do believe a little birdie has told me on one of the buses that these should be really
-Chair Guzman. Michael Guzman	[5881.295-5890.617]	positive discussions. So if you need more than that invitation, please signal tonight and I will call you and email you and hound you to be on these meetings, because I think they're really important for all
-Chair Guzman. Michael Guzman	[5890.916-5891.066]	of us.
-Thank you. Julien Bouquet	[5892.239-5893.714]	Thank you, Committee
-Thank you. Julien Bouquet	[5894.232-5894.793]	Chair Guzman. All right,
-Thank you. Julien Bouquet	[5895.875-5898.871]	moving on. We're going to do the approval of Board meeting minutes and
-Thank you. Julien Bouquet	[5899.522-5902.957]	committee reports. The Board and committee meeting minutes were included in the
-Thank you. Julien Bouquet	[5903.991-5907.862]	Board packet. Are there any corrections from the Board for the minutes to be approved
-Thank you. Julien Bouquet	[5911.345-5911.605]	this evening?
-Thank you. Julien Bouquet	[5913.489-5913.801]	Any corrections?
-Thank you. Julien Bouquet	[5913.801-5920.356]	All right. Unless there's objection to considering the minutes all at the same time, may I please have a motion to approve the minutes for the
-Thank you. Julien Bouquet	[5921.225-5924.144]	following meetings? The April 9, 2025 Operation Safety and
-Thank you. Julien Bouquet	[5925.029-5926.965]	Security Committee. The April 29, 2025
-Thank you. Julien Bouquet	[5927.912-5929.881]	Board meeting. The May 12, 2025
-Thank you. Julien Bouquet	[5930.515-5932.472]	Performance Committee. The May 13, 2025 Finance and
-Thank you. Julien Bouquet	[5933.699-5936.274]	Planning Committee. May 14, 2025 Operation Safety and
-Thank you. Julien Bouquet	[5936.942-5939.430]	Security Committee. And then May 22, 2025
-Thank you. Julien Bouquet	[5940.246-5940.506]	Executive Committee. Michael Guzman:
-Thank you. Julien Bouquet	[5940.786-5940.786]	So
-Thank you. Julien Bouquet	[5941.587-5942.058]	moved. Guzman. Julien Bouquet:
-Thank you. Julien Bouquet	[5943.610-5943.910]	Mover, Guzman. Joyann
-Ruscha	[5943.910-5943.910]	Second. Chris
-Gutschenritter	[5944.891-5946.119]	Second. Julien Bouquet: I'm going to give it
-Gutschenritter	[5949.211-5953.209]	to Gutschenritter. So I heard Director Guzman as the mover and Director Gutschenritter as
-Gutschenritter	[5953.496-5954.714]	the second. Is there any discussion on
-Gutschenritter	[5959.703-5959.703]	this
-Gutschenritter	[5960.244-5961.651]	motion? OK. Seeing none, I'll now call
-Gutschenritter	[5962.006-5963.337]	the vote. Are there any no votes on
-Gutschenritter	[5966.771-5970.117]	this action? It'll pass 14, 0, and
-Gutschenritter	[5972.417-5972.417]	1
-Gutschenritter	[5973.519-5973.719]	absent. Excellent.
-Gutschenritter	[5975.975-5976.273]	All right.
-Gutschenritter	[5976.571-5978.060]	Moving on. It will be our
-Gutschenritter	[5978.778-5983.919]	Chair's report. Due to the late hour, I will be quoting my principal and saying, I am giving you all the gift
-Gutschenritter	[5984.724-5993.054]	of time. And all I can say with my Chair's report is we will have a Board retreat on June 7 talking about our 2026 priorities for
-Gutschenritter	[5993.974-5996.164]	the agency. Again, Directors, hopefully you all can
-Gutschenritter	[5996.517-6003.878]	make that. It'll be a very healthy discussion, a very hearty discussion, I guarantee, but please make sure you have that marked down in
-Gutschenritter	[6004.586-6004.786]	your calendars.
-Thank you. Chris Nicholson	[6008.662-6010.865]	Did you want to remind everybody about the survey we
-Thank you. Chris Nicholson	[6011.085-6011.306]	sent you? Julien Bouquet:
-Thank you. Chris Nicholson	[6011.666-6011.867]	Of course.
-Thank you. Chris Nicholson	[6012.467-6015.585]	Thank you. And of course, Directors, you'll see in my weekly
-Thank you. Chris Nicholson	[6015.932-6022.154]	biweekly update. There was a survey that might have been passed to you, and if you've not filled out that survey, please
-Thank you. Chris Nicholson	[6022.862-6025.782]	do so. Thank you for the Directors who did fill
-Thank you. Chris Nicholson	[6026.307-6027.122]	it in. So
-Thank you. Chris Nicholson	[6028.230-6033.832]	that's OK. If we could get that in by Monday morning, that would
-Thank you. Chris Nicholson	[6034.359-6035.918]	be excellent. I'll include that in my weekly
-Thank you. Chris Nicholson	[6036.321-6036.541]	update, though.
-Thank you. Chris Nicholson	[6037.973-6040.448]	Thank you. I'll give it now over to you,
-Thank you. Chris Nicholson	[6040.448-6043.584]	GM/CEO Johnson. Debra Johnson: Thank you very
-Thank you. Chris Nicholson	[6043.886-6043.886]	much,
-Thank you. Chris Nicholson	[6044.187-6055.938]	Mr. Chair. And to recognize the lateness of the hour, I just have a couple elements that I'll share with you that are in alignment with our activities and strategic endeavors since our last Board meeting on Tuesday,
-Thank you. Chris Nicholson	[6058.142-6068.067]	April 29. One notable aspect is the legislative conference held by the American Public Transportation Association from May 18th to the 20th in
-Thank you. Chris Nicholson	[6068.449-6079.540]	Washington, DC. Just for everyone's edification, this annual conference is an opportunity for Public Transportation industry professionals across the nation to visit Washington, DC and connect with policymakers, implementers, and
-Thank you. Chris Nicholson	[6080.583-6090.525]	their staffs. The conference helps educate and inform APTA members on important federal legislation and policy initiatives, and affords an unparalleled opportunity to shape the industry's positions in federal
-Thank you. Chris Nicholson	[6091.349-6100.879]	advocacy agenda. I, along with Directors O'Keefe, Chandler, and Gutschenritter, and Government Relations Officer Michael Davies, attended conference sessions and meetings with members of Colorado's congressional delegation and
-Thank you. Chris Nicholson	[6101.208-6117.555]	their staffs. While chairing an APTA committee meeting on Sunday, May 8, I personally engaged with Tariq Bokhari, who is the acting administrator of the Federal Transit Administration, who shared his views and inputs as it relates to public transit, as well as the importance of federal and
-Thank you. Chris Nicholson	[6118.332-6125.272]	local partnerships. Just yesterday, Tuesday, May 27, I, along with members of my team, met with individuals representing the alliance to
-Thank you. Chris Nicholson	[6126.380-6131.428]	transform transportation. As you may be aware, it's a coalition of groups on transit related matters
-Thank you. Chris Nicholson	[6132.406-6140.807]	in Colorado. Alliance representatives in attendance included executive Director of the Colorado Public Interest Research Group, Danny Katz, or CPIRG, as we refer
-Thank you. Chris Nicholson	[6141.189-6144.244]	to it. Jill Cantor, Executive Director of the Denver
-Thank you. Chris Nicholson	[6144.626-6151.747]	Streets Partnership. Portia Prescott, Present of the Rocky Mountain NAACP branch of the State Conference representing Colorado, Montana,
-Thank you. Chris Nicholson	[6152.117-6154.706]	and Wyoming. Dennis Hawkins, representing the Amalgamated Transit
-Thank you. Chris Nicholson	[6156.233-6158.522]	Union 1001. Matt Fromer, representing transportation and
-Thank you. Chris Nicholson	[6158.903-6164.626]	land use. Well, he is the Transportation and Land Use Policy Manager from the Southwest Energy
-Thank you. Chris Nicholson	[6165.027-6169.119]	Efficiency Project. The meeting really was focused on alliance's vision for transit in the
-Thank you. Chris Nicholson	[6170.235-6183.694]	Denver region. As you know, they have been very vocal in which they're seeking to increase funding for transit in the Denver region by $420 million per year to bolster the frequency and availability of transit services in the
-Thank you. Chris Nicholson	[6186.159-6200.555]	metro area. From RTD's perspective, questions were posed relative to how that $420 million figure was derived, and they explained how that came about with the work they had done with the third
-Thank you. Chris Nicholson	[6200.993-6204.061]	party entity. Very bare bones relative to providing
-Thank you. Chris Nicholson	[6204.884-6220.463]	some information. And then we talked about the agency's focus, which all of you are very well aware that we are laser focused on asset renewal, state of good repair, and rightsizing transit service in alignment with RTD's branded comprehensive operational analysis being the System
-Thank you. Chris Nicholson	[6221.675-6222.805]	Optimization Plan. Related to
-Thank you. Chris Nicholson	[6223.182-6235.237]	personal security. As was recently reported, RTD experienced a 60% reduction in security related calls for service, as well as a three year decrease in reports of criminal activities between 2022 and 2025 at Denver
-Thank you. Chris Nicholson	[6235.674-6255.150]	Union Station. The decrease is representative of concerted efforts to restore and maintain a welcoming transit environment within the critical multi-modal transit hub and following a collaborative and multifaceted strategy aimed at enhancing personal safety and security through crime prevention through environmental
-Thank you. Chris Nicholson	[6255.968-6271.796]	design methodologies. This effort would have not have been a success without the commitment of numerous agency employees, as well as support from the City and County of Denver, its police department, the Downtown Denver Partnership, Sage Hospitality, the Lower Denver Neighborhood Association, as well as several local businesses in downtown
-Thank you. Chris Nicholson	[6272.705-6293.401]	Denver residents. Fare enforcement has also increased in recent months, which is the result of RTD's growing ranks of sworn police officers having been trained to perform this function alongside the contracted team that we have in security with Allied Universal personnel who had primarily been responsible for
-Thank you. Chris Nicholson	[6294.465-6308.906]	this responsibility. I look forward to sharing additional details regarding the impacts of these efforts during the June Performance Committee, which you heard committee Chair Guzman reference when I, along with staff, will present data related to annual customer, community, and employee surveys that have
-Thank you. Chris Nicholson	[6309.290-6324.142]	recently concluded. On a related note, the agency has proactively increased its transit police officer presence at Denver Union Station and across the agency's downtown Denver sector to support the personal safety and security of customers and visitors attending major events
-Thank you. Chris Nicholson	[6324.513-6346.035]	and activity. Notably, while we're no longer in the hockey playoffs and NBA, but people had a welcoming experience in and around our facilities, and RTD PD had increased patrols at Denver Union Station and bus stops and rail stations before the high profile events, which included the playoff games I
-Thank you. Chris Nicholson	[6346.771-6351.011]	just referenced. And this coincides with increasing Denver Police patrols throughout the
-Thank you. Chris Nicholson	[6352.037-6358.501]	Downtown area. And RTD and DPD are working closely to collaborate to support enhanced safety for the
-Thank you. Chris Nicholson	[6361.045-6373.358]	traveling public. And moreover, data and metrics related to personal safety and Security are now conveniently located on the recently created security related metrics page, and we've actually showcased that on other social media channels
-Thank you. Chris Nicholson	[6374.921-6390.499]	as well. As it relates to our customer excellence in relation to the strategic priorities of customer excellence and employee ownership, I shared yesterday with the Board the last of the 31 light rail speed restrictions put into place last year on the D, H, and E and R lines was lifted as of
-Thank you. Chris Nicholson	[6391.843-6395.749]	yesterday morning. I want to give a special shout out to our Maintenance of Way teams that have done
-Thank you. Chris Nicholson	[6396.407-6405.694]	yeoman's work. The final speed restriction, which was approximately 400 feet in the southbound segment north of Southmoor Station, was removed after crews completed
-Thank you. Chris Nicholson	[6408.798-6423.462]	those repairs. Keeping in mind those rigorous restrictions were put into place due to the fact that we enhanced our inspections of track back in May 2024 as an enhanced focus on maintaining the agency's assets in a state of
-Thank you. Chris Nicholson	[6424.251-6427.743]	good repair. At the time, crews found several minor issues and
-Thank you. Chris Nicholson	[6428.475-6440.308]	track imperfections. So, as I said before, I thank and congratulate all the agency employees who work tire-- I'm tired-- tirelessly over the course of these
-Thank you. Chris Nicholson	[6441.147-6444.480]	11 months. And like I said, a special shout out
-Thank you. Chris Nicholson	[6446.534-6456.028]	to MOW. I would be remiss if I didn't state that while this is a cause to celebrate, I shared previously, as we look at our infrastructure and it continues to age, this will be par for
-Thank you. Chris Nicholson	[6456.291-6460.774]	the course. But since we're ahead of where we were before, we will see less of an impact,
-Thank you. Chris Nicholson	[6461.900-6468.445]	I'm certain. And last, but certainly not least, I'm pleased to welcome RTD's new Chief Financial Officer, Kelly Mackey, who's in
-Thank you. Chris Nicholson	[6468.912-6469.483]	the audience. She's giving
-Thank you. Chris Nicholson	[6469.990-6471.587]	a wave. Who began her tenure on
-Thank you. Chris Nicholson	[6472.173-6474.444]	May 12. And this is her first in-person
-Thank you. Chris Nicholson	[6474.696-6482.076]	Board meeting. While we introduced her at the Finance and Planning Committee, you guys are real people, not figments of our imagination, so I wanted to ensure I did
-Thank you. Chris Nicholson	[6482.327-6487.915]	that here. So with that, I will yield the floor so we can move on to the rest of the matters that we have
-Thank you. Chris Nicholson	[6487.915-6488.988]	before us. So thank you very
-Thank you. Chris Nicholson	[6489.202-6489.202]	much,
-Mr. Chair. Julien Bouquet	[6492.160-6493.482]	Thank you,
-Mr. Chair. Julien Bouquet	[6494.824-6497.262]	GM/CEO Johnson. Any comments or questions for
-Mr. Chair. Julien Bouquet	[6500.855-6500.855]	GM/CEO Johnson? Chris Nicholson:
-Mr. Chair. Julien Bouquet	[6500.855-6500.855]	Just [INAUDIBLE]. Julien
-Bouquet	[6506.261-6506.582]	Yeah.
-Bouquet	[6507.242-6508.544]	Very exciting. And Kelly, welcome to
-Bouquet	[6509.324-6509.494]	the team.
-Bouquet	[6512.488-6512.688]	Thank you.
-Bouquet	[6513.409-6513.770]	All right.
-Bouquet	[6514.759-6516.889]	Moving on. We're going to move on to
-Bouquet	[6518.011-6524.356]	unanimous consent. There are three items on the unanimous consent agenda listed under Section 16, actions A
-Bouquet	[6524.752-6535.100]	through C. Those items are the security operations budget transfer, the 2025-2028 Title VI program update, and the Allied Universal security services contract extension for
-Bouquet	[6535.556-6544.102]	one year. I do understand that Director Benker would like to offer some amendments to item B, the 2025-2028 Title VI
-Bouquet	[6544.529-6548.375]	program update. And such, I will move that our a
-Bouquet	[6548.802-6549.230]	recommended actions.
-Bouquet	[6549.677-6564.184]	Excuse me. If anyone else has a change to discussion on or questions about any of the remaining unanimous consent items, please feel free to advise the Chair at this time and I will, of course, be happy to pull the item from unanimous consent for consideration under
-Bouquet	[6565.597-6565.967]	recommended action.
-Director Nicholson. Chris Nicholson	[6565.967-6569.963]	The Allied Universal
-Director Nicholson. Chris Nicholson	[6570.314-6571.015]	security contract. Please
-Director Nicholson. Chris Nicholson	[6571.705-6572.526]	pull that. Julien
-Bouquet	[6572.526-6579.695]	OK. So item B will be removed and placed into recommended action
-Bouquet	[6580.076-6585.626]	Excuse me. Former item C, as I look in real time here, the Allied
-Bouquet	[6587.289-6589.199]	Universal security. So are we OK with security operations
-Bouquet	[6593.919-6597.994]	budget transfer? Troy Whitmore: I would move to approve the remainder of the unanimous
-Bouquet	[6598.726-6598.726]	consent agenda. Joyann
-Ruscha	[6599.667-6599.983]	Second. Julien
-Bouquet	[6599.983-6602.195]	OK. I have Whitmore and then Ruscha as
-Bouquet	[6605.936-6606.907]	a second. Are
-Bouquet	[6606.907-6623.375]	there-- OK. So this is item A for the Board of Directors to approve a budget transfer of $3,845,437.10 between operating expenses lines for transit
-Bouquet	[6626.481-6628.662]	security services. Is there any no votes
-Bouquet	[6631.590-6631.590]	on
-Bouquet	[6633.239-6635.437]	that? OK. Seeing none, that item will
-Bouquet	[6636.564-6637.099]	pass 14-0-1.
-Bouquet	[6637.635-6641.917]	All right. Now we're moving on to our recommended
-Bouquet	[6643.214-6648.965]	action items. And we're going to have first on our list the Allied Universal security services contract extension for
-Bouquet	[6650.845-6651.806]	one year. Is there
-Bouquet	[6653.148-6653.548]	a motion? Chris Nicholson:
-Bouquet	[6653.969-6654.249]	So moved. Julien Bouquet:
-Bouquet	[6656.112-6656.353]	OK, Nicholson. And
-Bouquet	[6657.515-6657.735]	a second.
-Bouquet	[6659.658-6659.948]	And Ruscha.
-Bouquet	[6660.239-6660.529]	All right.
-Bouquet	[6662.001-6662.311]	Any discussion?
-Bouquet	[6662.311-6663.192]	Director Nicholson? Chris
-Nicholson	[6663.459-6667.191]	Yeah. So I just have a quick question about this one that came from
-Nicholson	[6668.399-6675.055]	a constituent. How many people do we have working on our security side
-Nicholson	[6676.090-6680.272]	from allied? And how many do we have from RTD PD
-Nicholson	[6681.558-6681.699]	right now?
-Nicholson	[6683.100-6683.100]	Thank you. Julien
-Nicholson	[6683.261-6683.261]	Bouquet:
-Ms. Johnson. Debra Johnson	[6683.261-6687.388]	Yes, I will yield the floor to Chief Martingano, who can address
-Ms. Johnson. Debra Johnson	[6687.687-6687.857]	that question.
-Ms. Johnson. Debra Johnson	[6690.591-6690.942]	Thank you. Julien Bouquet:
-Chief Martingano. Steve Martingano	[6690.942-6693.731]	I am trying to
-Chief Martingano. Steve Martingano	[6694.000-6694.537]	figure out. Oh, there
-Chief Martingano. Steve Martingano	[6694.806-6695.075]	we go.
-Chief Martingano. Steve Martingano	[6695.344-6695.882]	Turned green. Chair,
-Chief Martingano. Steve Martingano	[6696.171-6696.171]	for me? Julien
-Bouquet	[6696.551-6701.724]	Yes. Steve Martingano: Yeah, so technically, in regards to how many Allied personnel, it's an
-Bouquet	[6702.378-6705.163]	hourly contract. So you'd have to take the amount of the hours and obviously divide it
-Bouquet	[6705.402-6709.258]	by 40. It roughly equates to the recommended action for
-Bouquet	[6709.707-6711.325]	next year. I think it's about
-Bouquet	[6711.689-6714.440]	9,100 hours. So it roughly equates about 180
-Bouquet	[6714.813-6720.201]	security officers. Right now, we currently have 87 on our staff in regards to post-certified
-Bouquet	[6720.900-6723.964]	police officers. We have a couple in training and one in
-Bouquet	[6724.271-6727.642]	the academy. We should be probably about 90 by the end of
-Bouquet	[6728.308-6728.468]	next month. Julien Bouquet:
-Bouquet	[6731.592-6731.592]	Thank
-you. Secretary. Chris Nicholson	[6731.592-6732.746]	This is for
-you. Secretary. Chris Nicholson	[6734.561-6742.382]	GM/CEO Johnson. Are there any plans in place or-- and please feel free to not answer this if
-you. Secretary. Chris Nicholson	[6743.810-6749.578]	you can't. But I know there's been a drawdown over the last few years in our reliance on
-you. Secretary. Chris Nicholson	[6749.958-6771.257]	Allied Security. Is there anything in this contract or in your planning around this contract or anything that can give us guidance on whether we expect that to continue after authorizing this, or are we expecting to stay at 90 something hundred or 180 people over the next
-you. Secretary. Chris Nicholson	[6773.134-6773.134]	few years? Julien
-you. Secretary. Chris Nicholson	[6773.134-6773.134]	Bouquet:
-you. Secretary. Chris Nicholson	[6773.134-6773.134]	Ms. Johnson. Debra
-Johnson	[6773.355-6774.472]	Yes. Thank you very much for
-Johnson	[6774.778-6781.584]	the question. As Chief indicated, this is a contract extension and there's hours that are specified, hence in reference to the dollar amount that we
-Johnson	[6781.850-6790.229]	have here. I would have to come back to the Board as it relates to any type of authorization as we're doing now currently with this contract extension, if that were to
-Johnson	[6790.721-6794.181]	be modified. So on this point in time, it would stay
-Johnson	[6794.527-6805.944]	the same. Unless there's some extenuating circumstances whereby we go out for a solicitation and we're not able to ensure that we're meeting the timeline before, since that's why we're here now with the
-Johnson	[6806.290-6811.524]	contract extension. Quite naturally, in doing so, we have to ensure that we have the appropriate
-Johnson	[6812.500-6817.178]	staffing levels. So I'm talking around and around in circles right now, but the answer would be no at this point
-Johnson	[6819.014-6819.014]	in time. Julien
-Johnson	[6821.477-6821.477]	Bouquet:
-Johnson	[6822.839-6823.499]	Secretary. Perfect. Second Vice
-Chair Whitmore. Troy Whitmore	[6823.720-6831.035]	So, Chief, jog my memory on our goal for the end of the year for
-Chair Whitmore. Troy Whitmore	[6831.449-6832.305]	sworn officers. It's not
-Chair Whitmore. Troy Whitmore	[6832.671-6833.783]	90, right? It's continuing
-Chair Whitmore. Troy Whitmore	[6834.713-6835.452]	to grow. Julien Bouquet:
-Chair Whitmore. Troy Whitmore	[6835.452-6835.452]	Chief Martingano. Steve
-Martingano	[6835.732-6837.134]	Yeah. So we are budgeted
-Martingano	[6837.874-6840.276]	for 150. We're still in the process of growing to
-Martingano	[6842.587-6848.266]	those numbers. So obviously with applications, background checks, everything else, we're heading positively
-Martingano	[6848.743-6850.527]	toward that. We're putting eight more in the academy here
-Martingano	[6850.765-6852.892]	in June. We continue to get
-Martingano	[6853.747-6856.944]	lateral transfers. I'm sorry, lateral applications from other agencies, officers
-Martingano	[6857.671-6860.350]	with experience. So we're hoping to hit 150 goal by the end of
-Martingano	[6860.593-6860.833]	the year. Troy Whitmore:
-Martingano	[6861.094-6861.634]	All right. Thank you
-Martingano	[6861.834-6863.988]	very much. I did have the right memory
-Martingano	[6864.336-6864.796]	up here. Thank
-Martingano	[6865.027-6865.027]	you,
-Martingano	[6865.338-6865.338]	Mr. Chair. Julien
-Bouquet	[6867.821-6869.905]	Absolutely. Any other-- well, any further questions or discussions
-Bouquet	[6871.144-6871.517]	on this? Yeah,
-Bouquet	[6873.546-6873.773]	Director Ruscha? Joyann Ruscha: Thank
-Bouquet	[6873.967-6901.547]	you, sir. So I just wanted to note, in the past, upon request, the agency has provided a breakdown of how many-- just our security personnel from RTD to contracted and even break down in terms of with our contracted Allied force, like the ones that are authorized to have firearms versus not and our mental health staff
-Bouquet	[6901.862-6907.844]	and stuff. So that's something that I think the agency-- I'm sure the agency would be happy to provide that
-Bouquet	[6908.209-6919.874]	breakdown chart. I think it's been a little over a year since we've had one, so I just wanted to offer that to those who are interested and just to piggyback on Secretary
-Bouquet	[6920.282-6920.733]	Nicholson's comments.
-Thank you. Julien Bouquet	[6921.203-6921.630]	Thank
-Thank you. Julien Bouquet	[6924.287-6925.312]	you, Director. Any further comments
-Thank you. Julien Bouquet	[6927.168-6927.168]	or
-Thank you. Julien Bouquet	[6927.435-6927.702]	questions? OK.
-Thank you. Julien Bouquet	[6928.089-6929.737]	Seeing none. So I did have-- thank
-Thank you. Julien Bouquet	[6930.813-6933.658]	you, Chief. I did have Nicholson as the mover and Ruscha as
-Thank you. Julien Bouquet	[6934.418-6936.188]	the second. Are there any no votes on
-Thank you. Julien Bouquet	[6940.667-6940.667]	this
-Thank you. Julien Bouquet	[6941.101-6944.138]	item? OK. Seeing none, the item will pass
-Thank you. Julien Bouquet	[6945.433-6949.462]	14-0-1 absent. We are hitting our two hour mark, so we are going to take a break for our
-Thank you. Julien Bouquet	[6950.800-6953.756]	CART employee. Let's shoot to be back here
-Thank you. Julien Bouquet	[6954.145-6954.706]	9 o'clock. Would that be
-Thank you. Julien Bouquet	[6956.260-6956.260]	enough
-Thank you. Julien Bouquet	[6956.620-6956.620]	time?
-Thank you. Julien Bouquet	[6957.221-6957.221]	Nope?
-Thank you. Julien Bouquet	[6957.441-6958.192]	OK. OK. Let's do
-Thank you. Julien Bouquet	[6959.002-6959.273]	9:05, then. Chris Nicholson:
-Thank you. Julien Bouquet	[6959.563-6960.033]	Thank you. Julien Bouquet:
-Thank you. Julien Bouquet	[6960.524-6979.275]	Thank you. We'll be back
-Thank you. Julien Bouquet	[6985.792-6994.943]	at 9:05.
-Thank you. Julien Bouquet	[7004.095-7127.234]	All right. Thank you, everyone, for
-Thank you. Julien Bouquet	[7204.588-7231.600]	your patience. We are now moving on to our next recommended action
-Thank you. Julien Bouquet	[7231.935-7242.990]	for tonight. And that is going to be the recommended action of the 2025-2028 Title VI program update to comply with federal laws, regulations, and guidelines related Title VI of the Civil Rights Act
-Thank you. Julien Bouquet	[7243.325-7244.665]	of 1964. Do we have
-Thank you. Julien Bouquet	[7245.000-7246.005]	a motion? Peggy Catlin:
-So moved. Julien Bouquet	[7246.340-7682.699]	I have Caitlin as
-So moved. Julien Bouquet	[7683.059-7684.138]	the mover. Michael Guzman:
-Second, Guzman. Julien Bouquet	[7685.779-7692.956]	Guzman as
-Second, Guzman. Julien Bouquet	[7694.795-7698.963]	the second. I do understand that Director Benker has two amendments she would like to offer on
-Second, Guzman. Julien Bouquet	[7699.584-7701.893]	this item. Director Benker, we'll take your amendments one at
-Second, Guzman. Julien Bouquet	[7703.672-7705.338]	a time. What is your first amendment,
-Second, Guzman. Julien Bouquet	[7706.177-7706.793]	Director Benker? Karen Benker: Thank you
-Second, Guzman. Julien Bouquet	[7707.720-7717.019]	very much. And I'm glad everybody is now second wind and we're ready to go on to our, I don't know, six or seventh hour
-Second, Guzman. Julien Bouquet	[7718.220-7721.165]	of meeting. Actually, I will tell you, I
-Second, Guzman. Julien Bouquet	[7721.626-7722.636]	have three. We'll see how
-Second, Guzman. Julien Bouquet	[7722.908-7723.449]	things go.
-Second, Guzman. Julien Bouquet	[7724.992-7727.322]	They're short. The first one-- well, let me give you a little bit
-Second, Guzman. Julien Bouquet	[7728.478-7733.189]	of background. So the background is I met with my four cities back in February
-Second, Guzman. Julien Bouquet	[7733.506-7737.813]	and March. And of course, you meet with them and you say hi and you say, OK, what are
-Second, Guzman. Julien Bouquet	[7738.112-7738.744]	your needs? What are
-Second, Guzman. Julien Bouquet	[7739.995-7748.109]	your wants? I met with all of them, and they all gave me a list of basically trying to restore service that was removed during
-Second, Guzman. Julien Bouquet	[7749.828-7759.943]	the pandemic. And so of course, as is my job as Director, I'm trying to work with our staff to try to get that
-Second, Guzman. Julien Bouquet	[7761.224-7786.716]	service restored. And so one of my questions or issues is I am guessing that when the RTD Board had to make the hard decisions of how to cut service almost in half because of this highly unusual pandemic, perhaps some of these cuts were not done equally across all
-Second, Guzman. Julien Bouquet	[7787.438-7788.802]	15 districts. Julien Bouquet: Director Benker, I'm sorry
-Second, Guzman. Julien Bouquet	[7789.075-7794.532]	to interrupt. Just so that we keep an order, could we get a second on-- could you read the motion and then we get
-Second, Guzman. Julien Bouquet	[7794.705-7807.783]	a second? Karen Benker: The motion is change the threshold for disproportionate burden and disparate impact from 10% to 20% as it relates to major service changes and consistent with the FTA
-Second, Guzman. Julien Bouquet	[7809.841-7816.852]	circular 4702.1b. And I believe the version that will be voted on is actually the version
-Second, Guzman. Julien Bouquet	[7817.156-7818.370]	that Mr. Kroll put up
-for us. Julien Bouquet	[7819.755-7821.677]	So that's the language
-for us. Julien Bouquet	[7822.017-7837.569]	right there. The first motion is to move to amend the 2025-2028 Title VI program update, such that the threshold for triggering either disperportionate burden-- or disparities in-- disparate impact finding-- late night-- finding arising from a major service change from 10%
-for us. Julien Bouquet	[7839.613-7840.894]	to 20%. Do I have
-for us. Julien Bouquet	[7842.115-7842.115]	a second? Brett Paglieri:
-Second, Paglieri. Julien Bouquet	[7842.115-7843.091]	Paglieri is
-Second, Paglieri. Julien Bouquet	[7844.397-7844.497]	the second.
-Thank you. Karen Benker	[7845.488-7851.644]	So just to continue a little bit more background, and then we can start, I guess the
-Thank you. Karen Benker	[7852.648-7859.905]	debate here. I'm just trying to get service restored that was eliminated during
-Thank you. Karen Benker	[7860.490-7872.851]	the pandemic. And there have been a couple of times now when I have requested and the answer that I have gotten several times is, well, it's going to depend on how the equity analysis calculations
-Thank you. Karen Benker	[7873.865-7895.211]	come out. And so I'm just trying to find ways where we can perhaps start to restore some of the service that had been eliminated during the pandemic and perhaps do it a little bit quicker and also try to make it not quite
-Thank you. Karen Benker	[7896.071-7903.104]	so difficult. So then what happened, of course, is everyone received about a week, 10 days ago, a letter from the City and County
-Thank you. Karen Benker	[7904.212-7914.825]	of Broomfield. And their transportation staff went through our items quite closely, and they sent us all a letter with
-Thank you. Karen Benker	[7916.054-7925.562]	recommended changes. So I've gone through with their changes, and that's where I've come up with the three amendments that I'd like to at least talk to the Board, see what your
-Thank you. Karen Benker	[7926.790-7928.788]	thoughts are. Hopefully it'll pass, but we'll see
-Thank you. Karen Benker	[7929.514-7944.171]	what happens. But it's just basically what City and County of Broomfield had found when they did their research is that the RTD is using some very conservative calculations compared to some of the other large
-Thank you. Karen Benker	[7945.374-7950.592]	transit agencies. And so I did send you also a copy of the City and County of Broomfield's letter, just to refresh
-Thank you. Karen Benker	[7951.842-7958.306]	your memory. And so I would like to put forth that the first amendment would be changing the threshold from 10%
-Thank you. Karen Benker	[7959.030-7960.126]	to 20%. Julien Bouquet: Thank you,
-Thank you. Karen Benker	[7960.652-7966.090]	Treasurer Benker. So again, the discussion right now is on the motion, this first motion, the
-Thank you. Karen Benker	[7966.818-7967.229]	first amendment.
-Director Catlin. Peggy Catlin	[7967.229-7971.696]	Thank
-Director Catlin. Peggy Catlin	[7971.922-7971.922]	you,
-Director Catlin. Peggy Catlin	[7972.768-7975.207]	Mr. Chair. I'd like to ask
-Director Catlin. Peggy Catlin	[7976.374-7980.758]	GM/CEO Johnson. I heard from someone-- I don't remember now because it's
-Director Catlin. Peggy Catlin	[7981.156-7987.134]	getting late. But someone said that some of those assumptions made by City and County of Broomfield
-Director Catlin. Peggy Catlin	[7989.036-7989.036]	were incorrect. Julien
-Director Catlin. Peggy Catlin	[7989.496-7989.496]	Bouquet:
-Director Catlin. Peggy Catlin	[7990.141-8010.114]	Ms. Johnson. Yes thank you very much relative to the comments that were made-- and thank you very much, Director Catlin-- as it relates to the transit agencies that were mentioned, being MARTA, the Metropolitan Atlanta Rapid Transit Authority, Los Angeles County Metropolitan Transit Authority, King County Metro, which is in greater Seattle, and the Chicago
-Director Catlin. Peggy Catlin	[8012.232-8020.818]	Transit Authority. That information, especially coming from LA Metro as the former Chief Operations Officer there, this is not correct relative to where
-Director Catlin. Peggy Catlin	[8021.159-8035.152]	we sit. And more specifically, I do know our Director of Civil Rights, when we were going through this, quite naturally in the role that he is in, he and his team did a desk audit and worked with colleagues at different
-Director Catlin. Peggy Catlin	[8035.494-8039.589]	transit agencies. So that's the communiqué that I did disseminate yesterday upon receiving
-Director Catlin. Peggy Catlin	[8039.930-8040.272]	this information.
-Director Catlin. Peggy Catlin	[8040.613-8043.685]	So, Mr. Green, if you want to just expound succinctly
-Director Catlin. Peggy Catlin	[8044.495-8044.495]	and briefly. Carl
-Green	[8044.867-8047.847]	Yes. Thank you so much, General Manager and
-Green	[8048.220-8059.278]	CEO Johnson. To expand upon the response, I just also want to ground us and first state that it is our collective responsibility to make federally compliant and equitable decisions, especially as it relates to
-Green	[8060.215-8071.111]	service changes. And in doing that audit, we looked at 22-- rather, 23 different organizations, which includes the four, MARTA, LA Metro, King County, and the Chicago
-Green	[8071.570-8082.881]	Transit Authority. And I would say the way to look at the disparate impact or disproportionate burden, the framing of it is how sensitive or less sensitive versus more
-Green	[8083.486-8085.133]	sensitive, right? And ours is stacked in
-Green	[8085.468-8087.177]	the middle. So I want to give you some
-Green	[8088.132-8100.005]	numbers here. So for the four that I just mentioned, MARTA has 10%, LA Metro has 5%, King County has 10%, CTA or Chicago Transit Authority
-Green	[8101.472-8110.072]	has 15%. And then when we rack and stack, look at those 22 different organizations, 6 out of that 23 have 5%
-Green	[8111.143-8111.690]	or less. Two
-Green	[8113.045-8117.631]	have 8%. Six, which includes us, or seven including us, is
-Green	[8118.458-8119.174]	at 10%. Three
-Green	[8119.532-8120.964]	at 15%. And then three
-Green	[8121.983-8140.352]	at 20%. And in my over eight years of doing this work, I'll just say that when you are setting your policy, you don't want to do a disservice to the spirit and the letter of what we're ultimately trying to achieve specifically with
-Green	[8141.312-8146.544]	Title VI. Title VI is not a stopping mechanism of bringing back or
-Green	[8147.669-8154.715]	restoring service. There are a lot of different variables, as I mentioned before, with respect to our service development guidelines, our operators resources, so on and
-Green	[8155.497-8166.650]	so forth. This is just a mechanism for the agencies such as RTD and the Board of Directors so we don't get too far over our skis without discounting populations that are more likely to be
-Green	[8166.989-8174.863]	transit reliant. So again, it's not a stopping mechanism, but this is just more so to make sure that we are taking into consideration all of
-our customers. Julien Bouquet	[8177.200-8179.074]	I have Director
-our customers. Julien Bouquet	[8184.407-8184.407]	Ruscha next. Joyann
-Ruscha	[8184.407-8191.225]	OK. I did have a question, but also Treasurer Benker had her hand up, and it was her motion, so I'm happy to wait if that was
-Ruscha	[8192.234-8192.514]	in response. Julien Bouquet:
-Ruscha	[8195.277-8199.738]	Treasurer Benker? Karen Benker: I feel that we are in an extremely unique situation because of
-Ruscha	[8201.062-8209.856]	the pandemic. So how can we restore, let's say 40% of the service that had been cut several
-Ruscha	[8210.693-8217.985]	years ago? How can we get back to 2019 when my district, other districts had
-Ruscha	[8219.368-8231.190]	that service? And so now we're being told that we can't get that service back because of this conservative calculation that we're doing, but we used to
-Ruscha	[8232.786-8239.519]	have it. And so how do we get from where we are now to bringing service back to
-Ruscha	[8241.237-8241.237]	pre-pandemic levels? Julien
-Ruscha	[8241.437-8241.437]	Bouquet:
-Ms. Johnson. Debra Johnson	[8241.437-8243.045]	Yes, thank you
-Ms. Johnson. Debra Johnson	[8243.277-8245.136]	very much. Director Benker, that question is better suited
-Ms. Johnson. Debra Johnson	[8246.164-8261.673]	for me. Relative to the service delivery framework that we have, while Title VI plays a role relative to major service changes as we talk about how we deploy services based upon a myriad of different factors relative to our revenue
-Ms. Johnson. Debra Johnson	[8262.040-8268.278]	service hours. But more specifically, at how we use our comprehensive operational analysis specifically as we talk about
-Ms. Johnson. Debra Johnson	[8269.306-8278.328]	the SOP. When I came into this organization, it was decided that we were going to look at 85% of what service levels were-- 85% of what service levels were
-Ms. Johnson. Debra Johnson	[8279.397-8288.070]	in 2019. We were in a different time relative to the commuting patterns, relative to how people were working
-Ms. Johnson. Debra Johnson	[8289.634-8299.310]	going forward. What I will share is that we are being very diligent and judicious in how we're applying service, because we do want to ensure there
-Ms. Johnson. Debra Johnson	[8299.671-8305.958]	is equity. I'm going to speak a little bit out of school here because I shared this with you yesterday, but I'll say it in this context
-Ms. Johnson. Debra Johnson	[8306.641-8316.783]	as well. As we talk about Longmont and we talk about service, we are looking at that for the fall
-Ms. Johnson. Debra Johnson	[8317.499-8319.747]	service change. That is up to the Board,
-Ms. Johnson. Debra Johnson	[8320.068-8340.305]	quite naturally. But I did want to put that forward because with the restoration of service, keeping in mind that all transit agencies across the US were in these precarious positions and the Federal Transit Administration more or less provided waivers, waivers from the sense of how we were decreasing service due to the fact that we didn't have enough
-Ms. Johnson. Debra Johnson	[8340.972-8346.023]	people power. Also, we currently are still working under a waiver as it relates to our
-Ms. Johnson. Debra Johnson	[8346.380-8356.168]	spare ratio. What I mean by that is when you deploy service in the mornings and in the afternoons with the peak, you have a certain pullout rate and you're only supposed to have a 20%
-Ms. Johnson. Debra Johnson	[8356.776-8363.701]	spare ratio. We've deviated from that and have a waiver, and we're rightsizing the fleet as we
-Ms. Johnson. Debra Johnson	[8364.148-8371.493]	move forward. So while you're bringing up these points, as you indicated, we are in uncharted territory, or were, and we're coming back
-Ms. Johnson. Debra Johnson	[8372.783-8384.643]	from that. We are looking at where there are needs relative to the entire area, from an origin and destination vantage point, just by virtue of how our service area is
-Ms. Johnson. Debra Johnson	[8385.519-8396.448]	going forward. So I'm not providing this to say I don't understand what you're trying to do, and as I share it with you, I do clearly, and we want to work within the framework that
-Ms. Johnson. Debra Johnson	[8396.828-8402.902]	we have. But a wholesale of restoration of what was happening in 2019, that wouldn't be
-Ms. Johnson. Debra Johnson	[8403.362-8413.116]	fiscally responsible. And I say it from the vantage point of we had a lot of service that was out on the street, maybe that yielded one passenger boarding per hour, but that was out on
-Ms. Johnson. Debra Johnson	[8413.716-8416.816]	the street. Does that really yield the return on investment
-Ms. Johnson. Debra Johnson	[8417.281-8424.121]	going forward? Hence that's why there were modifications relative to reallocation of services
-Ms. Johnson. Debra Johnson	[8425.220-8425.513]	going forward. Karen
-Benker	[8425.513-8427.806]	OK. But if I can-- Julien Bouquet:
-Treasurer, yeah. Karen Benker	[8428.868-8432.440]	Some of the issues that you just raised
-Treasurer, yeah. Karen Benker	[8433.037-8433.452]	are important. There's
-Treasurer, yeah. Karen Benker	[8434.020-8437.844]	no doubt. However, I don't believe it goes to the
-Treasurer, yeah. Karen Benker	[8442.914-8458.277]	equity calculation. What I think is important to hear from staff-- and I know we're going to be talking about this at our retreat, which I'm looking forward to that-- is if it's possible for us to go back to over 100 million riders in
-Treasurer, yeah. Karen Benker	[8459.283-8478.393]	three years. What barriers are we facing to try to do that so that we can go from 65 million to 100, 106, 110, and start quickly-- or not quickly, but faster than what we're doing now to get back up to higher
-Treasurer, yeah. Karen Benker	[8480.810-8480.810]	service levels? Julien
-Treasurer, yeah. Karen Benker	[8481.010-8481.010]	Bouquet:
-Treasurer, yeah. Karen Benker	[8481.010-8481.832]	Ms. Johnson. Debra Johnson:
-Treasurer, yeah. Karen Benker	[8482.893-8486.174]	Thank you. There's a couple of external factors that play into that
-Treasurer, yeah. Karen Benker	[8486.504-8504.811]	quite naturally. When we look at the central business district and the occupancy rate in the lack of people commuting in, it's important to keep in mind that there was-- I'm forgetting the name, but the City and County of Denver did the report relative to the usage rate in looking at the
-Treasurer, yeah. Karen Benker	[8505.421-8514.206]	occupancy levels. But more specifically, what's important to note is that there hasn't been the level of bounce back relative to the central
-Treasurer, yeah. Karen Benker	[8515.780-8526.222]	business district. I believe the last time I looked at stats, City and County of Denver was in the bottom three out of 50
-Treasurer, yeah. Karen Benker	[8526.660-8536.454]	major cities. And then as we know, the state of Colorado is the number-- is the third state relative to remote work and then city of Boulder is
-Treasurer, yeah. Karen Benker	[8537.178-8544.573]	number one. While I factor that in, we don't have the same operating environment that we did in 2019 or prior to
-Treasurer, yeah. Karen Benker	[8545.285-8554.007]	the pandemic. How do we get back to the transit usage that we
-Treasurer, yeah. Karen Benker	[8555.394-8582.792]	had before? I think there's so many extenuating factors going forward relative to how we're delivering the service, but also having the vehicle capacity, the people power, and the reliability aspect, which bring us full circle to state of good repair, and the other aspects that have caused people to shy away from utilizing our network because we were sacrificing one element for something else relative
-Treasurer, yeah. Karen Benker	[8583.726-8610.945]	to delivery. And I bring that up because as we talk about the people power, we clearly saw that our operating workforce was decreasing in 2016 as it was across the country, but more specifically, having other ancillary services that were readily available were people whereby were working extra shifts, and then we didn't have enough people for daily pull out on those
-Treasurer, yeah. Karen Benker	[8611.862-8620.393]	other routes. And so I'm providing that context to say, to get back, there are certain things that the agency can
-Treasurer, yeah. Karen Benker	[8620.778-8635.381]	surely do. But to get back to those numbers within the period of time that you specify would be very challenging, just because of the different operating characteristics that have been altered by factors that are no fault of
-Treasurer, yeah. Karen Benker	[8637.854-8638.315]	this agency's. Julien Bouquet:
-Director Ruscha. Joyann Ruscha	[8638.315-8638.315]	Thank
-Director Ruscha. Joyann Ruscha	[8638.315-8641.294]	you, sir. So I have a question
-Director Ruscha. Joyann Ruscha	[8643.142-8652.701]	for legal. So recognizing this has to be submitted shortly, I-- I'm going to be careful with
-Director Ruscha. Joyann Ruscha	[8655.141-8664.676]	my words. Can we make significant changes at this juncture after all of the public
-Director Ruscha. Joyann Ruscha	[8665.357-8673.716]	comment process? Or is that something that we-- I guess I don't know if it's a yes, no, or a gray area, and I wanted to get a bit of feedback
-Director Ruscha. Joyann Ruscha	[8674.422-8675.651]	on that. Not to disparage
-Director Ruscha. Joyann Ruscha	[8675.958-8678.722]	the motion. I just also want to understand the potential
-legal implications. Debra Johnson	[8684.175-8688.030]	I will address that question and then I'll
-legal implications. Debra Johnson	[8688.458-8689.315]	ask Mr. Green
-legal implications. Debra Johnson	[8689.823-8716.761]	to expound. I think if anything, as we talk about public engagement and talk about the agencies, the perception of the agency being trustworthy, going forward and getting public engagement quite naturally and then not leveraging it for the betterment of the constituencies that we serve, I think, pose a risk as it relates to the agency in reference to the
-legal implications. Debra Johnson	[8717.690-8723.211]	public perception. There is leeway relative to the circular in light of what can
-legal implications. Debra Johnson	[8723.696-8736.435]	be done. We are sitting here on May 28, recognizing that we have a new administration and that we do need to have a Title VI program that's submitted, and we have been engaged on this topic
-legal implications. Debra Johnson	[8737.230-8739.608]	since January. That's not to negate any amendments or anything
-legal implications. Debra Johnson	[8739.953-8742.107]	like that. I am just trying to answer
-legal implications. Debra Johnson	[8742.665-8743.794]	the question. But more
-legal implications. Debra Johnson	[8744.170-8749.437]	specifically, Mr. Green, since you are very well versed in 4702.1b, would yield the floor
-legal implications. Debra Johnson	[8749.853-8753.579]	to you. And that's the citation for the FTA circular that we're
-legal implications. Debra Johnson	[8754.359-8754.359]	talking about. Carl
-Green	[8754.654-8756.426]	Yes. Thank you so much,
-Green	[8757.522-8757.522]	GM/CEO
-Green	[8759.024-8759.024]	Johnson.
-Green	[8762.388-8762.388]	Oh.
-Green	[8762.855-8764.050]	Apologies. Apologies. Julien Bouquet:
-Green	[8764.291-8765.071]	Sensitive microphone. Carl
-Green	[8765.622-8765.622]	Green:
-Green	[8766.232-8792.336]	Yes. Apologies. But to piggyback off of what GM/CEO Johnson has noted, I would couch that as the bigger risk is when we think about establishing policy as it relates to 4702.1b, the FTA Title VI circular, it does call upon the agency to do a lot of outreach and public involvement to ensure that we are collecting that feedback to
-Green	[8793.259-8806.322]	inform decisions. So at the ground level, if we think about public involvement in Title VI, it's part and parcel of what the Title VI program stands for, ensuring that folks in the community are able to inform the decision, such as
-Green	[8807.760-8815.281]	the policy. But with respect to the circular, we can, i.e. the Board of Directors could adopt a
-Green	[8815.757-8819.296]	different threshold. So, for example, the one that Director Benker has
-Green	[8819.650-8836.518]	put forth. Although we received a lot of feedback indicating the 25% threshold and 36 month cumulative change, et cetera, all that's packaged in within the proposed update, there is an exception to that within the circular where it states where the Board is ultimately approving
-Green	[8838.768-8838.968]	the policy. Julien Bouquet:
-Green	[8840.009-8840.009]	Thank you.
-Green	[8840.009-8840.009]	Director
-Green	[8840.009-8843.279]	Ruscha? OK. Director Guissinger and then
-Green	[8847.536-8847.536]	Director Larsen.
-Green	[8847.536-8847.840]	Oh, perfect.
-Green	[8848.144-8848.753]	Director Larsen. And
-Green	[8851.219-8851.440]	then Harwick. Matt Larsen:
-Green	[8853.221-8869.094]	Thank you. I guess my question is, I looked through a lot of the Title VI updates that were for service changes, this Title VI analyses that were in the
-Green	[8870.022-8890.488]	Board packet. And it seemed like most of the time-- sometimes there was a little bit of disparate impact on one route or the other, but mostly it sort of ended up that, in the aggregate, there wasn't really much, and there were legitimate justifications for what there was on an
-Green	[8891.728-8899.937]	individual basis. I guess my basic question is with regard to this update and the changes that
-Green	[8901.401-8903.962]	we're proposing. I mean, is there really a
-Green	[8904.368-8906.261]	problem here? Are we just making this harder
-Green	[8906.591-8917.297]	for ourselves? Because it doesn't seem like we're trying to generally start out making service changes with an intention of causing disparate impact, one place or
-Green	[8917.785-8939.124]	the other. We make them, I guess, for a variety of reasons, and on balance they don't really seem to, under our current setup, ever, ever look like they were somehow some bad intent or just inattention to who we
-Green	[8939.581-8945.369]	are serving. It seems we do a lot of analysis and then basically do what we would have
-Green	[8946.059-8951.251]	done anyways. So why put a greater burden, regulate ourselves more than we
-Green	[8951.597-8964.058]	have to? And why not just give us the freedom to operate as we would as much as we can, given that we don't-- it doesn't necessarily seem like it's been a problem for a
-Green	[8964.404-8966.481]	long time? At least from what I
-Green	[8966.848-8974.819]	could see. I mean, there weren't that many Title VI complaints in the information that
-Green	[8975.725-8975.966]	was provided. I
-Green	[8977.293-8980.131]	don't know. My basic question is, why would we make things harder
-Green	[8980.751-8980.751]	for
-Green	[8982.762-8983.057]	ourselves? Thanks. Julien Bouquet:
-Green	[8983.351-8983.351]	Thank
-Green	[8983.687-8983.687]	you.
-Ms. Johnson. Debra Johnson	[8983.687-8986.097]	Thank you
-Ms. Johnson. Debra Johnson	[8986.292-8997.773]	very much. The one thing I would share, Director Larsen, is we look at the modification that's been put forward for your consideration, like a 36 month period as we're adding
-Ms. Johnson. Debra Johnson	[8998.156-9002.748]	back service. There could be unforeseen consequences as we do them in a
-Ms. Johnson. Debra Johnson	[9003.471-9006.655]	segmented fashion. And so that's one element as
-Ms. Johnson. Debra Johnson	[9007.109-9012.567]	a whole. Because if we're making modifications going forward, there could be an
-Ms. Johnson. Debra Johnson	[9013.340-9015.443]	adverse impact. And so that's what I would
-Ms. Johnson. Debra Johnson	[9016.524-9019.356]	showcase there. Keeping in mind to the point that
-Ms. Johnson. Debra Johnson	[9019.710-9028.207]	you raised. When we talk about the aspects of DIDB, it's what can we do as an agency to help mitigate that to your point
-Ms. Johnson. Debra Johnson	[9028.802-9040.532]	going forward. But it's just to ensure that we have a program whereby we are not causing undue harm to certain
-Ms. Johnson. Debra Johnson	[9043.158-9043.158]	population segments. Julien Bouquet:
-Director Larsen. Matt Larsen	[9043.158-9059.971]	But it just seems like, when I was reading the documents, that there's always a legitimate justification for everything we want to do or there's always this will have a disparate impact but we have a legitimate justification for doing this so we're just going to
-Director Larsen. Matt Larsen	[9060.797-9074.345]	do it. I mean, how many times in the last however many years has it been that we did this analysis, we looked at all the service changes we wanted to do, and we were like, OK, no, we're not going to do this list of
-Director Larsen. Matt Larsen	[9074.664-9080.522]	service changes. We're going to cross out these ones because the aggregate impact is
-Director Larsen. Matt Larsen	[9081.493-9083.188]	too much. I mean, does
-Director Larsen. Matt Larsen	[9083.435-9090.339]	that happen? I just didn't-- from what I read in the packet, I don't know if I caught everything, but it didn't seem like there were a lot
-Director Larsen. Matt Larsen	[9090.846-9103.838]	of those. Or is this happening at an earlier stage where when Bob and service says, let's just send a bunch of buses to Cherry Hills Village, somebody says, no, no, that's not going to work out, before it even gets to
-Director Larsen. Matt Larsen	[9105.399-9105.549]	this point.
-Director Larsen. Matt Larsen	[9108.102-9108.342]	You know? Debra Johnson:
-Director Larsen. Matt Larsen	[9109.323-9110.141]	I'm sorry. Thank you for
-Director Larsen. Matt Larsen	[9110.630-9116.767]	the question. For me, I've only been here for five years, and I came in the height of the pandemic, and we've been adding back service
-Director Larsen. Matt Larsen	[9117.413-9129.033]	and not. So that's difficult for me to answer just because we have not been in a situation whereby it's been
-Director Larsen. Matt Larsen	[9129.954-9131.911]	the opposite. Carl, do you have anything
-Director Larsen. Matt Larsen	[9132.838-9135.928]	to add? Carl Green: Yeah, I would just highlight, Chairman, if
-Director Larsen. Matt Larsen	[9136.502-9151.414]	I may. Since January 2023, there was about 270 service change recommendations that have been implemented, and roughly 24-26 of those 276 were considered major
-Director Larsen. Matt Larsen	[9152.508-9158.988]	service changes. And out of that 26, to Director Larsen's point, there has been 13 potential
-Director Larsen. Matt Larsen	[9160.301-9163.943]	disparate impacts. And to your point, there was a substantial
-Director Larsen. Matt Larsen	[9165.157-9178.871]	legitimate justification. I wouldn't necessarily couch it as an exercise, but I would say we work, the Transit Equity Office within the Civil Rights Division, works hand in glove with Jessie Carter and his team,
-Director Larsen. Matt Larsen	[9180.030-9193.482]	Service Development. And as we are having those conversations after the service change recommendation are put forth and we analyze it, if there is a potential disparate impact, more often than not, to your point and to my earlier earlier point, that Title VI is not a
-Director Larsen. Matt Larsen	[9194.294-9204.674]	stopping mechanism. And I wouldn't necessarily state that it's burdensome because it's one of our responsibilities to make sure that we are equitably distributing services across our
-Director Larsen. Matt Larsen	[9205.694-9212.885]	service area. But more often than not, there is a legitimate justification to put forth the service recommendation as it is presented to
-Director Larsen. Matt Larsen	[9215.941-9216.529]	the Board. Julien Bouquet:
-Director Larsen. Matt Larsen	[9217.116-9217.116]	Thank
-Director Larsen. Matt Larsen	[9219.827-9219.827]	you.
-Director Larsen. Matt Larsen	[9220.303-9221.372]	Director? OK. I had
-Director Larsen. Matt Larsen	[9221.728-9226.002]	Director Harwick. And just as a reminder, we're currently in discussion regarding this
-Director Larsen. Matt Larsen	[9226.438-9229.859]	first motion. Just want to make sure that-- first amendment,
-Director Larsen. Matt Larsen	[9230.201-9230.543]	excuse me.
-Director Larsen. Matt Larsen	[9230.905-9233.954]	First amendment. So make sure comments are
-Director Larsen. Matt Larsen	[9234.430-9234.941]	around that.
-Director Harwick. Ian Harwick	[9234.941-9243.297]	Mine will be comments about this but also moving forward as well, because I am in support of this
-Director Harwick. Ian Harwick	[9243.879-9246.497]	Title VI. Not the amendment, just a straight
-Director Harwick. Ian Harwick	[9249.505-9258.277]	Title VI. I don't think moving from 10% to 20% is going to
-Director Harwick. Ian Harwick	[9259.091-9268.779]	increase ridership. I think that right now it allows our staff the ability to really center equity and effectively protect
-Director Harwick. Ian Harwick	[9269.369-9275.813]	our communities. And while I get that Broomfield feels like they want more service, I don't think this is going to get
-Director Harwick. Ian Harwick	[9276.758-9281.539]	it there. I think this is the 11th hour, and I think that it's really imperative that our staff has worked extremely hard
-Director Harwick. Ian Harwick	[9281.796-9289.256]	on this. They've had to jump through a whole variety of hoops for a bunch of different
-Director Harwick. Ian Harwick	[9289.583-9292.856]	Board members. And I think that we're here, they've done an
-Director Harwick. Ian Harwick	[9293.183-9301.691]	incredible job. And I think that this is-- they are the subject matter experts, and it's our opportunity here to put our trust in them, our belief
-Director Harwick. Ian Harwick	[9302.018-9304.309]	in them. And I think that we owe
-Director Harwick. Ian Harwick	[9304.636-9309.217]	them that. And we have been talking about this since January, so we're well into
-Director Harwick. Ian Harwick	[9309.544-9320.526]	four months. And I think that it is key that we support this Title Vi as is, and we allow them to move forward and we allow them to start handing this off to the feds and we can
-Director Harwick. Ian Harwick	[9321.037-9321.803]	move forward. That's where
-Director Harwick. Ian Harwick	[9322.178-9322.319]	I'm at.
-Thank you. Julien Bouquet	[9322.819-9323.886]	Thank
-Thank you. Julien Bouquet	[9324.419-9327.087]	you, Director. Any further conversation on
-Thank you. Julien Bouquet	[9327.620-9328.154]	this amendment?
-Secretary Nicholson. Chris Nicholson	[9328.154-9332.422]	So this is for our deputy
-Secretary Nicholson. Chris Nicholson	[9333.222-9344.979]	General Counsel. If we were to pass this tonight, what's the legal risk to the agency when it comes to our federal Title VI approval as a result of
-Secretary Nicholson. Chris Nicholson	[9345.884-9357.593]	this change? Is this going to have any-- would this have any legal repercussions or could we just feel pretty comfortable that we could do this and not have the federal government take issue
-Secretary Nicholson. Chris Nicholson	[9359.319-9360.437]	with it? Julien Bouquet: In regards to the
-Secretary Nicholson. Chris Nicholson	[9361.222-9361.222]	amendment, Secretary? Chris
-Nicholson	[9364.745-9364.745]	Yeah. Julien
-Bouquet	[9364.745-9365.046]	OK.
-Deputy Counsel. Melanie Snyder	[9369.252-9369.479]	There
-Deputy Counsel. Melanie Snyder	[9369.613-9369.863]	we go.
-Deputy Counsel. Melanie Snyder	[9370.931-9371.761]	Excuse me. Thank you,
-Deputy Counsel. Melanie Snyder	[9373.005-9373.646]	Director Nicholson. I don't
-Deputy Counsel. Melanie Snyder	[9376.785-9376.785]	have concerns. Julien
-Bouquet	[9379.028-9379.389]	Secretary. Chris Nicholson: That
-is all. Julien Bouquet	[9380.771-9381.523]	Yeah,
-Treasurer Benker. Karen Benker	[9383.856-9389.370]	Here is where I do
-Treasurer Benker. Karen Benker	[9389.983-9394.679]	not understand. In 2019, we had
-Treasurer Benker. Karen Benker	[9396.359-9400.266]	the service. My area, my district, as many others,
-Treasurer Benker. Karen Benker	[9405.177-9409.710]	have grown. For example, the town of Erie just a few years ago
-Treasurer Benker. Karen Benker	[9410.087-9412.731]	was 20,000. Now it's 40,000 two, three
-Treasurer Benker. Karen Benker	[9413.149-9420.819]	years later. And when I met with Erie, they said, hey, we're planning on going to 80,000 in just the next couple
-Treasurer Benker. Karen Benker	[9421.943-9432.192]	of years. I also read in the Denver Post that the town of Erie is the 15th fastest city in the country in terms of
-Treasurer Benker. Karen Benker	[9433.561-9448.682]	population growth. So my question is if we had this service prior to the pandemic and it was serving all of these communities, why is it so difficult to get
-Treasurer Benker. Karen Benker	[9453.332-9453.642]	that restored? Julien
-Treasurer Benker. Karen Benker	[9453.642-9453.642]	Bouquet:
-Ms. Johnson. Debra Johnson	[9453.642-9459.718]	So thank you,
-Ms. Johnson. Debra Johnson	[9462.986-9482.191]	Director Benker. What I'm going to say goes back to the previous comments that I had before, recognizing that RTD is a regional service, and the way the service was outlined, for all intents and purposes, was bringing individuals into the central
-Ms. Johnson. Debra Johnson	[9485.121-9487.300]	business district. That level of ridership
-Ms. Johnson. Debra Johnson	[9487.736-9496.704]	isn't there. And that's not to negate that there is some elements centered on a need to move people to
-Ms. Johnson. Debra Johnson	[9497.161-9509.773]	and fro. Hence, that's why there was the advent of the partnership program and one of the reasons why Erie basically wanted to join the district, because they were looking to put forward an application for the
-Ms. Johnson. Debra Johnson	[9510.135-9546.104]	partnership program. And I know you're just using that as an example, but just wanted to further iterate that, because for all intents and purposes, as we're looking to provide mobility options, the intent behind the partnership program was more or less like a pilot in the sense that let's see how many people are utilizing this means of connection prior to putting out a 40 foot or 60 foot R tick that costs more money per revenue hour and doesn't yield the same return on investment relative to the cost
-Ms. Johnson. Debra Johnson	[9548.110-9550.651]	per boarding. Does that help or did I complicate
-Ms. Johnson. Debra Johnson	[9551.855-9551.855]	it
-Ms. Johnson. Debra Johnson	[9553.176-9553.176]	more?
-Ms. Johnson. Debra Johnson	[9554.518-9554.678]	No? OK. Julien Bouquet:
-Ms. Johnson. Debra Johnson	[9555.099-9556.600]	Thank you. Director Guzman and then
-Director Guissinger. Michael Guzman	[9557.661-9577.097]	So I would urge us to cleanly pass this through tonight, getting back to the motion before us, I would like to ask one question, which is the 10% to 20% is still not going to prevent us from
-Director Guissinger. Michael Guzman	[9578.028-9600.187]	adding services. It is simply a filter through which to look, if I understand this correctly, that we are not unintentionally harming community with protected status under the Title VI legislation, or those that might be disproportionately burdened or impacted by their financial and economic status within
-Director Guissinger. Michael Guzman	[9601.830-9613.735]	the region. The only purpose we need to pass this is because it is due, because it is the law, and it is how we ensure that we are able to receive our federal funding, which is approximately 25% of our
-Director Guissinger. Michael Guzman	[9615.240-9617.828]	total budget. So I just want to make sure
-Director Guissinger. Michael Guzman	[9618.475-9623.327]	I understand. What has been presented here does not tell the Board, no, we cannot provide
-Director Guissinger. Michael Guzman	[9624.471-9647.929]	transit service. It is simply a way to look at it and say, we may have an issue if it reaches a certain threshold that we need to be aware of in order to be able to approve changes in service, fare changes, or other changes that would create a potential burden on specific communities as defined within the Title
-Director Guissinger. Michael Guzman	[9648.563-9652.496]	VI language. Is that correct, or am I completely lost in
-Director Guissinger. Michael Guzman	[9654.711-9655.328]	this conversation? Carl Green: Chair, OK
-Director Guissinger. Michael Guzman	[9655.832-9656.106]	for me? Julien Bouquet:
-Director Guissinger. Michael Guzman	[9656.379-9656.379]	Absolutely,
-Mr. Green. Carl Green	[9656.379-9663.470]	If I'm tracking Director Guzman, I'll try to answer the question from what I hear, and if you have any double back, then I'll respond
-Mr. Green. Carl Green	[9664.208-9704.872]	to it. So the current 10%, so if we think about different thresholds for DIDB and we are in-- based off of the desk audit, we're in the middle tier of having a threshold that allows us as an agency, which ultimately each service equity analyses is approved by the Board of Directors, where it allows us-- again, to your point, when we're thinking about BIPOC or Black, Indigenous, people of color for disparate impact or low income communities for disproportionate burden, it allows us to make a well-informed, eyes-wide-open decision of better understanding of who's more likely to receive more of
-Mr. Green. Carl Green	[9705.308-9713.608]	the impact. And when we're thinking about service increases, we're thinking about the fair share of benefits where if there is a service reduction, we're looking at who's more likely to receive more of
-Mr. Green. Carl Green	[9714.400-9723.675]	the burden. So to your point, Director Guzman, it allows us to just get a better understanding of the level of impact that we can have on a
-Mr. Green. Carl Green	[9724.423-9726.683]	particular community. It does not prevent us from
-Mr. Green. Carl Green	[9729.089-9729.269]	moving forward. Michael Guzman:
-Mr. Green. Carl Green	[9730.230-9736.330]	Thank you. I would just urge a no vote, and let's move on to
-Mr. Green. Carl Green	[9737.700-9737.941]	the policy. Julien Bouquet:
-Mr. Green. Carl Green	[9738.982-9743.505]	All right. Director Guissinger, I'm going to have you as our final comment on this
-specific amendment. Lynn Guissinger	[9744.061-9744.932]	I'll be
-specific amendment. Lynn Guissinger	[9745.553-9746.799]	super quick. That last explanation
-specific amendment. Lynn Guissinger	[9747.110-9751.159]	that Mr. Green gave helped me in terms of just giving us a better
-specific amendment. Lynn Guissinger	[9751.490-9758.947]	holistic view. But I shared Director Larsen's view of, are we just making this harder for ourselves, creating
-specific amendment. Lynn Guissinger	[9761.062-9761.663]	more work? Is that
-specific amendment. Lynn Guissinger	[9763.445-9763.445]	not right? Julien
-specific amendment. Lynn Guissinger	[9763.676-9763.676]	Bouquet:
-Mr. Green. Carl Green	[9763.676-9765.879]	Yeah, that's a great follow
-Mr. Green. Carl Green	[9768.698-9781.510]	up question. I wouldn't say it's making it harder because when we think about what we're ultimately trying to achieve and a percentage that's mathematically consistent relative to the populations that
-Mr. Green. Carl Green	[9782.498-9807.519]	we serve. So in doing this work, given my background, and doing an assessment of whether if we-- and that's why we didn't want to make any modifications of increasing or decreasing the major service change, we just wanted to keep it consistent, is with doing this work or even doing an analysis of previous run boards or equity analyzes, 20% is something where you wouldn't
-Mr. Green. Carl Green	[9809.226-9822.607]	see anything. And that's a disservice when we think about our populations within our service area, specifically, as we look at our Census data, where 38.1% is BIPOC, 13.1%-- or 14.1%, rather for
-Mr. Green. Carl Green	[9823.028-9823.028]	low
-Mr. Green. Carl Green	[9823.568-9827.486]	income. Right? And then if we look the onboard survey, 56% are
-Mr. Green. Carl Green	[9828.813-9849.241]	considered BIPOC. And so I say all that to say, just to wrap it up, is that 10% threshold for DIDB allows us to make an informed decision that is backed by not only our desk audit, but the years of experience and knowing, having a better understanding of ultimately what we're trying
-Mr. Green. Carl Green	[9852.179-9852.550]	to achieve. Lynn Guissinger:
-Mr. Green. Carl Green	[9852.940-9853.100]	Thank you. Julien Bouquet:
-Mr. Green. Carl Green	[9853.780-9855.042]	Thank you. All right, let's do a roll
-Mr. Green. Carl Green	[9855.482-9865.254]	call vote. As a reminder, it is the first amendment being introduced, as you all can see on that screen, with Director Benker as the mover and Director Paglieri as
-Mr. Green. Carl Green	[9865.711-9867.976]	the second. Again, we're voting on this
-Mr. Green. Carl Green	[9869.174-9869.475]	first amendment.
-Mr. Green. Carl Green	[9870.636-9870.636]	Treasurer Benker. Karen
-Benker	[9871.677-9872.503]	Yes. Julien Bouquet: Director Buzek
-Benker	[9873.558-9873.909]	is gone.
-Benker	[9875.841-9875.841]	Director Catlin. Peggy
-Catlin	[9876.901-9877.502]	No. Julien Bouquet:
-Catlin	[9880.725-9880.725]	Director Guissinger. Lynn
-Guissinger	[9882.183-9882.684]	No. Julien Bouquet:
-Guissinger	[9883.024-9909.223]	Director Gutschenritter. Chris
-Gutschenritter	[9909.223-9909.223]	No. Julien Bouquet:
-Gutschenritter	[9909.223-9909.223]	Director Guzman. Michael
-Guzman	[9909.223-9909.223]	No. Julien Bouquet:
-Guzman	[9909.223-9909.223]	Director Harwick. Ian
-Harwick	[9909.223-9909.223]	No. Julien Bouquet:
-Harwick	[9909.223-9909.223]	Director Larsen. Matt
-Larsen	[9909.223-9909.223]	No. Julien Bouquet:
-Larsen	[9909.223-9909.223]	Director Nicholson. Chris
-Nicholson	[9909.223-9909.223]	Yes. Julien Bouquet: First Vice
-Nicholson	[9909.223-9909.223]	Chair O'Keefe. Patrick
-O'Keefe	[9909.223-9909.223]	No. Julien Bouquet:
-O'Keefe	[9909.223-9909.223]	Director Paglieri. Brett
-Paglieri	[9911.900-9912.434]	No. Julien Bouquet:
-Paglieri	[9912.611-9912.967]	Director Ruscha. Joyann
-Ruscha	[9913.145-9915.856]	No. Julien Bouquet:
-Ruscha	[9916.380-9917.429]	Director Whitmore. Troy
-Whitmore	[9919.278-9920.821]	No. Julien Bouquet: I'm a yes, but the motion
-Whitmore	[9920.821-9920.821]	will fail. And we have 3
-Whitmore	[9920.821-9920.821]	to
-Whitmore	[9920.821-9921.072]	10. OK.
-Whitmore	[9921.563-9921.863]	Moving on.
-Whitmore	[9922.204-9924.075]	Yes, Director? Karen Benker: I would like to withdraw the next
-two amendments. Julien Bouquet	[9924.771-9925.238]	Next
-two amendments. Julien Bouquet	[9925.592-9925.592]	two amendments? Karen
-Benker	[9926.495-9927.477]	Yes. Julien
-Bouquet	[9927.477-9929.676]	OK. The next two amendments have
-been withdrawn. Chris Nicholson	[9931.373-9933.898]	They were never introduced, so they're not
-been withdrawn. Chris Nicholson	[9934.378-9939.420]	really withdrawn. But now you would return back to the debate on the main motion, which is to approve the Title VI
-been withdrawn. Chris Nicholson	[9940.102-9940.102]	program update. Julien
-Bouquet	[9941.025-9942.091]	Excellent. Back to the main motion
-Bouquet	[9942.831-9943.162]	at hand.
-Director O'Keefe. Patrick O'Keefe	[9945.008-9951.670]	So I contemplated a no vote out of principle on
-Director O'Keefe. Patrick O'Keefe	[9952.316-9954.585]	this action. There's a few things
-Director O'Keefe. Patrick O'Keefe	[9955.099-9957.975]	going on. First of all, it should never get to the
-Director O'Keefe. Patrick O'Keefe	[9958.783-9963.586]	last minute. The Board should never be asked to pass things because it's due in
-Director O'Keefe. Patrick O'Keefe	[9964.249-9968.182]	two days. And I know there's a lot of things that go into
-Director O'Keefe. Patrick O'Keefe	[9968.510-9975.905]	the delay. But that's just not the right-- that's not the right urgency to place on the Board
-Director O'Keefe. Patrick O'Keefe	[9977.667-9984.390]	to act. Secondly, I don't know very much about this topic, and I have sat in on two operations
-Director O'Keefe. Patrick O'Keefe	[9986.166-9987.214]	committee meetings. I've talked to a bunch
-Director O'Keefe. Patrick O'Keefe	[9987.449-9989.598]	of people. I've done my
-Director O'Keefe. Patrick O'Keefe	[9990.115-9994.999]	own research. And I still am looking for a succinct description of
-Director O'Keefe. Patrick O'Keefe	[9995.464-10000.567]	the program. I would note that there was a wonderful book written by
-Director O'Keefe. Patrick O'Keefe	[10001.092-10001.990]	Robert Caro. It's called The
-Director O'Keefe. Patrick O'Keefe	[10002.455-10004.512]	Power Broker. I'm sure a lot of people in this room
-Director O'Keefe. Patrick O'Keefe	[10005.439-10019.551]	know it. Talks a lot about bad policy decisions on disadvantaged communities and how those decisions were made and the harmful outcome of
-Director O'Keefe. Patrick O'Keefe	[10021.619-10025.524]	those decisions. It is 15 pages shorter than our
-Director O'Keefe. Patrick O'Keefe	[10026.582-10035.520]	packet tonight. He won the Pulitzer Prize for a 1,200 page treatise on impact by
-Director O'Keefe. Patrick O'Keefe	[10036.178-10048.077]	public infrastructure. I would request that when we're passing along documents as part of a packet, it needs to have a point, and it should be summarized from the committee for the rest of
-Director O'Keefe. Patrick O'Keefe	[10048.418-10052.855]	the Board. Simply passing things along for us does not help me understand
-Director O'Keefe. Patrick O'Keefe	[10053.265-10061.429]	this better. I'm probably a yes vote tonight, but I was a no vote until about an hour and a
-Director O'Keefe. Patrick O'Keefe	[10061.817-10073.868]	half ago. And so just, when you are putting together packets on complex questions for the Board, giving us reams of paper does not help us get to a
-Director O'Keefe. Patrick O'Keefe	[10074.978-10087.395]	better decision. So that's something, a request for the two, three-ish Committee Chairs as you're putting together topics like this, and that would be very helpful for me to make
-Director O'Keefe. Patrick O'Keefe	[10088.267-10088.267]	better
-decisions. Thanks. Julien Bouquet	[10088.848-10089.539]	Thank you,
-decisions. Thanks. Julien Bouquet	[10090.531-10092.330]	Director O'Keefe. Any further comments or questions on the
-decisions. Thanks. Julien Bouquet	[10093.597-10093.897]	main motion?
-Director Guzman. Michael Guzman	[10093.897-10104.384]	I would just like to mention that the Denver City Council unanimously submitted a proclamation for RTD on May
-Director Guzman. Michael Guzman	[10105.094-10106.429]	19, 2025. It is in the
-Director Guzman. Michael Guzman	[10107.357-10128.692]	director's emails. It was sent over by City Council, that they wholeheartedly support the 2025-2028 Title VI program to include the proposed updates to major service change, disparate impact, and fare equity policies, as well as updates to RTD's public participation plan and language access plan, which we are voting on now, and that the clerk and recorder of the City and County of Denver did affix the seal, making
-Director Guzman. Michael Guzman	[10130.300-10131.572]	it official. I believe that that
-Director Guzman. Michael Guzman	[10131.847-10132.703]	is necessary. There's a
-Director Guzman. Michael Guzman	[10133.289-10134.941]	whole proclamation. You can read
-Director Guzman. Michael Guzman	[10135.354-10144.027]	through it. But former Board Director Lewis-- sorry, We had two Lewises and I wanted to make sure I said
-Director Guzman. Michael Guzman	[10145.482-10149.642]	it right. Did work with city council member Serena
-Director Guzman. Michael Guzman	[10150.104-10155.001]	Gutierrez Gonzalez. And the unanimity of that vote is remarkable from our
-Director Guzman. Michael Guzman	[10155.489-10158.653]	city council. So they stand behind this as well with us to move
-Director Guzman. Michael Guzman	[10158.937-10159.097]	this forward.
-Thank you. Julien Bouquet	[10159.919-10160.550]	Thank you,
-Thank you. Julien Bouquet	[10161.542-10161.893]	Director Guzman.
-Director Larsen. Matt Larsen	[10163.647-10171.421]	I'm going to be a no vote, I think it's kind of, like I said, we're constraining our freedom
-Director Larsen. Matt Larsen	[10171.756-10174.506]	to operate. We're spending a lot of energy and effort to
-Director Larsen. Matt Larsen	[10175.161-10188.405]	track this. And I know the intentions behind that are good, but I think, just as a matter of principle, we shouldn't be trying to over-- regulating
-Director Larsen. Matt Larsen	[10189.282-10209.694]	ourselves more. We should be thinking, there's not really a lot of evidence that we have disparately or ever had any recent plans to expand service or decrease service in a way that causes a disparate impact on
-Director Larsen. Matt Larsen	[10210.616-10225.333]	these populations. And I honestly believe that if we focused 100% just on increasing ridership, which is what I think we should be doing, and not trying to expand our purview about when maybe we shouldn't
-Director Larsen. Matt Larsen	[10225.782-10226.207]	increase ridership. I
-Director Larsen. Matt Larsen	[10227.481-10228.755]	don't know. If it's legitimate, we'll do
-Director Larsen. Matt Larsen	[10229.318-10244.095]	it anyways. I really think if we were focusing strictly on increasing ridership, we would actually-- it would all be disparately impacted in favor of all the communities we're worried about, just based on the way population is distributed in
-Director Larsen. Matt Larsen	[10244.514-10259.348]	the area. And I would like for us to move towards a paradigm of focusing much, much more on increasing ridership across the board and less on finding possible reasons to not
-Director Larsen. Matt Larsen	[10261.015-10261.833]	increase ridership. So I'll be a
-Director Larsen. Matt Larsen	[10262.017-10262.017]	no
-vote. Thanks. Julien Bouquet	[10262.960-10263.592]	Thank you,
-vote. Thanks. Julien Bouquet	[10263.883-10264.304]	Director Larsen.
-Secretary Nicholson. Chris Nicholson	[10264.304-10274.491]	So I sat through two committee meetings, a study session, and a town hall, all on
-Secretary Nicholson. Chris Nicholson	[10275.310-10285.614]	this topic. And I should say expertly facilitated by our co-chairs and by our Chair of Finance and
-Secretary Nicholson. Chris Nicholson	[10286.500-10291.890]	our staff. And I feel like I'm just starting to get a decent understanding
-Secretary Nicholson. Chris Nicholson	[10292.772-10300.092]	of it. I came into this knowing nothing about this, and I was an absolute no when we
-Secretary Nicholson. Chris Nicholson	[10300.563-10303.856]	first started. And my public remarks made that
-Secretary Nicholson. Chris Nicholson	[10304.426-10315.746]	very clear. But I want to commend staff and our Board leadership who were willing to indulge because I came to
-Secretary Nicholson. Chris Nicholson	[10316.697-10317.803]	understand it. I came to understand what it
-Secretary Nicholson. Chris Nicholson	[10318.221-10319.304]	was for. I came to understand how
-Secretary Nicholson. Chris Nicholson	[10320.608-10328.433]	it works. And I don't necessarily agree with all of it and I think we could use more data in addition to the data we have now to
-Secretary Nicholson. Chris Nicholson	[10329.843-10331.606]	determine this. But if we don't pass this, we lose
-Secretary Nicholson. Chris Nicholson	[10332.167-10334.157]	federal funding. So there's a good reason to pass it even if you don't
-Secretary Nicholson. Chris Nicholson	[10335.873-10340.273]	like it. But on top of that, I just think our staff did
-Secretary Nicholson. Chris Nicholson	[10341.121-10345.795]	their jobs. They have demonstrated to me this is the right thing to do, despite
-Secretary Nicholson. Chris Nicholson	[10346.370-10347.965]	my skepticism. And so I'm definitely voting for
-Secretary Nicholson. Chris Nicholson	[10348.814-10348.984]	it tonight. Julien Bouquet:
-Secretary Nicholson. Chris Nicholson	[10349.595-10350.762]	Thank you. Any further comments on the
-Secretary Nicholson. Chris Nicholson	[10352.337-10352.337]	main
-Secretary Nicholson. Chris Nicholson	[10352.587-10355.591]	motion? OK. Seeing none, we had Catlin as the mover and Guzman as
-Secretary Nicholson. Chris Nicholson	[10356.362-10360.338]	the second. There is indication that there will be no votes so I will be doing a roll call vote
-Secretary Nicholson. Chris Nicholson	[10361.929-10362.183]	on this.
-Secretary Nicholson. Chris Nicholson	[10362.436-10363.351]	Treasure Benker. Karen
-Benker	[10365.854-10366.194]	No. Julien Bouquet:
-Benker	[10366.194-10367.416]	Director Catlin. Peggy
-Catlin	[10370.080-10370.450]	Yes. Julien Bouquet:
-Catlin	[10371.461-10371.461]	Director Guissinger. Lynn
-Guissinger	[10373.584-10373.584]	Yes. Julien Bouquet:
-Guissinger	[10373.584-10373.584]	Director Gutschenritter. Chris
-Gutschenritter	[10373.584-10374.535]	Yes. Julien Bouquet:
-Gutschenritter	[10374.535-10375.687]	Director Guzman. Michael
-Guzman	[10376.247-10376.557]	Yes. Julien Bouquet:
-Guzman	[10376.557-10377.269]	Director Harwick. Ian
-Harwick	[10379.031-10379.361]	Yes. Julien Bouquet:
-Harwick	[10380.293-10380.293]	Director Larsen. Matt
-Larsen	[10381.008-10381.439]	No. Julien Bouquet:
-Larsen	[10381.439-10382.681]	Director Nicholson. Chris Nicholson:
-I'm in. Julien Bouquet	[10384.133-10384.779]	First Vice
-I'm in. Julien Bouquet	[10385.855-10385.855]	Chair O'Keefe. Patrick
-O'Keefe	[10386.476-10388.880]	Yes. Julien Bouquet:
-O'Keefe	[10388.880-10388.880]	Director Paglieri. Brett
-Paglieri	[10389.801-10390.743]	Yes. Julien Bouquet:
-Paglieri	[10390.743-10390.743]	Director Ruscha. Joyann
-Ruscha	[10392.565-10393.271]	Yep. Julien Bouquet: Second Vice
-Ruscha	[10393.271-10393.907]	Chair Whitmore. Troy
-Whitmore	[10394.909-10395.496]	Yes. Julien Bouquet: I'm also
-Whitmore	[10396.211-10401.850]	a yes. So the motion, the main motion will pass 11, 2, and
-Whitmore	[10403.762-10403.762]	2
-Whitmore	[10404.091-10405.076]	absent. Yes. That math
-Whitmore	[10406.146-10406.146]	adds
-Whitmore	[10406.947-10407.203]	up. OK.
-Whitmore	[10407.459-10417.160]	Moving on. We're going to be moving to our next recommended action, which is the budget transfer articulated buses supporting Colfax Bus Rapid Transit or
-Whitmore	[10417.690-10418.443]	BRT service. Do I have
-Whitmore	[10419.553-10420.100]	a mover? Michael Guzman: So
-moved, Guzman. Julien Bouquet	[10420.534-10421.402]	Guzman is
-moved, Guzman. Julien Bouquet	[10421.616-10422.437]	the mover. Do I have
-moved, Guzman. Julien Bouquet	[10422.437-10422.437]	a second? Troy
-Whitmore	[10424.400-10424.400]	Second. Julien Bouquet: I have-- Joyann
-Whitmore	[10424.400-10424.400]	Ruscha:
-Whitmore	[10424.941-10424.941]	Wait. Sir. Julien
-Bouquet	[10425.662-10425.792]	Yeah? Joyann Ruscha:
-Bouquet	[10426.343-10426.840]	Oh, wait. Well, I could
-Bouquet	[10426.984-10428.875]	be wrong. I'm sorry, I forgot we
-Bouquet	[10429.347-10430.294]	started late. I thought we hit our four
-Bouquet	[10430.909-10433.273]	hour mark. Please
-Bouquet	[10434.475-10434.475]	ignore me. Julien
-Bouquet	[10434.835-10434.835]	Oh. Joyann
-Ruscha	[10434.975-10436.282]	Sorry. Julien Bouquet: Guzman is
-Ruscha	[10436.778-10437.844]	the mover. Whitmore is
-Ruscha	[10441.599-10442.441]	the second. Any discussion
-Ruscha	[10443.702-10444.263]	on it? Yeah,
-Ruscha	[10444.263-10449.371]	Director Paglieri? Brett Paglieri: I just wanted to say a few quick words about why I will not be voting
-Ruscha	[10450.814-10466.385]	for this. I was not necessarily sure how this would further the clean energy and zero emission goals of the State of Colorado and therefore will just be
-Ruscha	[10466.936-10467.106]	voting no.
-Thank you. Julien Bouquet	[10469.652-10470.606]	Any
-Thank you. Julien Bouquet	[10471.083-10471.560]	further conversation?
-Secretary Nicholson. Chris Nicholson	[10471.560-10477.382]	Yeah, so I understand the importance of what we're
-Secretary Nicholson. Chris Nicholson	[10479.313-10484.027]	doing here. I think that these buses in particular-- in my religion, there's
-Secretary Nicholson. Chris Nicholson	[10484.444-10486.012]	a thing. Why is this night different from all
-Secretary Nicholson. Chris Nicholson	[10486.248-10488.404]	other nights? Why are these buses different from all
-Secretary Nicholson. Chris Nicholson	[10489.902-10500.764]	other buses? These are going to be the flagship of our flagship BRT line, and if these suck, it will
-Secretary Nicholson. Chris Nicholson	[10502.118-10516.342]	kill BRT. And if they are not comfortable, if they are not just awesome in every way possible-- you can make a lot of choices when you buy a bus about how nice it's going to be in the same way can make a lot of choices about how when you buy a car, about how nice it's going
-Secretary Nicholson. Chris Nicholson	[10516.497-10525.632]	to be. And so I just want to lean in here, and I do have one question to say that we need to pull the
-Secretary Nicholson. Chris Nicholson	[10526.113-10540.374]	stops out. We need to make sure we're giving you enough money, GM/CEO Johnson, to make sure we're buying top of the line, to make sure that these are things that when they run through my district, people go, wow, I want to get
-Secretary Nicholson. Chris Nicholson	[10540.705-10542.452]	on that. Not, wow, that doesn't look
-Secretary Nicholson. Chris Nicholson	[10543.480-10551.684]	very nice. And so my question for you is, how do you know that the amount of money that we're authorizing today is enough to get top of
-Secretary Nicholson. Chris Nicholson	[10552.008-10562.785]	the line? And how many bites at the apple are we going to get to make sure that you are buying the right buses for this incredibly
-Secretary Nicholson. Chris Nicholson	[10564.421-10564.421]	important project? Julien
-Bouquet	[10564.641-10568.119]	Ms. Johnson, is 51 million enough to make them
-Bouquet	[10568.525-10568.525]	not suck? Debra
-Johnson	[10570.160-10572.133]	Yeah. So thank you very
-Johnson	[10572.527-10575.235]	much, Mr. Chair, and thank you for
-Johnson	[10576.285-10576.765]	the question. Julien Bouquet:
-Johnson	[10577.266-10577.634]	My apologies. That
-was unprofessional. Debra Johnson	[10577.819-10581.816]	Keep it in mind, this is a
-was unprofessional. Debra Johnson	[10582.240-10588.309]	budget transfer. And full transparency, Director Nicholson emailed me about this because I think there was some confusion about where
-was unprofessional. Debra Johnson	[10588.876-10590.248]	we are. There is yet to be
-was unprofessional. Debra Johnson	[10590.537-10591.995]	a solicitation. There's yet to
-was unprofessional. Debra Johnson	[10592.739-10602.039]	be specifications. So these monies that are being transferred or needed for all intents and purposes so we can start
-was unprofessional. Debra Johnson	[10604.694-10607.364]	a procurement. Now, keeping in mind there's a couple
-was unprofessional. Debra Johnson	[10608.038-10615.874]	of elements. These buses have to be dedicated because this is designated as a bus rapid transit project as defined by the Federal
-was unprofessional. Debra Johnson	[10616.670-10621.811]	Transit Administration. There are certain criteria that we have to ensure that we
-was unprofessional. Debra Johnson	[10622.298-10629.088]	adhere to. This will be a dedicated fleet just by virtue of the configuration of BRT, with it being a center
-was unprofessional. Debra Johnson	[10629.965-10651.066]	running platform. So when you talk about it being top of the line, that's yet to be seen in reference to what we had before us, because there's only two original equipment manufacturers in the United States, there's only so many suppliers, there are certain seats, and there is a national task force on which I sit, where we're talking about doing away with customization, because that
-was unprofessional. Debra Johnson	[10651.632-10655.405]	increases prices. I bet you don't know how many shades of white there is with new
-was unprofessional. Debra Johnson	[10655.676-10655.676]	flyer industries. Chris
-Nicholson	[10656.216-10656.877]	24. Debra Johnson:
-Nicholson	[10657.557-10657.557]	How many? Chris
-Nicholson	[10657.678-10657.678]	24. Debra
-Johnson	[10658.999-10660.508]	23. I think I told you
-Johnson	[10660.841-10671.276]	that earlier. So the point of the matter is, as we talk about this, we're going to do our due diligence and we're going to ensure it's a
-Johnson	[10671.649-10677.984]	competitive solicitation. And we do understand the aspects, because that's what separates bus rapid transit from general fixed
-Johnson	[10679.258-10679.478]	route service.
-Johnson	[10680.337-10680.337]	Thank you. Julien
-Bouquet	[10680.826-10687.285]	Secretary. Chris Nicholson: I really appreciate it and I look forward to you coming back often to update us on how the purchase
-Bouquet	[10689.931-10689.931]	is going.
-Speaker	[10690.472-10690.911]	Yes. And
-Speaker	[10690.911-10691.350]	what white. Julien Bouquet:
-Director Guzman. Michael Guzman	[10691.789-10692.667]	Just
-Director Guzman. Michael Guzman	[10693.545-10701.009]	really quickly. With regards to this, moving this money from the unrestricted fund is simply to begin the
-Director Guzman. Michael Guzman	[10701.969-10705.513]	procurement process. And although it's not part of the 2025 budget, we do need to get started
-Director Guzman. Michael Guzman	[10706.828-10726.263]	on it. However, I would suggest that as we go forward, these buses are meant to be purchased in finality by 2027 to begin this service, and that is work that we will dutifully do on Finance and Planning to ensure that it is included in all necessary documents that come before this Board
-Director Guzman. Michael Guzman	[10727.546-10730.144]	for approval. And I am certain that our new CFO is up to the task
-Director Guzman. Michael Guzman	[10730.430-10733.784]	on that. So rest assured, Directors, we're not wantonly
-Director Guzman. Michael Guzman	[10734.203-10740.264]	spending money. But we do need to authorize this for the procurement of the buses at
-Director Guzman. Michael Guzman	[10740.596-10740.929]	this point.
-Thank you. Julien Bouquet	[10741.261-10741.926]	Thank
-Thank you. Julien Bouquet	[10742.258-10743.920]	you, Director. Any further discussion on
-Thank you. Julien Bouquet	[10744.252-10744.584]	this item?
-Thank you. Julien Bouquet	[10744.917-10746.578]	All right. There is a no--
-Thank you. Julien Bouquet	[10746.911-10747.243]	oh, no.
-Thank you. Julien Bouquet	[10747.575-10753.890]	Sounds good. All right, it was indicated there will be a no vote, so I will do a roll
-Thank you. Julien Bouquet	[10754.222-10758.543]	call vote. Again, this is the budget transfer articulated buses supporting Colfax
-Thank you. Julien Bouquet	[10758.875-10759.207]	BRT service.
-Thank you. Julien Bouquet	[10759.540-10760.307]	Treasurer Benker. Karen
-Benker	[10761.289-10761.629]	Yes. Julien Bouquet:
-Benker	[10761.629-10762.230]	Director Catlin. Peggy
-Catlin	[10763.352-10765.015]	Yes. Julien Bouquet:
-Catlin	[10765.376-10766.096]	Director Guissinger. Lynn
-Guissinger	[10766.096-10766.096]	Yes. Julien Bouquet:
-Guissinger	[10766.096-10766.096]	Director Gutschenritter. Chris
-Gutschenritter	[10766.858-10767.159]	Yes. Julien Bouquet:
-Gutschenritter	[10767.159-10767.939]	Director Guzman. Michael
-Guzman	[10768.380-10768.700]	Yes. Julien Bouquet:
-Guzman	[10768.700-10769.221]	Director Harwick. Ian
-Harwick	[10769.702-10770.042]	Yep. Julien Bouquet:
-Harwick	[10770.042-10770.544]	Director Larsen. Matt
-Larsen	[10770.964-10772.226]	Yes. Julien Bouquet:
-Director Nicholson. Chris Nicholson	[10772.226-10775.211]	Nicholson
-Director Nicholson. Chris Nicholson	[10775.211-10775.211]	go brr. Peggy
-Catlin	[10775.932-10777.535]	What? Chris Nicholson: Sorry that was a bad internet
-ref-- yes. Julien Bouquet	[10778.977-10779.593]	Nicholson is
-ref-- yes. Julien Bouquet	[10779.879-10780.329]	a yes.
-ref-- yes. Julien Bouquet	[10783.190-10783.190]	Director O'Keefe. Patrick
-O'Keefe	[10783.190-10784.312]	Yes. Julien Bouquet: Director O'Keefe is
-O'Keefe	[10785.072-10785.493]	a yes.
-O'Keefe	[10786.074-10786.074]	Director Paglieri. Brett
-Paglieri	[10786.815-10787.664]	No. Julien Bouquet: Director Paglieri is
-Paglieri	[10787.936-10788.287]	a no.
-Paglieri	[10788.857-10788.857]	Director Ruscha. Joyann
-Ruscha	[10789.778-10790.109]	Yes. Julien Bouquet:
-Ruscha	[10790.109-10791.520]	Director Whitmore. Troy
-Whitmore	[10793.523-10793.523]	Yes. Julien
-Bouquet	[10793.603-10796.195]	OK. So that passes 12, 1,
-Bouquet	[10797.528-10797.678]	and 2.
-Bouquet	[10797.868-10798.295]	All right. Thank
-you, folks. So we have one-- Jack Kroll	[10798.569-10802.003]	Chairman Bouquet, could you remind us
-you, folks. So we have one-- Jack Kroll	[10802.372-10806.069]	over here? We missed who the mover and the seconder were
-on that. Julien Bouquet	[10806.799-10807.585]	I had Guzman
-on that. Julien Bouquet	[10808.281-10808.281]	and Whitmore. Jack
-Kroll	[10808.381-10808.532]	OK.
-Kroll	[10809.403-10809.553]	Thank you. Julien Bouquet:
-Kroll	[10810.578-10810.578]	Thank
-Kroll	[10811.479-10811.479]	you.
-Kroll	[10812.308-10813.433]	OK. Excellent. Thank you all again for
-Kroll	[10813.661-10819.199]	your patience. We do have one more item, and that is the equitable transit oriented development
-Kroll	[10820.929-10839.971]	policy amendment. So for the Board of Directors to approve the amendment to resolution number two, series of 2021, which created the equitable transit oriented development policy that permits and encourages the development of affordable housing on RTD real property in order to include guidelines for disposing of RTD real property below fair market value
-Kroll	[10840.739-10841.268]	or rent. Do we have
-Kroll	[10841.600-10842.522]	a motion? Michael Guzman: So
-moved, Guzman. Julien Bouquet	[10842.522-10843.108]	Guzman is
-moved, Guzman. Julien Bouquet	[10843.343-10843.808]	the mover. Do we have
-moved, Guzman. Julien Bouquet	[10843.808-10843.808]	a second? Ian
-Harwick	[10844.445-10845.397]	Second. Julien Bouquet: I have Harwick as
-Harwick	[10847.550-10852.544]	the second. I do understand that on this item, we have some proposed amendments from Director Nicholson and
-Harwick	[10853.780-10857.351]	Director Ruscha. Since Director Nicholson's amendment was circulated to the Board first, we will
-Harwick	[10858.247-10860.757]	start there. Director Nicholson, please now make your motion
-Harwick	[10861.675-10861.675]	to amend. Chris
-Nicholson	[10862.181-10866.230]	Yes. I'd like to move to amend the
-Nicholson	[10866.736-10869.773]	ETOD policy. And I'm hoping that GM/CEO--
-Nicholson	[10869.773-10870.279]	not GM/CEO.
-Nicholson	[10870.785-10875.340]	That Mr. Kroll can put up that language on
-Nicholson	[10876.808-10877.019]	the screen. Speaker:
-Nicholson	[10877.890-10879.774]	It's there. Chris
-Nicholson	[10879.774-10879.914]	Great.
-Nicholson	[10881.470-10884.037]	May I? Julien Bouquet: Would you like to read the motion and then we'll get
-Nicholson	[10884.374-10884.555]	a second? Chris Nicholson:
-Nicholson	[10884.775-10884.775]	Thank
-Nicholson	[10885.315-10894.768]	you. Yeah. So move to amend the policy such that Section 5 of the equitable transit oriented development policy regarding negotiated land price be updated
-Nicholson	[10895.132-10928.443]	as follows. To raise the maximum negotiated land price discount to 75% from 50% and add the following additional factors to favorably consider projects which include more accessible units than required by law, limit residential parking, are deeply affordable, emphasize priority groups as identified by the Colorado Housing and Finance Authority, and incorporate smaller footprint retail, including below market rate units-- below market rate retail, excuse me, that prioritizes local businesses
-Nicholson	[10929.125-10929.125]	and entrepreneurs. Julien
-Bouquet	[10933.271-10933.847]	Excellent. Jack Kroll: Do we have
-Bouquet	[10933.847-10934.077]	a second? Julien Bouquet: And do we have a second
-Bouquet	[10934.793-10934.793]	on that? Ian
-Harwick	[10935.454-10936.111]	Second. Julien Bouquet: Harwick is
-Harwick	[10938.458-10940.003]	the second. Secretary, would you like to
-Harwick	[10940.281-10940.471]	discuss further? Chris Nicholson:
-Harwick	[10940.682-10940.682]	Thank
-Harwick	[10941.222-10953.246]	you. Yes. Before I get into my remarks, I'd like to ask Executive Manager Kroll to briefly describe the five pieces of written public comment that we received on this recommended action from some of our local
-Harwick	[10954.083-10954.083]	public officials. Jack
-Kroll	[10954.453-10961.845]	Yes. So four of the written public comment items were submitted by individuals specifically supportive of the change Director Nicholson
-Kroll	[10962.255-10971.532]	is offering. And those four individuals were the mayor of Boulder, a city council member from Boulder, a city council member from Westminster, and the Colorado Cross
-Kroll	[10971.869-10985.484]	Disability Coalition. And then the fifth letter was submitted by SWEEP in joint with Conservation Colorado and Denver Streets Partnership, which spoke more broadly to the overall changes being offered
-Kroll	[10988.799-10988.799]	this evening. Julien
-Kroll	[10989.110-10989.110]	Bouquet:
-Kroll	[10989.881-10990.482]	Perfect. Secretary. Chris Nicholson:
-Kroll	[10991.204-10992.456]	Thank you. And thank
-Kroll	[10992.456-10993.291]	you, Mr. Executive
-Kroll	[10994.465-10996.971]	Manager Kroll. So here at RTD, we make lives better
-Kroll	[10997.610-11000.971]	through connections. Tonight as a Board, we have an opportunity to do that in a particularly
-Kroll	[11002.076-11003.724]	powerful way. Our rider surveys tell a
-Kroll	[11004.500-11010.828]	clear story. Over half of our passengers live below 200% of the federal poverty level, and they are far less likely to own
-Kroll	[11011.870-11018.321]	a car. Our riders with disabilities use RTD at disproportionately high rates, as do other vulnerable populations in
-Kroll	[11018.680-11025.225]	our community. Yet only a fraction of affordable housing developed near our stations truly meets the needs of our most
-Kroll	[11026.250-11029.929]	dedicated riders. Communities in our state have struggled to create housing targeted at
-Kroll	[11030.636-11037.076]	our ridership. Inclusionary zoning has mostly led to housing at 60% AMI, about $51,000 a year
-Kroll	[11037.525-11045.877]	in earnings. This housing is necessary, but priced well out of reach for someone making only $31,000, which is 200% of the federal
-Kroll	[11046.237-11055.251]	poverty line. This amendment empowers RTD to deepen our land discount offerings up to 75% to incentivize projects specifically tailored to the actual economic realities of
-Kroll	[11056.273-11057.750]	our riders. Here's how that can work
-Kroll	[11058.016-11064.808]	in practice. Just this month, Denver Health donated the land to create Tapestry, a deeply affordable, accessible, transit- oriented
-Kroll	[11065.627-11074.339]	housing project. It supports a range of affordability from 30% to 80% as well as far more three bedroom and even four bedroom units than most affordable projects being
-Kroll	[11075.456-11081.943]	built today. It targets accessibility because distance to transit is a major barrier for people with disabilities to
-Kroll	[11082.703-11091.178]	use transit. This holds for all types of disabilities, and unfortunately, painfully few class A fully accessible units exist in the RTD
-Kroll	[11092.143-11096.667]	service area. By creating greater incentives for developers, we can do a lot to play our part in
-Kroll	[11097.082-11103.248]	fixing that. It's late, so I won't go through the argument for reduced parking and service of CFHA's
-Kroll	[11103.892-11105.352]	priority populations. You all have an email from me with
-Kroll	[11106.015-11112.184]	that data. But I do want Director Harwick to speak after me to address the language, he added on smaller footprint and below
-Kroll	[11113.285-11119.336]	market retail. Community is about more than housing, and I enthusiastically added his language for the reasons
-Kroll	[11119.947-11124.244]	he'll highlight. This framework recognizes that we are not the housing
-Kroll	[11125.195-11143.799]	policy experts. It increases the scope of our tools and trusts our staff to use them effectively to bring us thoughtful projects, projects that align with our strategic priority of community value and enable us to grow ridership by putting the people who most need transit where they can best be served
-Kroll	[11144.665-11146.485]	by it. I ask your support for
-Kroll	[11147.469-11147.579]	this amendment. Julien Bouquet:
-Kroll	[11147.710-11147.870]	Thank you.
-Kroll	[11149.512-11149.512]	Director Harwick. Ian
-Harwick	[11149.900-11157.665]	Yeah. So I wanted to make sure that when we're talking about TOD, that we're really thinking also about mixed
-Harwick	[11158.053-11166.759]	use TOD. And I'm wildly in favor of anything that we can do to bring more housing, let alone affordable housing, to our park
-Harwick	[11167.019-11173.246]	and rides. I do think it's really key that we also think about what are the businesses that we are bringing
-Harwick	[11173.557-11184.455]	in there. And having spent a lot of time working at Starbucks and a good friend of mine works at Starbucks, I'm also really in favor of coffee shops like Prodigy and
-Harwick	[11184.766-11201.764]	smaller shops. But also thinking about when I've traveled to travel to other communities throughout the world, there oftentimes are smaller retail shops that give young entrepreneurs that opportunity to start a business and not be burdened by a larger footprint that some of our larger restaurants or larger retail
-Harwick	[11202.139-11204.009]	shops can. They can cover
-Harwick	[11204.383-11223.498]	those costs. So this, to me, was a way to encourage local businesses to start up or expand give them the opportunity in a place that we all-- when we go to a park and ride and there's not something there to grab that quick bite to eat, I want to give them that opportunity, everyone
-Harwick	[11223.774-11225.430]	that opportunity. One to shop there and
-sell there. Julien Bouquet	[11227.089-11227.690]	Thank you,
-sell there. Julien Bouquet	[11228.632-11229.868]	Director Harwick. Any further discussion on
-sell there. Julien Bouquet	[11231.217-11231.507]	this amendment?
-sell there. Julien Bouquet	[11232.082-11232.336]	Director Ruscha? Joyann
-Ruscha	[11232.590-11234.112]	Mr. Chair, maybe you can help
-Ruscha	[11234.446-11238.176]	me here. So I had a comment, but I had a comment on the
-Ruscha	[11238.443-11239.509]	main motion. But we moved
-Ruscha	[11240.216-11245.798]	to amendments. But recognizing that Secretary Nicholson's language can't exist without the motion language or the way
-Ruscha	[11246.346-11248.011]	it's drafted. May I just make a
-Ruscha	[11248.310-11249.194]	general comment? Does that
-Ruscha	[11249.391-11252.244]	make sense? It would apply to both, but I don't know if I would be called out
-Ruscha	[11252.422-11252.779]	of order. And
-Ruscha	[11253.779-11254.313]	I'm tired. I will do what
-you say. Julien Bouquet	[11254.520-11254.787]	You
-you say. Julien Bouquet	[11255.081-11255.291]	know what?
-you say. Julien Bouquet	[11255.562-11256.347]	Why not? Let's give it
-you say. Julien Bouquet	[11256.564-11257.015]	a try. Joyann Ruscha:
-you say. Julien Bouquet	[11257.445-11257.956]	OK, thanks. I'm doing
-you say. Julien Bouquet	[11259.088-11270.058]	my best. So this morning, we got an email from staff that addressed some outstanding questions that I still had, just so I knew what I was
-you say. Julien Bouquet	[11271.040-11280.571]	voting on. And the issue-- I have heartburn over just the main motion because the way
-you say. Julien Bouquet	[11281.252-11287.889]	it's written. We, as a Board, are not just expanding the bounds of what a
-you say. Julien Bouquet	[11288.246-11297.508]	policy is. We're also signing away 30 plus years of precedent of having this guardrail that says, before you go dispense a real property, get our
-you say. Julien Bouquet	[11298.484-11305.790]	preliminary authorization. So I am already a little
-you say. Julien Bouquet	[11306.855-11321.619]	bit uncomfortable. And also the policy says that if a developer, as it relates to housing, cannot meet our 50% standard, they could still get a major discount and it could be millions and millions
-you say. Julien Bouquet	[11322.496-11327.496]	of dollars. And so those two combined and just recognizing that these deals take a long,
-you say. Julien Bouquet	[11327.830-11328.830]	long time. They're not
-you say. Julien Bouquet	[11330.645-11333.890]	summer projects. In some, it means that all of that is going
-you say. Julien Bouquet	[11334.185-11339.199]	to happen. And then it's going to come back to the Board when all of those decisions have
-you say. Julien Bouquet	[11340.986-11357.793]	been made. So for that, because I'm struggling with the original proposal, but I can accept it for now, is why I can't vote yes on Secretary Nicholson's amendment, because we don't have guardrails that I
-you say. Julien Bouquet	[11358.224-11360.884]	would prefer. So I hope that was not out
-you say. Julien Bouquet	[11361.089-11363.337]	of order. And if it was, thanks for not calling me out
-you say. Julien Bouquet	[11363.561-11363.742]	of order. Julien Bouquet:
-you say. Julien Bouquet	[11364.202-11365.324]	Thank you. Thank you,
-you say. Julien Bouquet	[11365.324-11365.594]	Director Ruscha.
-Director Guzman. Michael Guzman	[11365.594-11373.100]	So ETOD has been discussed a number of times in the committee, and this is
-Director Guzman. Michael Guzman	[11376.302-11390.587]	my concern. Although I am with you in spirit-- deeply affordable housing is really important-- I'm not sure that giving an additional 25% discount in our policy is wise for a number
-Director Guzman. Michael Guzman	[11391.605-11396.039]	of reasons. I do believe, however-- and maybe Madam CEO
-Director Guzman. Michael Guzman	[11396.572-11398.334]	or Ms. Chessy Brady might be able to speak
-Director Guzman. Michael Guzman	[11398.554-11398.995]	to this. I'm
-Director Guzman. Michael Guzman	[11401.058-11408.011]	not sure. What we were asked for in this policy was to give guidelines to begin negotiation that would eventually come back to
-Director Guzman. Michael Guzman	[11409.539-11421.234]	this Board. Let's say a developer comes to us and just brings us an amazing proposal that includes everything that you could want in a development
-Director Guzman. Michael Guzman	[11421.722-11443.061]	and more. I don't see why they wouldn't necessarily come back to us and say, hey, they're willing to do all of these things-- they being staff-- and asking for an additional amount of up to whatever amount makes sense to give that discount from the Board that we would consider properly and then be able to authorize in
-Director Guzman. Michael Guzman	[11444.244-11450.406]	that moment. But in order to begin the process, we were simply asked to give authorization for them to work within
-Director Guzman. Michael Guzman	[11450.774-11456.871]	a parameter. That way, there was no confusion that they would be able to do a 30% to 50% discount as was written in the
-Director Guzman. Michael Guzman	[11457.626-11465.913]	original policy. Beyond that, the Board would still have authority, as I understand it, if we were asked to offer an additional discount
-Director Guzman. Michael Guzman	[11466.888-11484.319]	for more. I don't know that we need to lock that into policy, and it does the one thing that I was trained by former Directors and members that are currently here not to do, which is bind future boards in a way that creates difficulty for us to do our job as the fiduciaries of
-Director Guzman. Michael Guzman	[11484.796-11486.559]	the agency. And so I would like to ask
-Director Guzman. Michael Guzman	[11487.265-11502.983]	that question. Is there anything that would prevent you from coming back to us if we were to receive such an excellent proposal that prevents you from saying, can we receive an additional discount to offer a developer, Board, and would you approve this so we can make a
-Director Guzman. Michael Guzman	[11504.967-11504.967]	project work? Julien
-Director Guzman. Michael Guzman	[11505.167-11505.167]	Bouquet:
-Director Guzman. Michael Guzman	[11505.382-11508.663]	Ms. Brady. First off, thank you for your patience and greatly appreciate you sticking
-Director Guzman. Michael Guzman	[11508.993-11509.213]	around tonight. Chessy Brady:
-Director Guzman. Michael Guzman	[11509.774-11510.414]	Of course. Julien Bouquet:
-Director Guzman. Michael Guzman	[11511.376-11511.546]	You're recognized. Chessy Brady:
-Director Guzman. Michael Guzman	[11512.357-11515.033]	Thank you. No, there is nothing that would stop us from
-Director Guzman. Michael Guzman	[11515.762-11521.153]	doing that. As you say, the point of the policy is to create guardrails and certainty within
-Director Guzman. Michael Guzman	[11522.231-11534.731]	those guardrails. We would use the opinions of the Board to guide developers towards what we think the Board would be interested in, as we're negotiating with them, and we come back to the Board for approval of any
-Director Guzman. Michael Guzman	[11535.906-11536.076]	given project. Karen Benker:
-Director Guzman. Michael Guzman	[11537.047-11537.798]	Thank you. One more
-Director Guzman. Michael Guzman	[11538.388-11548.783]	quick thing. And Director Benker, Treasurer Benker, the sales and the lease income from our real estate properties are put into a
-Director Guzman. Michael Guzman	[11549.298-11550.051]	specific account. Can you guess
-Director Guzman. Michael Guzman	[11550.979-11564.216]	which one? Because when we deeply discount things beyond where we should, we are saying no to the potential income that we could use for operations and maintenance and service provision elsewhere in
-Director Guzman. Michael Guzman	[11565.147-11572.331]	the agency. So on balance, real estate and real property are a finite resource and dollars can be
-Director Guzman. Michael Guzman	[11573.515-11583.703]	stretched thin. But how we use the opportunity to either receive money to prolong and serve the public further is a huge consideration
-Director Guzman. Michael Guzman	[11584.386-11588.810]	in this. So although I am with you in spirit, I would be voting no on the amendment as it is
-right now. Julien Bouquet	[11589.711-11591.273]	Thank
-right now. Julien Bouquet	[11591.273-11591.744]	you, Director.
-right now. Julien Bouquet	[11592.481-11592.681]	Director Paglieri. Brett Paglieri:
-right now. Julien Bouquet	[11592.881-11593.282]	Thank you. I'll
-right now. Julien Bouquet	[11594.563-11598.950]	be brief. I really like the language that highlights these things that I deeply
-right now. Julien Bouquet	[11600.068-11601.456]	agree with. I am a little bit concerned about
-right now. Julien Bouquet	[11601.670-11603.969]	two things. The first is the language
-right now. Julien Bouquet	[11604.813-11608.741]	deeply affordable. It's a little bit ambiguous, if I'm saying
-right now. Julien Bouquet	[11610.118-11616.138]	that right. And I think using language like that can-- what's to say they
-right now. Julien Bouquet	[11616.568-11618.718]	discounted $100? To some, that's a
-right now. Julien Bouquet	[11619.148-11620.438]	deep discount. To others,
-right now. Julien Bouquet	[11620.848-11628.319]	that's nothing. So I'd recommend removing that word and just maybe also deeply affordable unless you can define
-right now. Julien Bouquet	[11629.279-11631.207]	it elsewhere. But I do want to leave
-right now. Julien Bouquet	[11631.502-11638.421]	this language. And the other thing is I just have a hard time giving a 75% discount even with these things that
-right now. Julien Bouquet	[11639.352-11656.150]	I want. And perhaps that this is a really limited circumstance that we'd give 75% But this is our property, and I really would like to see it sold for the highest value to
-right now. Julien Bouquet	[11656.772-11656.952]	benefit all.
-Thank you. Julien Bouquet	[11657.152-11658.433]	Thank
-Thank you. Julien Bouquet	[11659.094-11659.385]	you, Director.
-Treasurer Benker. Karen Benker	[11661.657-11662.828]	Just a
-Treasurer Benker. Karen Benker	[11663.739-11670.366]	quick question. Some of the surplus properties that we're talking about, we are not including our current park
-Treasurer Benker. Karen Benker	[11670.756-11670.756]	and
-Treasurer Benker. Karen Benker	[11672.147-11678.159]	rides. Correct? Would be excess land, perhaps around a park and ride, but not one of our park
-Treasurer Benker. Karen Benker	[11679.758-11680.279]	and rides.
-Treasurer Benker. Karen Benker	[11681.560-11681.800]	Just clarification. Chessy Brady:
-Treasurer Benker. Karen Benker	[11682.061-11685.514]	Thank you. So this policy is aimed at transit
-Treasurer Benker. Karen Benker	[11686.487-11691.423]	oriented development. So property that RTD owns at transit stations or near high
-Treasurer Benker. Karen Benker	[11692.182-11698.257]	frequency transit. Excess property and surplus property are definable terms that perhaps Michelle could help
-Treasurer Benker. Karen Benker	[11698.637-11704.711]	us with. But those are distinctive properties that the Board has named to be excess
-Treasurer Benker. Karen Benker	[11705.531-11708.065]	and surplus. And so I just want to separate that from a park
-Treasurer Benker. Karen Benker	[11708.256-11710.042]	and ride. A park and ride is certainly not excess
-Treasurer Benker. Karen Benker	[11711.081-11712.876]	or surplus. It may have
-Treasurer Benker. Karen Benker	[11713.525-11726.927]	underutilized land. It may have a large drainage area that is part of the park and ride, but not every development that we would consider on a park and ride would remove parking, if that's getting more to
-Treasurer Benker. Karen Benker	[11728.090-11728.441]	your question. Karen
-Benker	[11728.441-11728.441]	OK. Chessy
-Brady	[11731.275-11731.776]	Yes. Julien Bouquet:
-Secretary Nicholson. Chris Nicholson	[11731.776-11735.586]	I actually have some questions
-Secretary Nicholson. Chris Nicholson	[11736.493-11736.493]	for
-Secretary Nicholson. Chris Nicholson	[11737.454-11741.871]	Ms. Brady. So first off, Director Paglieri raised the concern about the term
-Secretary Nicholson. Chris Nicholson	[11742.859-11747.264]	deep affordability. I think you and I know what that means, but maybe the rest of the Board doesn't, given it's a term
-Secretary Nicholson. Chris Nicholson	[11747.505-11750.729]	of art. Can you elaborate on what that's
-Secretary Nicholson. Chris Nicholson	[11751.929-11751.929]	referring to? Julien
-Secretary Nicholson. Chris Nicholson	[11752.130-11752.130]	Bouquet:
-Secretary Nicholson. Chris Nicholson	[11752.130-11753.191]	Ms. Brady. Chessy Brady:
-Secretary Nicholson. Chris Nicholson	[11753.671-11761.292]	Sure, yes. Deep affordability is a term in the affordable housing network that means generally 30% to 40%
-Secretary Nicholson. Chris Nicholson	[11762.159-11766.937]	of AMI. It is squishy, I think still, but generally it's understood to mean 30%
-Secretary Nicholson. Chris Nicholson	[11767.338-11767.338]	to 40%. Julien
-Bouquet	[11769.905-11770.949]	Secretary. Chris Nicholson: So
-Bouquet	[11771.471-11776.692]	second question. I've heard a couple of concerns about 75% as
-Bouquet	[11778.896-11782.945]	a discount. I was hoping maybe you could speak to the-- because I mentioned it a
-Bouquet	[11783.215-11790.503]	little bit. But as someone who's an expert in the space, and I will say you and I worked pretty closely together on this language and went back
-Bouquet	[11790.773-11792.123]	and forth. You did a meeting
-Bouquet	[11792.473-11794.609]	with me. So this isn't just something that I
-Bouquet	[11794.956-11798.884]	wrote myself. This is something that got vetted pretty heavily
-Bouquet	[11800.229-11815.267]	by staff. What impact does a greater discount have on the types of projects that, in the affordable housing space, you tend to see people able
-Bouquet	[11815.909-11829.316]	to build? At least from where I sit, the reason for doing this is that when it comes to those deeply affordable, which are deeply subsidized units, when it comes to things like units that are fully accessible, those
-Bouquet	[11829.947-11836.037]	are expensive. They cost developers money, which is why, when you don't have those subsidies, those units don't
-Bouquet	[11836.455-11847.862]	get built. I think it's about half the projects that are in the CHFA Database have zero units at 30% AMI, and very few of them have anything with regard
-Bouquet	[11848.328-11854.150]	to accessibility. So I'm hoping you can maybe elaborate on-- you're the one who would be using this tool at the end of
-Bouquet	[11854.433-11858.787]	the day. How do you see it coming in handy with regard to what you're able
-Bouquet	[11859.698-11860.976]	to do? And then I have one last
-Bouquet	[11862.981-11866.804]	follow up. Julien
-Bouquet	[11869.116-11869.116]	Bouquet:
-Bouquet	[11873.804-11875.856]	Ms. Brady. Chessy Brady:
-Bouquet	[11878.650-11882.211]	Thank you. So affordable housing projects are notoriously difficult
-Bouquet	[11883.337-11889.034]	to finance. And I think if you use the example earlier of Tapestry and
-Bouquet	[11889.414-11893.591]	Denver Health. Denver Health, as you stated, as I assume it's correct, donated the land
-Bouquet	[11894.011-11897.745]	for Tapestry. I can assure you that development was still very difficult
-Bouquet	[11898.937-11908.332]	to finance. So even if we were giving the land at 100% discount, the projects would still not pencil, in
-Bouquet	[11909.400-11931.193]	many cases. And so our ability to discount the land to 75% as the Board prefers, in many cases, could get us over the hump from a project not being built to a project being built, and to that project having more affordable units as opposed to a higher, more of a middle
-Bouquet	[11931.905-11934.290]	income range. And that's the difference that the land
-Bouquet	[11934.949-11939.548]	discount makes. And that's the certainty that this policy helps me bring to conversations
-Bouquet	[11940.255-11945.207]	with developers. Gets them in the mindset of we're going to get some help here
-Bouquet	[11946.342-11948.573]	from RTD. We can focus on deeper
-Bouquet	[11948.965-11954.160]	affordability units. We can make bigger promises to CHFA or other financing entities that host
-Bouquet	[11955.192-11958.310]	in Denver. And it helps us keep the
-Bouquet	[11959.659-11961.124]	projects moving. And I'll be frank
-Bouquet	[11962.096-11966.567]	with you. As I said, Tapestry, even with 100% discount, it's still hard
-Bouquet	[11967.066-11968.668]	to do. This is not a
-Bouquet	[11969.269-11974.719]	silver bullet. But it moves the needle and it helps us actually keep projects afloat and get to the
-finish line. Julien Bouquet	[11975.399-11975.693]	Thank
-finish line. Julien Bouquet	[11975.880-11975.880]	you,
-finish line. Julien Bouquet	[11976.461-11979.547]	Ms. Brady. We're going to wrap up with Director O'Keefe and then
-Director Larsen. Patrick O'Keefe	[11980.307-11981.767]	Oh, I thought I got
-Director Larsen. Patrick O'Keefe	[11982.682-11985.102]	last word. So I support
-Director Larsen. Patrick O'Keefe	[11985.848-11996.368]	this amendment. I think it is a reasonable step toward developing communities that are very likely to use
-Director Larsen. Patrick O'Keefe	[11997.743-12002.228]	our services. I think increasing ridership is something we all
-Director Larsen. Patrick O'Keefe	[12002.508-12004.453]	agree on. This is a concrete way to
-Director Larsen. Patrick O'Keefe	[12005.873-12015.431]	do that. It also takes land not just for our benefit in ridership, but also puts improvements on it that helps the
-Director Larsen. Patrick O'Keefe	[12016.307-12031.160]	tax base. And I think the communities that we serve would rather see a housing project end up on that property where it becomes improved versus
-Director Larsen. Patrick O'Keefe	[12031.688-12032.804]	somewhere else. We're not the only game
-Director Larsen. Patrick O'Keefe	[12033.030-12034.421]	in town. There's a lot of discounts
-Director Larsen. Patrick O'Keefe	[12034.674-12040.715]	out there. And so we're not necessarily in a tight
-Director Larsen. Patrick O'Keefe	[12041.486-12043.499]	buyer's market. There's a lot of projects that can
-Director Larsen. Patrick O'Keefe	[12044.452-12052.556]	go forward. And I think we need to put our best deal, and at least give Chessy and the rest of the team the tools to bring the
-Director Larsen. Patrick O'Keefe	[12052.848-12054.502]	deal forward. I do want to put
-Director Larsen. Patrick O'Keefe	[12055.153-12055.785]	one plug-in. We talked
-Director Larsen. Patrick O'Keefe	[12056.296-12060.797]	about it. I don't think ground leases are the best tool
-Director Larsen. Patrick O'Keefe	[12061.287-12064.396]	in Colorado. First of all, it's not as common as other places in
-Director Larsen. Patrick O'Keefe	[12065.296-12073.038]	the world. And the other thing is, toward the end of your ground lease, no matter how long you make it, the property will fall
-Director Larsen. Patrick O'Keefe	[12073.773-12078.709]	into disrepair. They are not going to put money into physical facilities that are going to roll off
-Director Larsen. Patrick O'Keefe	[12079.680-12086.547]	their books. So for that reason, the discount's great and I love a sale versus a
-Director Larsen. Patrick O'Keefe	[12086.949-12089.042]	ground lease. And I know you'll keep that in mind as we
-Director Larsen. Patrick O'Keefe	[12089.953-12097.522]	go forward. And anyway, that's another argument in favor of
-Director Larsen. Patrick O'Keefe	[12100.182-12100.182]	that tactic. Julien Bouquet:
-Director Larsen. Patrick O'Keefe	[12100.182-12100.423]	Director Larsen. Matt Larsen:
-Director Larsen. Patrick O'Keefe	[12101.284-12102.744]	Thank you. I'm going to be a no vote
-Director Larsen. Patrick O'Keefe	[12103.286-12108.281]	on this. I don't agree with our transit oriented development policy as it is
-Director Larsen. Patrick O'Keefe	[12108.834-12115.206]	right now. I don't agree with the goal of trying to provide affordable housing or encourage it,
-Director Larsen. Patrick O'Keefe	[12115.984-12119.553]	incentivize it. I think we should be focused on trying to
-Director Larsen. Patrick O'Keefe	[12120.070-12134.747]	increase ridership. If we want to provide discounts on our land, we should provide them with the goal in mind of increasing the number of people that can live on the property, whatever is developed, and the amount of traffic that is on
-Director Larsen. Patrick O'Keefe	[12136.212-12138.264]	the property. So I'm a no
-on this. Julien Bouquet	[12139.355-12140.015]	Thank you,
-on this. Julien Bouquet	[12140.396-12140.536]	Director Larsen.
-on this. Julien Bouquet	[12141.116-12144.791]	All right. With the indication there is a no vote, I am going to do a roll
-on this. Julien Bouquet	[12145.040-12147.869]	call vote. As a reminder, we are voting on Director
-on this. Julien Bouquet	[12148.683-12152.747]	Nicholson's amendment. He was the mover and Director Harwick is the second
-on this. Julien Bouquet	[12153.147-12153.147]	Treasurer Benker. Karen
-Benker	[12156.651-12156.981]	Yes. Julien Bouquet:
-Benker	[12156.981-12158.773]	Director Catlin. Peggy
-Catlin	[12159.920-12160.320]	Yes. Julien Bouquet:
-Catlin	[12161.041-12161.041]	Director Guissinger. Lynn
-Guissinger	[12161.602-12162.013]	Yes. Julien Bouquet:
-Guissinger	[12162.944-12162.944]	Director Gutschenritter. Chris
-Gutschenritter	[12163.484-12163.825]	Yes. Julien Bouquet:
-Gutschenritter	[12163.825-12164.446]	Director Guzman. Michael
-Guzman	[12165.607-12165.917]	No. Julien Bouquet:
-Guzman	[12165.917-12166.408]	Director Harwick. Ian
-Harwick	[12167.569-12167.930]	Yes. Julien Bouquet:
-Harwick	[12167.930-12169.271]	Director Larsen. Matt
-Larsen	[12170.553-12170.933]	No. Julien Bouquet:
-Larsen	[12170.933-12171.794]	Secretary Nicholson. Chris
-Nicholson	[12172.916-12173.477]	Yes. Julien Bouquet: First Vice
-Nicholson	[12173.477-12174.558]	Chair O'Keefe. Patrick
-O'Keefe	[12175.339-12175.739]	Yes. Julien Bouquet:
-O'Keefe	[12176.600-12176.600]	Director Paglieri. Brett
-Paglieri	[12177.421-12177.742]	Yes. Julien Bouquet:
-Paglieri	[12177.742-12181.016]	Director Ruscha. Joyann Ruscha:
-Sorry, no. Julien Bouquet	[12182.227-12183.365]	And finally, Second Vice
-Sorry, no. Julien Bouquet	[12183.365-12184.210]	Chair Whitmore. Troy
-Whitmore	[12185.317-12188.427]	Yes. Julien Bouquet: And I am
-Whitmore	[12189.049-12195.891]	a yes. That amendment will pass 10, 2-- excuse me. 10, 3,
-Whitmore	[12198.697-12201.308]	and 2. Yes. 10 yes, 3 no,
-Whitmore	[12201.743-12203.049]	2 absent. That is
-Whitmore	[12204.105-12204.105]	the
-Whitmore	[12204.482-12204.859]	math. OK.
-Whitmore	[12205.236-12210.137]	Moving on. We are going to do our second amendment, which was brought forward by
-Whitmore	[12211.979-12215.121]	Director Ruscha. And Director Ruscha, would you like to introduce the language of
-Whitmore	[12217.286-12224.862]	the amendment? Joyann Ruscha: It's being brought forth by Directors Ruscha and Guzman, and I-- Michael Guzman: I can make
-Whitmore	[12225.716-12225.716]	the
-motion. Sorry. Joyann Ruscha	[12226.197-12227.387]	I think he has the language in front
-motion. Sorry. Joyann Ruscha	[12227.919-12228.239]	of him. Julien Bouquet:
-Director Guzman. Michael Guzman	[12228.239-12229.572]	Thank
-Director Guzman. Michael Guzman	[12229.817-12229.817]	you,
-Director Guzman. Michael Guzman	[12230.102-12256.032]	Mr. Chair. We would like to make a motion to add the language to the end of this policy that says, additionally, no project will be eligible for any discounts unless it complies with the greater of the following. 5% of all units are accessible to persons with mobility disabilities, and an additional 2% of all units are accessible to persons with hearing or visual disabilities, or two, current US Department of Housing Urban Development
-Director Guzman. Michael Guzman	[12258.755-12259.380]	accessibility requirements. Do we have
-Director Guzman. Michael Guzman	[12260.579-12263.229]	a second? We have Ruscha as
-Director Guzman. Michael Guzman	[12263.229-12263.229]	the
-Director Guzman. Michael Guzman	[12263.496-12263.953]	second. Mr. Kroll,
-I'm sorry. Jack Kroll	[12264.464-12272.761]	Just to clarify, Director Guzman, as I understood you reading that into the record, the highlighted portion above would
-I'm sorry. Jack Kroll	[12273.176-12275.665]	be deleted. And is not included in
-I'm sorry. Jack Kroll	[12277.241-12277.241]	your
-I'm sorry. Jack Kroll	[12277.241-12277.241]	motion. Correct? Michael
-Guzman	[12279.985-12283.337]	Correct. Julien Bouquet: So the language we see, this would substitute
-Guzman	[12284.311-12284.712]	the language?
-OK, perfect. Michael Guzman	[12285.452-12287.886]	Simplifying it to the bare minimum to get
-OK, perfect. Michael Guzman	[12289.778-12290.039]	this done. Julien Bouquet:
-Director Ruscha. Joyann Ruscha	[12291.764-12296.325]	I was happy to speak to the motion, but I wasn't sure if we were--
-Director Ruscha. Joyann Ruscha	[12296.950-12297.190]	I'm tired. Is
-Director Ruscha. Joyann Ruscha	[12298.411-12298.656]	that OK? Julien
-Bouquet	[12298.656-12298.656]	Mhm. Joyann
-Ruscha	[12298.656-12302.331]	OK. Julien Bouquet: We got Guzman as the mover and Ruscha as the second, and we're up
-Ruscha	[12302.636-12302.816]	for conversation. Joyann
-Ruscha	[12302.816-12303.372]	OK. Julien Bouquet: You're up,
-Director Ruscha. Joyann Ruscha	[12303.917-12304.264]	Thank
-Director Ruscha. Joyann Ruscha	[12304.458-12304.458]	you
-Director Ruscha. Joyann Ruscha	[12304.946-12309.336]	sir. OK. So just for everyone's edification, we struck the
-Director Ruscha. Joyann Ruscha	[12309.884-12311.500]	first sentence. It was a two
-Director Ruscha. Joyann Ruscha	[12311.904-12320.322]	sentence amendment. Just recognizing that we didn't have full staff concurrence on the first sentence, which would have applied this accessibility minimum to market
-Director Ruscha. Joyann Ruscha	[12321.557-12325.467]	rate housing. And sometimes you shoot for the stars and land on
-Director Ruscha. Joyann Ruscha	[12326.843-12333.607]	the moon. The second sentence, which just applies to the HUD requirement to affordable housing, we did get
-Director Ruscha. Joyann Ruscha	[12335.292-12336.543]	staff concurrence. That was the context
-Director Ruscha. Joyann Ruscha	[12338.595-12344.554]	behind that. I sent out like a Q&A, frequently asked questions in anticipation of
-Director Ruscha. Joyann Ruscha	[12344.885-12348.198]	some questions. So I'm happy to entertain any or we can
-Director Ruscha. Joyann Ruscha	[12349.029-12369.943]	address them. I will say that we worked for three weeks and some change on this with housing advocates and folks who had worked in the space, and people had worked at CHFA and at the state level on similar policy and advocacy organizations and then staff
-Director Ruscha. Joyann Ruscha	[12370.790-12374.040]	and legal. So, I mean, just--
-Director Ruscha. Joyann Ruscha	[12374.690-12375.990]	I'm sorry. I
-Director Ruscha. Joyann Ruscha	[12377.290-12395.214]	am tired. In case anybody has any questions about what this is, I think it just simplify it and say that HUD has a current minimum accessibility requirement
-Director Ruscha. Joyann Ruscha	[12396.389-12400.151]	for funding. And it's 5% of units are accessible to persons with
-Director Ruscha. Joyann Ruscha	[12400.493-12404.597]	mobility disabilities. Additional 2% of units are accessible to persons with hearing or
-Director Ruscha. Joyann Ruscha	[12405.740-12410.260]	visual disabilities. And so a lot of times in these projects, that HUD requirement is going to
-Director Ruscha. Joyann Ruscha	[12410.543-12413.085]	kick in. But not all projects are going to have
-Director Ruscha. Joyann Ruscha	[12413.969-12420.183]	HUD dollars. So just recognizing that a lot of jurisdictions take that HUD standard, which is--
-Director Ruscha. Joyann Ruscha	[12420.494-12423.885]	maybe Ms. Brady can correct me, but I think it's 20 plus years, 30 plus years
-Director Ruscha. Joyann Ruscha	[12425.439-12429.384]	old now. And they also incorporate that into their policies or their code
-Director Ruscha. Joyann Ruscha	[12430.043-12430.749]	or statute. We did
-Director Ruscha. Joyann Ruscha	[12431.454-12432.631]	the same. Good for goose, good
-Director Ruscha. Joyann Ruscha	[12433.627-12438.784]	for gander. I will stop there unless anyone else has further questions
-or comments. Julien Bouquet	[12440.314-12441.999]	Questions or comments on
-or comments. Julien Bouquet	[12443.677-12446.592]	this amendment? Director Catlin, then
-Secretary Nicholson. Peggy Catlin	[12447.571-12471.277]	I appreciate the thought going into this, but I believe that the first amendment that we passed does give a lot of latitude towards Chessy and her staff to negotiate, and I fear that this one might be a little bit too regulatory
-Secretary Nicholson. Peggy Catlin	[12473.542-12483.096]	and prescriptive. And if that's the HUD requirement and somebody is applying for a HUD grant, then this would be taken care
-Secretary Nicholson. Peggy Catlin	[12484.175-12492.824]	of automatically. So right now, I'm willing to listen to other discussions, but I fear that it would not
-Secretary Nicholson. Peggy Catlin	[12493.326-12500.046]	give Ms. Brady and her staff the maximum flexibility to look at the comprehensive merits of
-Secretary Nicholson. Peggy Catlin	[12503.309-12504.337]	a proposal. Julien Bouquet:
-Secretary Nicholson. Peggy Catlin	[12504.871-12504.871]	Yeah,
-Ms. Brady. Chessy Brady	[12506.312-12506.673]	Would you like me
-Ms. Brady. Chessy Brady	[12506.673-12518.858]	to comment? So this is a bare minimum requirement that Denver already requires, for example, and the Colorado Department of Housing is already considering a higher threshold
-Ms. Brady. Chessy Brady	[12519.427-12521.950]	of requirement. So I have no concerns about
-Ms. Brady. Chessy Brady	[12522.290-12525.712]	incorporating this. I think it's already going to be taken care of in
-most cases. Peggy Catlin	[12526.375-12527.036]	If
-most cases. Peggy Catlin	[12527.366-12528.688]	I might? That's kind of
-most cases. Peggy Catlin	[12529.118-12530.436]	my point. It seems a little
-most cases. Peggy Catlin	[12534.190-12534.591]	bit redundant. Julien Bouquet:
-Secretary Nicholson. Chris Nicholson	[12534.591-12538.924]	I'd like to offer an amendment, if that's
-all right. Julien Bouquet	[12540.844-12541.218]	To
-all right. Julien Bouquet	[12541.606-12541.806]	the Amendment? Chris Nicholson:
-Thank you. Julien Bouquet	[12543.249-12544.434]	Just to clarify, that was
-Thank you. Julien Bouquet	[12544.672-12546.258]	a question. You would like to offer an amendment to
-Thank you. Julien Bouquet	[12546.817-12548.681]	the amendment? Chris
-Thank you. Julien Bouquet	[12548.842-12548.842]	Nicholson:
-Thank you. Julien Bouquet	[12549.002-12549.378]	Yes. Sub-amendment. Julien
-Thank you. Julien Bouquet	[12550.099-12550.099]	Bouquet:
-Thank you. Julien Bouquet	[12550.840-12558.636]	Mr. Kroll? Jack Kroll: Technically, the initial motion on the table is to amend the ETOD policy, and this is an amendment to
-Thank you. Julien Bouquet	[12559.026-12566.432]	that amendment. And at this point would be amending an amendment to an amendment, which is not allowed under
-Thank you. Julien Bouquet	[12566.822-12571.110]	Robert's Rules. So you would need to tackle this amendment as it's
-Thank you. Julien Bouquet	[12571.500-12580.832]	being presented. And then, if you feel so inclined, offer an amendment to whatever or whatever state the policy is in at
-Thank you. Julien Bouquet	[12581.971-12582.420]	that point. Julien Bouquet:
-Thank you. Julien Bouquet	[12582.868-12582.868]	Rock
-Thank you. Julien Bouquet	[12583.769-12583.769]	on. Secretary. Chris
-Nicholson	[12584.086-12588.833]	Yeah. So at that point, I would say I'd have to be a no for the very
-Nicholson	[12589.150-12601.477]	simple reason. Where it says no project will be eligible, we're talking about an equitable TOD policy here, which is specifically focused on using our land to facilitate the-- literally the policy is about
-Nicholson	[12602.439-12608.862]	giving discounts. I can't see putting something like this in there unless it is related to
-Nicholson	[12609.310-12616.786]	said discount. So I'd be fine if it said, additionally, no project receiving a discount will be eligible for any discounts, et cetera, unless it
-Nicholson	[12617.181-12623.509]	complies with. But I don't necessarily think it makes sense to do market rate policy in an
-ETOD policy. Julien Bouquet	[12623.905-12624.696]	Thank
-ETOD policy. Julien Bouquet	[12625.882-12627.860]	you, Secretary. Treasurer Benker and then
-Director Ruscha. Karen Benker	[12628.471-12629.462]	Just
-Director Ruscha. Karen Benker	[12629.973-12640.086]	real quick. Have you perhaps considered something more positive, saying something along the lines, greater consideration would be given a project if these items
-Director Ruscha. Karen Benker	[12640.507-12642.614]	were attained? As opposed to make
-it mandatory. Julien Bouquet	[12646.040-12647.322]	Director Ruscha or
-Director Guzman. Karen Benker	[12647.662-12649.746]	Again, sort of an amendment, but just
-a thought. Joyann Ruscha	[12650.807-12654.537]	So I just want to address what Secretary
-a thought. Joyann Ruscha	[12655.707-12663.426]	Nicholson said. I might have missed part of the closed captioning, but I think you said you don't think we should be applying accessibility minimums to
-a thought. Joyann Ruscha	[12664.676-12664.676]	market
-a thought. Joyann Ruscha	[12665.237-12665.528]	rate. OK.
-a thought. Joyann Ruscha	[12666.038-12666.198]	That's exactly.
-a thought. Joyann Ruscha	[12666.659-12667.392]	We don't. So this amendment doesn't
-a thought. Joyann Ruscha	[12667.940-12668.713]	do that. And the
-a thought. Joyann Ruscha	[12669.228-12680.816]	second piece. The reason why it doesn't say it doesn't reference discounts is because-- so this goes at the end of the policy, which is all-- the way it's nested under the paragraph, this is talking about when discounts apply, if that
-a thought. Joyann Ruscha	[12683.753-12686.673]	makes sense. It does what you said you wanted it
-a thought. Joyann Ruscha	[12687.037-12687.544]	to do. It's
-a thought. Joyann Ruscha	[12688.518-12688.779]	just late. Julien
-Bouquet	[12688.779-12689.430]	Nicholson. Chris Nicholson:
-Bouquet	[12690.020-12693.959]	Thank you. And then I guess the only question I have for-- and this is actually
-Bouquet	[12694.225-12695.351]	for Ms. Brady, if
-Bouquet	[12696.984-12707.671]	that's OK. Because you mentioned that Denver has a policy that supersedes or that matches this, and the state currently is considering a policy that would supersede it, but currently
-Bouquet	[12708.509-12712.114]	does not. Under what circumstances would this have any effect
-Bouquet	[12713.081-12720.381]	at all? In what circumstances can you imagine in your professional capacity do you see this being something that
-Bouquet	[12721.869-12721.869]	would matter? Julien
-Bouquet	[12722.069-12722.069]	Bouquet:
-Bouquet	[12722.069-12723.110]	Ms. Brady. Chessy
-Brady	[12723.553-12729.058]	Yes. In a jurisdiction that doesn't currently require accessible units-- and Director Ruscha has
-Brady	[12729.334-12732.649]	mentioned some. I'm not aware of them, but this is not my area
-Brady	[12733.275-12751.308]	of expertise. But in a jurisdiction that does not already have those requirements, that is not accepting HUD money, and, if Colorado Department of Housing changes their rules, does not accept department of housing money, then that project would then be subject to this
-policy requirement. Julien Bouquet	[12753.665-12753.945]	Thank
-policy requirement. Julien Bouquet	[12754.125-12754.125]	you,
-policy requirement. Julien Bouquet	[12754.726-12754.726]	Ms.
-policy requirement. Julien Bouquet	[12755.117-12756.388]	Brady. Secretary. Chris
-Nicholson	[12756.817-12759.823]	Yeah. Just, I guess for Director Ruscha or
-Nicholson	[12760.252-12767.551]	Director Guzman. Are there any jurisdictions in the RDD service area that don't have that same requirement that
-Nicholson	[12769.951-12770.341]	Denver does? Julien Bouquet:
-Nicholson	[12772.154-12772.154]	Either Directors. Joyann
-Ruscha	[12772.447-12776.549]	Yeah. I think I'm pretty smart, but I'm not qualified to talk about 53
-Ruscha	[12776.902-12784.771]	separate jurisdictions. So I'm just going to have to lean into this is ETOD and the E in it
-Ruscha	[12785.735-12790.897]	is equitable. We spent a lot of time talking about equity today, including spending a significant amount of time talking about people
-Ruscha	[12791.664-12817.762]	with disabilities. And so just, again, recognizing that the HUD requirement is about equity and not excluding people on the basis of disability from accessing affordable housing, because the Fair Housing Act, the ADA, and other areas of anti-discrimination law, including state law, don't effectively cover
-Ruscha	[12819.444-12821.098]	that aspect. Sorry, that was more than what
-Ruscha	[12821.334-12835.202]	you asked. But no, I can't answer your question, just like you probably couldn't answer my question about every single jurisdiction in the RTD region that has something regarding
-Ruscha	[12835.853-12836.694]	parking minimums. It's a
-broad concept. Julien Bouquet	[12838.355-12838.911]	Thank you,
-broad concept. Julien Bouquet	[12839.536-12841.254]	Director Ruscha. Any further conversation on
-broad concept. Julien Bouquet	[12842.739-12843.089]	this amendment.
-Director Guzman. Michael Guzman	[12843.089-12846.834]	I will offer this last thing, and then we probably should go to
-Director Guzman. Michael Guzman	[12847.143-12856.260]	a vote. But very simply put, we need to make sure that we are protecting
-Director Guzman. Michael Guzman	[12857.414-12863.007]	the vulnerable. Providing access to these housing units, even in the City and County of Denver's building codes, is
-Director Guzman. Michael Guzman	[12863.378-12864.374]	not clear. It's as clear
-Director Guzman. Michael Guzman	[12864.991-12870.859]	as mud. There is reference to this if certain dollars are used, but stacking in the way that developers work, it's not
-Director Guzman. Michael Guzman	[12871.218-12879.663]	necessarily required. We aspire to a certain ICAA rule, but it's not clear if that means that they have to do this or not in order to
-Director Guzman. Michael Guzman	[12880.688-12892.031]	get licensed. And so, to be fair to ourselves and to ensure that we are taking care of the ADA community and providing those accessible units, I would like to see this in
-Director Guzman. Michael Guzman	[12892.810-12905.893]	the policy. I would be fine, by the way, to adjust language on this, to say we would consider giving additional discount, but I don't want any project to go forward that doesn't meet a bare minimum requirement
-Director Guzman. Michael Guzman	[12906.287-12909.944]	that's established. And although it is established in other places, it is not established in
-Director Guzman. Michael Guzman	[12910.205-12918.230]	our policy. And we are the government of this region and we should take it seriously that we have a due diligence and responsibility to those members of our community that would
-Director Guzman. Michael Guzman	[12918.719-12918.859]	need this.
-Director Guzman. Michael Guzman	[12920.242-12920.562]	Thank you. Julien Bouquet:
-Director Harwick. Ian Harwick	[12920.562-12924.680]	I always have to follow you,
-Director Harwick. Ian Harwick	[12924.979-12926.175]	Director Guzman. But obviously, I'm very
-Director Harwick. Ian Harwick	[12927.108-12939.126]	in support. Any time that we can be supportive of our communities most in need, those suffering from a whole variety of disabilities, I want to be able to put our best foot
-Director Harwick. Ian Harwick	[12939.962-12950.987]	forward there. And while we can't call out specific jurisdictions, if there is that chance that there is a jurisdiction that isn't meeting this requirement, then we should make sure we're
-Director Harwick. Ian Harwick	[12951.555-12956.790]	getting there. And if in the process the state comes up with something better or something in the future,
-Director Harwick. Ian Harwick	[12957.061-12963.762]	that's OK. But I think that this is like a safety net in my mind about how to really get there for
-Director Harwick. Ian Harwick	[12964.066-12982.616]	this community. And I think that also, as we're tying-- as these developments spur up around our transit, that's also giving them better access to the resources and giving them that the life that they want and the freedom of movement that we
-Director Harwick. Ian Harwick	[12983.048-12984.439]	so cherish. So I'm highly in support
-Director Harwick. Ian Harwick	[12985.192-12985.552]	of this.
-Thank you. Julien Bouquet	[12985.933-12987.583]	Secretary, less than
-Thank you. Julien Bouquet	[12987.976-12991.195]	30 seconds. Chris Nicholson: This question is
-Thank you. Julien Bouquet	[12992.261-12999.642]	for Chessy. My understanding with this language is that it applies to buildings with elevators
-Thank you. Julien Bouquet	[13000.269-13015.074]	in it. And so with single stair buildings, that there are different policies around equitable access because of the challenges, obviously in a single stair building, of getting people into the second, the third, the fourth, the
-Thank you. Julien Bouquet	[13015.617-13018.250]	fifth floor. You're probably the biggest expert on this in
-Thank you. Julien Bouquet	[13019.726-13030.383]	the room. Do you see any concerns with this language when it comes to buildings with stairs only
-Thank you. Julien Bouquet	[13031.716-13031.716]	versus elevators? Julien
-Thank you. Julien Bouquet	[13031.716-13031.716]	Bouquet:
-Ms. Brady. Chessy Brady	[13031.716-13041.134]	I am not the biggest expert on this in the room, but I would say that equitable-- I do know that equitable access and accessible units are different things and have
-Ms. Brady. Chessy Brady	[13042.249-13045.281]	different requirements. And so we're talking specifically about
-Ms. Brady. Chessy Brady	[13047.946-13055.288]	accessible units. We're tending to be talking about larger buildings because we do want them to be dense at stations, so I think they're typically going to be
-Ms. Brady. Chessy Brady	[13055.506-13057.471]	elevator buildings. But yeah, I don't have any concerns
-about that. Julien Bouquet	[13058.070-13058.297]	Thank
-about that. Julien Bouquet	[13058.450-13058.450]	you,
-about that. Julien Bouquet	[13059.211-13060.446]	Ms. Brady. Let's do the roll
-about that. Julien Bouquet	[13060.792-13065.526]	call vote. Again, this is the amendment offered by Director Guzman and
-about that. Julien Bouquet	[13065.956-13066.387]	Director Ruscha.
-about that. Julien Bouquet	[13070.781-13071.091]	Treasurer Benker.
-about that. Julien Bouquet	[13071.091-13072.883]	Director Catlin. Peggy
-Catlin	[13074.244-13074.605]	No. Julien Bouquet:
-Catlin	[13076.186-13076.186]	Director Guissinger. Lynn
-Guissinger	[13076.286-13076.666]	Yes. Julien Bouquet:
-Guissinger	[13078.087-13078.087]	Director Gutschenritter. Chris
-Gutschenritter	[13078.848-13079.148]	Yes. Julien Bouquet:
-Gutschenritter	[13079.148-13079.689]	Director Guzman. Michael
-Guzman	[13080.670-13080.970]	Yes. Julien Bouquet:
-Guzman	[13080.970-13081.410]	Director Harwick. Ian
-Harwick	[13082.551-13082.901]	Yep. Julien Bouquet:
-Harwick	[13084.153-13084.153]	Director Larsen. Matt
-Larsen	[13085.354-13085.734]	No. Julien Bouquet:
-Larsen	[13085.734-13088.496]	Director Nicholson. Chris
-Nicholson	[13089.617-13089.938]	Yes. Julien Bouquet:
-Nicholson	[13089.938-13092.938]	Director O'Keefe. Patrick
-O'Keefe	[13093.960-13094.548]	No. Julien Bouquet:
-O'Keefe	[13095.523-13095.523]	Director Paglieri. Brett
-Paglieri	[13096.425-13096.906]	No. Julien Bouquet:
-Paglieri	[13098.609-13098.609]	Director Ruscha. Joyann
-Ruscha	[13099.711-13100.192]	Yes. Julien Bouquet:
-Ruscha	[13100.192-13100.472]	Director Whitmore. Troy
-Whitmore	[13103.318-13103.994]	Yes. Julien Bouquet: I'm also
-Whitmore	[13104.500-13106.463]	a yes. So that'll pass. 1, 2,
-Whitmore	[13106.463-13113.859]	3, 4. I think I got 10 yeses, 3 nos, and
-Whitmore	[13115.661-13115.661]	2
-absent. OK. Jack Kroll	[13117.070-13117.746]	There are
-absent. OK. Jack Kroll	[13117.991-13118.892]	4 nos. Julien Bouquet: Excuse me,
-absent. OK. Jack Kroll	[13119.213-13119.383]	four nos.
-Thank you. Jack Kroll	[13119.894-13120.807]	So 9, 4,
-and 2. Julien Bouquet	[13121.235-13121.776]	9, 4
-and 2. Julien Bouquet	[13122.076-13122.367]	and 2.
-and 2. Julien Bouquet	[13122.857-13123.641]	My apologies. We'll save that for
-and 2. Julien Bouquet	[13125.220-13125.220]	the
-and 2. Julien Bouquet	[13126.263-13129.704]	record. OK. Now moving on back to the main motion
-and 2. Julien Bouquet	[13130.126-13131.766]	as amended. Do we have any further discussion on the
-and 2. Julien Bouquet	[13133.991-13133.991]	main
-and 2. Julien Bouquet	[13134.392-13138.802]	motion? OK. I will do a roll call vote for the main motion,
-and 2. Julien Bouquet	[13140.058-13140.319]	as amended.
-and 2. Julien Bouquet	[13142.762-13143.002]	Treasurer Benker. Karen
-Benker	[13143.002-13143.243]	Yes. Julien Bouquet:
-Benker	[13143.243-13144.024]	Director Catlin. Peggy
-Catlin	[13145.099-13146.541]	Yes. Julien Bouquet:
-Catlin	[13146.961-13148.183]	Director Guissinger. Lynn
-Guissinger	[13148.183-13148.183]	Yes. Julien Bouquet:
-Guissinger	[13148.183-13148.183]	Director Gutschenritter. Chris
-Gutschenritter	[13148.623-13148.994]	Yes. Julien Bouquet:
-Gutschenritter	[13148.994-13150.025]	Director Guzman. Michael
-Guzman	[13150.465-13150.845]	Yes. Julien Bouquet:
-Guzman	[13150.845-13151.246]	Director Harwick. Ian
-Harwick	[13152.047-13153.348]	Yes. Julien Bouquet:
-Harwick	[13153.348-13153.348]	Director Larsen. Matt
-Larsen	[13154.910-13155.341]	No. Julien Bouquet:
-Larsen	[13155.341-13156.372]	Director Nicholson. Chris
-Nicholson	[13156.973-13157.373]	Yes. Julien Bouquet:
-Nicholson	[13157.373-13158.054]	Director O'Keefe. Patrick
-O'Keefe	[13158.494-13160.477]	Yes. Julien Bouquet:
-O'Keefe	[13160.477-13160.477]	Director Paglieri. Brett
-Paglieri	[13162.539-13163.050]	Yes. Julien Bouquet:
-Paglieri	[13163.050-13163.580]	Director Ruscha. Joyann
-Ruscha	[13164.141-13164.481]	Yes. Julien Bouquet:
-Ruscha	[13164.481-13165.102]	Director Whitmore. Troy
-Whitmore	[13165.883-13166.457]	Yes. Julien Bouquet: I am also
-Whitmore	[13166.904-13172.615]	a yes. It will pass. 12 yes, 1 no,
-Whitmore	[13173.612-13173.802]	2 absent.
-Whitmore	[13174.850-13175.447]	Thank you.
-Whitmore	[13176.043-13176.639]	All right.
-Whitmore	[13177.276-13179.348]	Moving on. That was all our
-Whitmore	[13180.584-13181.501]	recommended actions. Board of
-Whitmore	[13183.631-13184.542]	Director activities. I think you're all good
-Whitmore	[13185.035-13185.325]	on that.
-Whitmore	[13188.563-13189.496]	Other matters? Speaker:
-Whitmore	[13190.560-13191.201]	Amen, buddy. Julien Bouquet:
-Director Guzman. Michael Guzman	[13191.201-13192.373]	I got
-Director Guzman. Michael Guzman	[13192.563-13192.563]	one
-Director Guzman. Michael Guzman	[13193.384-13194.077]	quick. Sorry. Thank
-Director Guzman. Michael Guzman	[13194.424-13201.009]	you, Mr. Chair, for approving the travel consideration for lodging and assistance to go to the NTI Public Engagement course
-Director Guzman. Michael Guzman	[13202.458-13208.376]	in Florida. Really packed, but came in really handy because as soon as I returned, we held the town hall to do exactly what I was sent to go
-Director Guzman. Michael Guzman	[13208.747-13209.543]	learn about. So I
-Director Guzman. Michael Guzman	[13210.370-13215.310]	appreciate that. And I was grateful for the assistance from staff and from Director Ruscha to be able to host that
-Director Guzman. Michael Guzman	[13215.577-13215.577]	town
-hall. Thanks. Julien Bouquet	[13217.300-13218.757]	Secretary-- thank you,
-hall. Thanks. Julien Bouquet	[13219.263-13219.654]	Director Guzman.
-Secretary Nicholson. Chris Nicholson	[13219.654-13225.931]	I just wanted to flag that this weekend is the reopening of Downtown Celebration on Saturday
-Secretary Nicholson. Chris Nicholson	[13226.268-13233.356]	and Sunday. So if you like RTD, please come take it to downtown and enjoy our lovely food and all the other
-Secretary Nicholson. Chris Nicholson	[13233.694-13238.660]	cool stuff. Most of the mall is back and running and we're very excited about
-it, so. Julien Bouquet	[13238.988-13239.645]	Any
-it, so. Julien Bouquet	[13239.974-13239.974]	other
-it, so. Julien Bouquet	[13240.302-13241.616]	matters? OK. I got a
-it, so. Julien Bouquet	[13241.984-13243.817]	quick one. It's only going to take
-it, so. Julien Bouquet	[13246.197-13246.467]	19 minutes.
-it, so. Julien Bouquet	[13247.139-13255.058]	Just joking. My only other matter is please make sure that you Directors fill out that form that was due last week, extended to
-it, so. Julien Bouquet	[13255.515-13258.213]	Monday morning. Please make sure you guys take care
-it, so. Julien Bouquet	[13258.482-13258.752]	of that.
-it, so. Julien Bouquet	[13259.062-13259.252]	The survey.
-it, so. Julien Bouquet	[13259.743-13262.444]	Thank you. With that being said, do I have a motion
-it, so. Julien Bouquet	[13263.590-13263.954]	to adjourn?
-it, so. Julien Bouquet	[13264.317-13264.317]	Director Ruscha. Chris
-Gutschenritter	[13264.317-13265.771]	Second. Julien Bouquet: And a second
-Gutschenritter	[13266.195-13267.398]	from Gutschenritter. You guys all have a
-Gutschenritter	[13267.778-13286.461]	lovely night. Thank you all for
+Chris Nicholson	[5126.708-5242.172]	Yeah. So yeah, as a first thing, I would say that since we're going to be updating this to offer the LiVE discount and not make it free, it should be required as part of the process if you're going through to sign up for AOD or AAR, some point in that process, to ask someone to affirm that they are either already signed up or haven't signed up or whatever. And then give them the opportunity. Make it super easy because we only have 15,000 people signed up for LiVE right now, and we have 180 something thousand boardings every day. And I think only about half the people in AOD are currently signed up for-- or AAR are currently signed up for LiVE. So definitely something I'd like to see there. The second thing. I want to echo what Director Ruscha said about the effect on people who are low income to having these fares. But I want to take it from the other side, which is if you don't have a lot of money and you need to get around to a lot of places, then 40 trips may be, or whatever the number ends up being, not nearly enough in a way that someone who makes more money can probably have some discretionary to be like, oh, I've run out of trips. I can afford to take an extra three or five or whatever. So I'm not sure that needs to be fit into the policy here. I'm wary about trying to do too much too quickly. But I do think we need to get a report from you after, I don't know, six months, a year, that looks at how many trips are people on LiVE using. Are they maxing out? Or are we seeing the same curve from LiVE users as we do from regular users right now? And that might inform us to take action a year from now to try to offer the right service for people who need it. Some LiVE people make decent incomes, some of them are literally broke. And we need to recognize that those two groups of people have very different lived experiences.
+Julien Bouquet	[5243.209-5244.371]	Thank you, Secretary. Ms. Johnson.
+Debra Johnson	[5244.371-5280.990]	Yes, thank you very much, Director Nicholson. Thank you, Mr. Chair. Thank you, Director Nicholson, for the comments. And what I will say in reference to your request. It appeared to be a directive, but I would just offer this up to you. That once we collectively agree upon the path forward and this Board acts, we can then assess what might be most prudent, because at this point in time, we don't know what we don't know. And relative to what you just asked, I can't commit to that without knowing what we intend to do. So I just had to say that for the record, because it seems as if Ms. Vallejos was getting direction, and I don't think that's appropriate at this juncture. Thank you.
+Julien Bouquet	[5282.862-5283.563]	Thank you. Director Larsen.
+Matt Larsen	[5285.605-5328.509]	Thank you. I was just kind of doing some stuff on my calculator. So if we only have 3,000 people who use Access-on-Demand , I mean, it seems like the disabled population might be 300,000 people in Denver or something. Much, much larger. How confident are we of our projection that it will stay at around, I mean, or however much we think it will increase? I mean, what do we think the total number of active users might become? And why won't it become many multiples more than 3,000 or so?
+Debra Johnson	[5334.522-5383.271]	First, if I may. Just for everyone's edification, probably you have heard this over the course of several months in the public comment discussions. When we talk about Access-on-Demand, currently as it's configured, recognizing that we're using private entities, transportation network companies in particular, not all of the vehicles are outfitted to be wheelchair accessible. So that's a critical element when we're talking about the population, because there's different disabilities that individuals have. Some may have cognitive. Somebody may be using a mobility device which can't be accommodated going forward. So I just wanted to provide that context prior to Ms. Vallejos answering the question, because that has not been factored in to this conversation this evening, and I believe it's a germane point.
+Julien Bouquet	[5385.508-5385.922]	Thank you, Director.
+Erin Vallejos	[5386.632-5398.183]	And I don't think I need to add anything. That was really exactly what I was going to say. Not everyone is able to use the Access-on-Demand service that is eligible for Access-a-Ride. There is a difference there.
+Matt Larsen	[5399.152-5408.547]	Can I just follow up? But I mean, surely many more people than 3,000 in the metro area would be eligible, though. I mean.
+Erin Vallejos	[5408.547-5427.869]	Well, and again, we have continued to see substantial growth in the number of customers that are beginning to use the service. Again, the trips that we are seeing continue to grow even into this year. So we are seeing quite significant growth still.
+Julien Bouquet	[5428.595-5428.755]	Thank you.
+Matt Larsen	[5429.095-5429.275]	Thank you.
+Julien Bouquet	[5429.476-5441.728]	Thank you. Any further questions, comments? Ms. Johnson and Ms. Vallejos, thank you very much for the presentation. I hope this was helpful feedback for going forward. So thank you.
+Debra Johnson	[5442.573-5462.395]	Yes. Thank you, Mr. Chair. This was in the sense that we do have some guidance. Now we know what we need to do as we do further outreach. So thank you all very much for the opportunity. And when we come back in July with a recommended action, hopefully we can all rally around that, recognizing the public comments that we heard and the direction in which you provided. Thank you.
+Julien Bouquet	[5462.845-5463.947]	Thank you. Director Guzman.
+Michael Guzman	[5463.947-5467.723]	Will that recommended action be going through Operation Safety and Security.
+Julien Bouquet	[5469.756-5469.936]	Ms. Johnson.
+Debra Johnson	[5469.936-5483.909]	Yes. Thank you very much, Mr. Chair. And thank you, Director "Guz-min--" Guzman, I apologize, for the question. Most definitely, we will go through the committee procedure. The only reason why this didn't happen because it's time sensitive. So thank you.
+Julien Bouquet	[5484.931-5510.804]	Thank you very much. All right. Well, thank you again, Ms. Vallejos. All right, moving on. Thank you, Directors, for the questions and conversations. We're going to be moving to our committee reports. Not to be the time police or anything. We are at 8:31 PM and we've been going at this since 3:30. If committee reports could be less than a minute, that'd be greatly appreciated. Audit Committee Chair Buzek. What would you like to share?
+Vince Buzek	[5512.064-5518.788]	Thank you, Mr. Chair. We did not meet in April or May. Our next meeting is June 12, 2025. That concludes my report. Thank you.
+Julien Bouquet	[5519.158-5524.048]	Thank you very much. Finance and Planning Committee report. Committee Chair Guzman.
+Michael Guzman	[5524.048-5565.210]	Thank you, Mr. Chair. The Finance Planning Committee met Tuesday, May 13, discussed a handful of items, received a report from our state demographer, which was really awesome. Directors are reminded to email the Board Office if you had any follow up questions or things specific to your sub district, so we can send that all at once to receive an answer to the whole Board. Received an update from Doti for the East Colfax BRT, and three items came out of committee which will be before us tonight. Just want to thank the committee for all of the hard work. And the next meeting for the Finance and Planning Committee is scheduled for Tuesday, June 10 at 10:25-- or sorry, at 5:30 PM. Thank you.
+Julien Bouquet	[5566.613-5572.677]	Thank you, Director . Committee Chair Ruscha or Committee Chair Harwick, what would you like to share for OSS?
+Joyann Ruscha	[5573.962-5711.775]	I'll take it, sir. Thank you. So we met remotely on Wednesday, May 14. We gaveled in at 5:34 PM and wrapped up at 9:44 PM. We had extensive public comments, the most I've ever seen at any OSS meeting. That was great. Come visit us anytime. It's always nice to know that people are listening to our podcast, and by that I mean our YouTube channel. But two major items that went on the consent calendar for tonight's meeting. Is the 2025, 2028 Title VI program update. Just ensuring that we stay in compliance with federal law, Civil Rights protections, and meet the needs of our customers, as well as the Allied Universal Security Services Contract Extension. F&P authorized a budget transfer which had no financial impact. It was just moving from one department to another. And then we followed that up with a vote to extend that contract for another year, with the cost of up to just a little over 22 million. And we did have four discussion items, two of which were heard. So we had the Vision Zero update from GM CEO Johnson. As you might recall, we passed a Vision Zero resolution last year and so that planning process is underway. We had a customer communications update. Stuart Summers led an excellent presentation discussing how we handle communications, some tech updates, customer service aspects. It was real-time information and service alerts and things like that. Unfortunately, we did hit our four hour mark before we could finish our agenda items. And even though the Nuggets weren't playing, folks wanted to go and we were tired. So we moved the on-Demand item to tonight's meeting, which we just heard. And then we'll be hearing paratransit legacy customer protections proposal next month. So for those of you who have been tracking what we're doing with paratransit, I strongly encourage you to come visit us at OSS next month and weigh in so we get your feedback before we come back with something more final. Our next meeting is Wednesday, June 11 at 5:30. Same time, same place, online or on the phone. Thank you.
+Julien Bouquet	[5712.406-5716.576]	Thank you, Committee Chair. Now to for Performance Committee Chair Guzman.
+Michael Guzman	[5716.576-5891.066]	I got it. Thank you, Mr. Chair. Performance committee met Monday, May 12, 2025. I, the Committee Chair, presented a draft proposal that I had worked on previously with Vice Chair Gutschenritter for the 2025 General Manager/CEO performance assessment form and process that needed to be updated to seek input from the committee and other Directors to find a way forward for the rest of the year based on the current 2025 General Manager/CEO short term goals and the respective adjustments made to the scoring points based on our votes in January. I've received some feedback. I continue to invite Directors to submit their feedback. If you have not reviewed that meeting, please do so, and any questions you may have, please email me or call me. I am happy to engage in that conversation. Of course, we are doing that with participation and a lot of communication with the General Manager/CEO, Debra Johnson. The next meeting of the Performance Committee is scheduled for June 2, 2025 at 8:30 AM. I really want to encourage all of you Directors to please participate in that meeting. Two reasons. One, we are going to receive-- I hope I don't get this wrong because I don't have my work plan in front of me, but the employee survey results in the beginning of that meeting, and then we will adjourn into executive session for the second quarterly one-on-one opportunity with our General Manager/CEO. And that is part of our contracted agreement with the General Manager/CEO to receive information from her and provide feedback regarding personnel matters. Additionally, the Performance Committee is set to have a second meeting in June because of that quarterly check-in. The second meeting is planned, I believe, for June 23 at 8:30 AM, and that is in order to do a deep dive into our community and customer surveys, which align with our community value and customer excellence strategic initiatives. And I would again encourage all Directors to participate in that meeting as well, which is the overview of the current status of the agency's surveys and where we're at with regard to public. It will inform the process for setting goals and priorities for the 2026 year which we are also doing all at the same time. So prioritizing what is important for our customers, the survey reports are a great opportunity to engage with direct feedback from our constituents in all areas of the agency. And I do believe a little birdie has told me on one of the buses that these should be really positive discussions. So if you need more than that invitation, please signal tonight and I will call you and email you and hound you to be on these meetings, because I think they're really important for all of us. Thank you.
+Julien Bouquet	[5892.239-5939.430]	Thank you, Committee Chair Guzman. All right, moving on. We're going to do the approval of Board meeting minutes and committee reports. The Board and committee meeting minutes were included in the Board packet. Are there any corrections from the Board for the minutes to be approved this evening? Any corrections? All right. Unless there's objection to considering the minutes all at the same time, may I please have a motion to approve the minutes for the following meetings? The April 9, 2025 Operation Safety and Security Committee. The April 29, 2025 Board meeting. The May 12, 2025 Performance Committee. The May 13, 2025 Finance and Planning Committee. May 14, 2025 Operation Safety and Security Committee. And then May 22, 2025 Executive Committee.
+Michael Guzman	[5940.246-5940.786]	So moved. Guzman.
+Julien Bouquet	[5941.587-5942.058]	Mover, Guzman.
+Joyann Ruscha	[5943.610-5943.910]	Second.
+Chris Gutschenritter	[5943.910-5943.910]	Second.
+Julien Bouquet	[5944.891-6004.786]	I'm going to give it to Gutschenritter. So I heard Director Guzman as the mover and Director Gutschenritter as the second. Is there any discussion on this motion? OK. Seeing none, I'll now call the vote. Are there any no votes on this action? It'll pass 14, 0, and 1 absent. Excellent. All right. Moving on. It will be our Chair's report. Due to the late hour, I will be quoting my principal and saying, I am giving you all the gift of time. And all I can say with my Chair's report is we will have a Board retreat on June 7 talking about our 2026 priorities for the agency. Again, Directors, hopefully you all can make that. It'll be a very healthy discussion, a very hearty discussion, I guarantee, but please make sure you have that marked down in your calendars. Thank you.
+Chris Nicholson	[6008.662-6010.865]	Did you want to remind everybody about the survey we sent you?
+Julien Bouquet	[6011.085-6040.448]	Of course. Thank you. And of course, Directors, you'll see in my weekly biweekly update. There was a survey that might have been passed to you, and if you've not filled out that survey, please do so. Thank you for the Directors who did fill it in. So that's OK. If we could get that in by Monday morning, that would be excellent. I'll include that in my weekly update, though. Thank you. I'll give it now over to you, GM/CEO Johnson.
+Debra Johnson	[6040.448-6489.202]	Thank you very much, Mr. Chair. And to recognize the lateness of the hour, I just have a couple elements that I'll share with you that are in alignment with our activities and strategic endeavors since our last Board meeting on Tuesday, April 29. One notable aspect is the legislative conference held by the American Public Transportation Association from May 18th to the 20th in Washington, DC. Just for everyone's edification, this annual conference is an opportunity for Public Transportation industry professionals across the nation to visit Washington, DC and connect with policymakers, implementers, and their staffs. The conference helps educate and inform APTA members on important federal legislation and policy initiatives, and affords an unparalleled opportunity to shape the industry's positions in federal advocacy agenda. I, along with Directors O'Keefe, Chandler, and Gutschenritter, and Government Relations Officer Michael Davies, attended conference sessions and meetings with members of Colorado's congressional delegation and their staffs. While chairing an APTA committee meeting on Sunday, May 8, I personally engaged with Tariq Bokhari, who is the acting administrator of the Federal Transit Administration, who shared his views and inputs as it relates to public transit, as well as the importance of federal and local partnerships. Just yesterday, Tuesday, May 27, I, along with members of my team, met with individuals representing the alliance to transform transportation. As you may be aware, it's a coalition of groups on transit related matters in Colorado. Alliance representatives in attendance included executive Director of the Colorado Public Interest Research Group, Danny Katz, or CPIRG, as we refer to it. Jill Cantor, Executive Director of the Denver Streets Partnership. Portia Prescott, Present of the Rocky Mountain NAACP branch of the State Conference representing Colorado, Montana, and Wyoming. Dennis Hawkins, representing the Amalgamated Transit Union 1001. Matt Fromer, representing transportation and land use. Well, he is the Transportation and Land Use Policy Manager from the Southwest Energy Efficiency Project. The meeting really was focused on alliance's vision for transit in the Denver region. As you know, they have been very vocal in which they're seeking to increase funding for transit in the Denver region by $420 million per year to bolster the frequency and availability of transit services in the metro area. From RTD's perspective, questions were posed relative to how that $420 million figure was derived, and they explained how that came about with the work they had done with the third party entity. Very bare bones relative to providing some information. And then we talked about the agency's focus, which all of you are very well aware that we are laser focused on asset renewal, state of good repair, and rightsizing transit service in alignment with RTD's branded comprehensive operational analysis being the System Optimization Plan. Related to personal security. As was recently reported, RTD experienced a 60% reduction in security related calls for service, as well as a three year decrease in reports of criminal activities between 2022 and 2025 at Denver Union Station. The decrease is representative of concerted efforts to restore and maintain a welcoming transit environment within the critical multi-modal transit hub and following a collaborative and multifaceted strategy aimed at enhancing personal safety and security through crime prevention through environmental design methodologies. This effort would have not have been a success without the commitment of numerous agency employees, as well as support from the City and County of Denver, its police department, the Downtown Denver Partnership, Sage Hospitality, the Lower Denver Neighborhood Association, as well as several local businesses in downtown Denver residents. Fare enforcement has also increased in recent months, which is the result of RTD's growing ranks of sworn police officers having been trained to perform this function alongside the contracted team that we have in security with Allied Universal personnel who had primarily been responsible for this responsibility. I look forward to sharing additional details regarding the impacts of these efforts during the June Performance Committee, which you heard committee Chair Guzman reference when I, along with staff, will present data related to annual customer, community, and employee surveys that have recently concluded. On a related note, the agency has proactively increased its transit police officer presence at Denver Union Station and across the agency's downtown Denver sector to support the personal safety and security of customers and visitors attending major events and activity. Notably, while we're no longer in the hockey playoffs and NBA, but people had a welcoming experience in and around our facilities, and RTD PD had increased patrols at Denver Union Station and bus stops and rail stations before the high profile events, which included the playoff games I just referenced. And this coincides with increasing Denver Police patrols throughout the Downtown area. And RTD and DPD are working closely to collaborate to support enhanced safety for the traveling public. And moreover, data and metrics related to personal safety and Security are now conveniently located on the recently created security related metrics page, and we've actually showcased that on other social media channels as well. As it relates to our customer excellence in relation to the strategic priorities of customer excellence and employee ownership, I shared yesterday with the Board the last of the 31 light rail speed restrictions put into place last year on the D, H, and E and R lines was lifted as of yesterday morning. I want to give a special shout out to our Maintenance of Way teams that have done yeoman's work. The final speed restriction, which was approximately 400 feet in the southbound segment north of Southmoor Station, was removed after crews completed those repairs. Keeping in mind those rigorous restrictions were put into place due to the fact that we enhanced our inspections of track back in May 2024 as an enhanced focus on maintaining the agency's assets in a state of good repair. At the time, crews found several minor issues and track imperfections. So, as I said before, I thank and congratulate all the agency employees who work tire-- I'm tired-- tirelessly over the course of these 11 months. And like I said, a special shout out to MOW. I would be remiss if I didn't state that while this is a cause to celebrate, I shared previously, as we look at our infrastructure and it continues to age, this will be par for the course. But since we're ahead of where we were before, we will see less of an impact, I'm certain. And last, but certainly not least, I'm pleased to welcome RTD's new Chief Financial Officer, Kelly Mackey, who's in the audience. She's giving a wave. Who began her tenure on May 12. And this is her first in-person Board meeting. While we introduced her at the Finance and Planning Committee, you guys are real people, not figments of our imagination, so I wanted to ensure I did that here. So with that, I will yield the floor so we can move on to the rest of the matters that we have before us. So thank you very much, Mr. Chair.
+Julien Bouquet	[6492.160-6497.262]	Thank you, GM/CEO Johnson. Any comments or questions for GM/CEO Johnson?
+Chris Nicholson	[6500.855-6500.855]	Just [INAUDIBLE].
+Julien Bouquet	[6500.855-6565.967]	Yeah. Very exciting. And Kelly, welcome to the team. Thank you. All right. Moving on. We're going to move on to unanimous consent. There are three items on the unanimous consent agenda listed under Section 16, actions A through C. Those items are the security operations budget transfer, the 2025-2028 Title VI program update, and the Allied Universal security services contract extension for one year. I do understand that Director Benker would like to offer some amendments to item B, the 2025-2028 Title VI program update. And such, I will move that our a recommended actions. Excuse me. If anyone else has a change to discussion on or questions about any of the remaining unanimous consent items, please feel free to advise the Chair at this time and I will, of course, be happy to pull the item from unanimous consent for consideration under recommended action. Director Nicholson.
+Chris Nicholson	[6565.967-6571.015]	The Allied Universal security contract. Please pull that.
+Julien Bouquet	[6571.705-6589.199]	OK. So item B will be removed and placed into recommended action Excuse me. Former item C, as I look in real time here, the Allied Universal security. So are we OK with security operations budget transfer?
+Troy Whitmore	[6593.919-6597.994]	I would move to approve the remainder of the unanimous consent agenda.
+Joyann Ruscha	[6598.726-6598.726]	Second.
+Julien Bouquet	[6599.667-6651.806]	OK. I have Whitmore and then Ruscha as a second. Are there-- OK. So this is item A for the Board of Directors to approve a budget transfer of $3,845,437.10 between operating expenses lines for transit security services. Is there any no votes on that? OK. Seeing none, that item will pass 14-0-1. All right. Now we're moving on to our recommended action items. And we're going to have first on our list the Allied Universal security services contract extension for one year. Is there a motion?
+Chris Nicholson	[6653.148-6653.548]	So moved.
+Julien Bouquet	[6653.969-6662.311]	OK, Nicholson. And a second. And Ruscha. All right. Any discussion? Director Nicholson?
+Chris Nicholson	[6662.311-6681.699]	Yeah. So I just have a quick question about this one that came from a constituent. How many people do we have working on our security side from allied? And how many do we have from RTD PD right now? Thank you.
+Julien Bouquet	[6683.100-6683.261]	Ms. Johnson.
+Debra Johnson	[6683.261-6687.857]	Yes, I will yield the floor to Chief Martingano, who can address that question. Thank you.
+Julien Bouquet	[6690.591-6690.942]	Chief Martingano.
+Steve Martingano	[6690.942-6695.882]	I am trying to figure out. Oh, there we go. Turned green. Chair, for me?
+Julien Bouquet	[6696.171-6696.171]	Yes.
+Steve Martingano	[6696.551-6727.642]	Yeah, so technically, in regards to how many Allied personnel, it's an hourly contract. So you'd have to take the amount of the hours and obviously divide it by 40. It roughly equates to the recommended action for next year. I think it's about 9,100 hours. So it roughly equates about 180 security officers. Right now, we currently have 87 on our staff in regards to post-certified police officers. We have a couple in training and one in the academy. We should be probably about 90 by the end of next month.
+Julien Bouquet	[6728.308-6731.592]	Thank you. Secretary.
+Chris Nicholson	[6731.592-6771.257]	This is for GM/CEO Johnson. Are there any plans in place or-- and please feel free to not answer this if you can't. But I know there's been a drawdown over the last few years in our reliance on Allied Security. Is there anything in this contract or in your planning around this contract or anything that can give us guidance on whether we expect that to continue after authorizing this, or are we expecting to stay at 90 something hundred or 180 people over the next few years?
+Julien Bouquet	[6773.134-6773.134]	Ms. Johnson.
+Debra Johnson	[6773.134-6817.178]	Yes. Thank you very much for the question. As Chief indicated, this is a contract extension and there's hours that are specified, hence in reference to the dollar amount that we have here. I would have to come back to the Board as it relates to any type of authorization as we're doing now currently with this contract extension, if that were to be modified. So on this point in time, it would stay the same. Unless there's some extenuating circumstances whereby we go out for a solicitation and we're not able to ensure that we're meeting the timeline before, since that's why we're here now with the contract extension. Quite naturally, in doing so, we have to ensure that we have the appropriate staffing levels. So I'm talking around and around in circles right now, but the answer would be no at this point in time.
+Julien Bouquet	[6819.014-6823.499]	Secretary. Perfect. Second Vice Chair Whitmore.
+Troy Whitmore	[6823.720-6833.783]	So, Chief, jog my memory on our goal for the end of the year for sworn officers. It's not 90, right? It's continuing to grow.
+Julien Bouquet	[6834.713-6835.452]	Chief Martingano.
+Steve Martingano	[6835.452-6860.350]	Yeah. So we are budgeted for 150. We're still in the process of growing to those numbers. So obviously with applications, background checks, everything else, we're heading positively toward that. We're putting eight more in the academy here in June. We continue to get lateral transfers. I'm sorry, lateral applications from other agencies, officers with experience. So we're hoping to hit 150 goal by the end of the year.
+Troy Whitmore	[6860.593-6865.027]	All right. Thank you very much. I did have the right memory up here. Thank you, Mr. Chair.
+Julien Bouquet	[6865.338-6871.517]	Absolutely. Any other-- well, any further questions or discussions on this? Yeah, Director Ruscha?
+Joyann Ruscha	[6873.546-6920.733]	Thank you, sir. So I just wanted to note, in the past, upon request, the agency has provided a breakdown of how many-- just our security personnel from RTD to contracted and even break down in terms of with our contracted Allied force, like the ones that are authorized to have firearms versus not and our mental health staff and stuff. So that's something that I think the agency-- I'm sure the agency would be happy to provide that breakdown chart. I think it's been a little over a year since we've had one, so I just wanted to offer that to those who are interested and just to piggyback on Secretary Nicholson's comments. Thank you.
+Julien Bouquet	[6921.203-6958.192]	Thank you, Director. Any further comments or questions? OK. Seeing none. So I did have-- thank you, Chief. I did have Nicholson as the mover and Ruscha as the second. Are there any no votes on this item? OK. Seeing none, the item will pass 14-0-1 absent. We are hitting our two hour mark, so we are going to take a break for our CART employee. Let's shoot to be back here 9 o'clock. Would that be enough time? Nope? OK. OK. Let's do 9:05, then.
+Chris Nicholson	[6959.002-6959.273]	Thank you.
+Julien Bouquet	[6959.563-7236.960]	Thank you. We'll be back at 9:05. All right. Thank you, everyone, for your patience. We are now moving on to our next recommended action for tonight. And that is going to be the recommended action of the 2025-2028 Title VI program update to comply with federal laws, regulations, and guidelines related Title VI of the Civil Rights Act of 1964. Do we have a motion?
+Peggy Catlin	[7237.295-7238.300]	So moved.
+Julien Bouquet	[7238.635-7240.980]	I have Caitlin as the mover.
+Michael Guzman	[7241.315-7242.320]	Second, Guzman.
+Julien Bouquet	[7242.655-7288.041]	Guzman as the second. I do understand that Director Benker has two amendments she would like to offer on this item. Director Benker, we'll take your amendments one at a time. What is your first amendment, Director Benker?
+Karen Benker	[7298.722-7786.716]	Thank you very much. And I'm glad everybody is now second wind and we're ready to go on to our, I don't know, six or seventh hour of meeting. Actually, I will tell you, I have three. We'll see how things go. They're short. The first one-- well, let me give you a little bit of background. So the background is I met with my four cities back in February and March. And of course, you meet with them and you say hi and you say, OK, what are your needs? What are your wants? I met with all of them, and they all gave me a list of basically trying to restore service that was removed during the pandemic. And so of course, as is my job as Director, I'm trying to work with our staff to try to get that service restored. And so one of my questions or issues is I am guessing that when the RTD Board had to make the hard decisions of how to cut service almost in half because of this highly unusual pandemic, perhaps some of these cuts were not done equally across all 15 districts.
+Julien Bouquet	[7787.438-7794.532]	Director Benker, I'm sorry to interrupt. Just so that we keep an order, could we get a second on-- could you read the motion and then we get a second?
+Karen Benker	[7794.705-7818.370]	The motion is change the threshold for disproportionate burden and disparate impact from 10% to 20% as it relates to major service changes and consistent with the FTA circular 4702.1b. And I believe the version that will be voted on is actually the version that Mr. Kroll put up for us.
+Julien Bouquet	[7819.755-7840.894]	So that's the language right there. The first motion is to move to amend the 2025-2028 Title VI program update, such that the threshold for triggering either disperportionate burden-- or disparities in-- disparate impact finding-- late night-- finding arising from a major service change from 10% to 20%. Do I have a second?
+Brett Paglieri	[7842.115-7842.115]	Second, Paglieri.
+Julien Bouquet	[7842.115-7844.497]	Paglieri is the second. Thank you.
+Karen Benker	[7845.488-7958.306]	So just to continue a little bit more background, and then we can start, I guess the debate here. I'm just trying to get service restored that was eliminated during the pandemic. And there have been a couple of times now when I have requested and the answer that I have gotten several times is, well, it's going to depend on how the equity analysis calculations come out. And so I'm just trying to find ways where we can perhaps start to restore some of the service that had been eliminated during the pandemic and perhaps do it a little bit quicker and also try to make it not quite so difficult. So then what happened, of course, is everyone received about a week, 10 days ago, a letter from the City and County of Broomfield. And their transportation staff went through our items quite closely, and they sent us all a letter with recommended changes. So I've gone through with their changes, and that's where I've come up with the three amendments that I'd like to at least talk to the Board, see what your thoughts are. Hopefully it'll pass, but we'll see what happens. But it's just basically what City and County of Broomfield had found when they did their research is that the RTD is using some very conservative calculations compared to some of the other large transit agencies. And so I did send you also a copy of the City and County of Broomfield's letter, just to refresh your memory. And so I would like to put forth that the first amendment would be changing the threshold from 10% to 20%.
+Julien Bouquet	[7959.030-7967.229]	Thank you, Treasurer Benker. So again, the discussion right now is on the motion, this first motion, the first amendment. Director Catlin.
+Peggy Catlin	[7967.229-7987.134]	Thank you, Mr. Chair. I'd like to ask GM/CEO Johnson. I heard from someone-- I don't remember now because it's getting late. But someone said that some of those assumptions made by City and County of Broomfield were incorrect.
+Julien Bouquet	[7989.036-8043.685]	Ms. Johnson. Yes thank you very much relative to the comments that were made-- and thank you very much, Director Catlin-- as it relates to the transit agencies that were mentioned, being MARTA, the Metropolitan Atlanta Rapid Transit Authority, Los Angeles County Metropolitan Transit Authority, King County Metro, which is in greater Seattle, and the Chicago Transit Authority. That information, especially coming from LA Metro as the former Chief Operations Officer there, this is not correct relative to where we sit. And more specifically, I do know our Director of Civil Rights, when we were going through this, quite naturally in the role that he is in, he and his team did a desk audit and worked with colleagues at different transit agencies. So that's the communiqué that I did disseminate yesterday upon receiving this information. So, Mr. Green, if you want to just expound succinctly and briefly.
+Carl Green	[8044.495-8174.863]	Yes. Thank you so much, General Manager and CEO Johnson. To expand upon the response, I just also want to ground us and first state that it is our collective responsibility to make federally compliant and equitable decisions, especially as it relates to service changes. And in doing that audit, we looked at 22-- rather, 23 different organizations, which includes the four, MARTA, LA Metro, King County, and the Chicago Transit Authority. And I would say the way to look at the disparate impact or disproportionate burden, the framing of it is how sensitive or less sensitive versus more sensitive, right? And ours is stacked in the middle. So I want to give you some numbers here. So for the four that I just mentioned, MARTA has 10%, LA Metro has 5%, King County has 10%, CTA or Chicago Transit Authority has 15%. And then when we rack and stack, look at those 22 different organizations, 6 out of that 23 have 5% or less. Two have 8%. Six, which includes us, or seven including us, is at 10%. Three at 15%. And then three at 20%. And in my over eight years of doing this work, I'll just say that when you are setting your policy, you don't want to do a disservice to the spirit and the letter of what we're ultimately trying to achieve specifically with Title VI. Title VI is not a stopping mechanism of bringing back or restoring service. There are a lot of different variables, as I mentioned before, with respect to our service development guidelines, our operators resources, so on and so forth. This is just a mechanism for the agencies such as RTD and the Board of Directors so we don't get too far over our skis without discounting populations that are more likely to be transit reliant. So again, it's not a stopping mechanism, but this is just more so to make sure that we are taking into consideration all of our customers.
+Julien Bouquet	[8177.200-8179.074]	I have Director Ruscha next.
+Joyann Ruscha	[8184.407-8191.225]	OK. I did have a question, but also Treasurer Benker had her hand up, and it was her motion, so I'm happy to wait if that was in response.
+Julien Bouquet	[8192.234-8192.514]	Treasurer Benker?
+Karen Benker	[8195.277-8239.519]	I feel that we are in an extremely unique situation because of the pandemic. So how can we restore, let's say 40% of the service that had been cut several years ago? How can we get back to 2019 when my district, other districts had that service? And so now we're being told that we can't get that service back because of this conservative calculation that we're doing, but we used to have it. And so how do we get from where we are now to bringing service back to pre-pandemic levels?
+Julien Bouquet	[8241.237-8241.437]	Ms. Johnson.
+Debra Johnson	[8241.437-8424.121]	Yes, thank you very much. Director Benker, that question is better suited for me. Relative to the service delivery framework that we have, while Title VI plays a role relative to major service changes as we talk about how we deploy services based upon a myriad of different factors relative to our revenue service hours. But more specifically, at how we use our comprehensive operational analysis specifically as we talk about the SOP. When I came into this organization, it was decided that we were going to look at 85% of what service levels were-- 85% of what service levels were in 2019. We were in a different time relative to the commuting patterns, relative to how people were working going forward. What I will share is that we are being very diligent and judicious in how we're applying service, because we do want to ensure there is equity. I'm going to speak a little bit out of school here because I shared this with you yesterday, but I'll say it in this context as well. As we talk about Longmont and we talk about service, we are looking at that for the fall service change. That is up to the Board, quite naturally. But I did want to put that forward because with the restoration of service, keeping in mind that all transit agencies across the US were in these precarious positions and the Federal Transit Administration more or less provided waivers, waivers from the sense of how we were decreasing service due to the fact that we didn't have enough people power. Also, we currently are still working under a waiver as it relates to our spare ratio. What I mean by that is when you deploy service in the mornings and in the afternoons with the peak, you have a certain pullout rate and you're only supposed to have a 20% spare ratio. We've deviated from that and have a waiver, and we're rightsizing the fleet as we move forward. So while you're bringing up these points, as you indicated, we are in uncharted territory, or were, and we're coming back from that. We are looking at where there are needs relative to the entire area, from an origin and destination vantage point, just by virtue of how our service area is going forward. So I'm not providing this to say I don't understand what you're trying to do, and as I share it with you, I do clearly, and we want to work within the framework that we have. But a wholesale of restoration of what was happening in 2019, that wouldn't be fiscally responsible. And I say it from the vantage point of we had a lot of service that was out on the street, maybe that yielded one passenger boarding per hour, but that was out on the street. Does that really yield the return on investment going forward? Hence that's why there were modifications relative to reallocation of services going forward.
+Karen Benker	[8425.220-8426.390]	OK. But if I can--
+Julien Bouquet	[8426.823-8427.806]	Treasurer, yeah.
+Karen Benker	[8428.868-8478.393]	Some of the issues that you just raised are important. There's no doubt. However, I don't believe it goes to the equity calculation. What I think is important to hear from staff-- and I know we're going to be talking about this at our retreat, which I'm looking forward to that-- is if it's possible for us to go back to over 100 million riders in three years. What barriers are we facing to try to do that so that we can go from 65 million to 100, 106, 110, and start quickly-- or not quickly, but faster than what we're doing now to get back up to higher service levels?
+Julien Bouquet	[8480.810-8481.010]	Ms. Johnson.
+Debra Johnson	[8481.010-8635.381]	Thank you. There's a couple of external factors that play into that quite naturally. When we look at the central business district and the occupancy rate in the lack of people commuting in, it's important to keep in mind that there was-- I'm forgetting the name, but the City and County of Denver did the report relative to the usage rate in looking at the occupancy levels. But more specifically, what's important to note is that there hasn't been the level of bounce back relative to the central business district. I believe the last time I looked at stats, City and County of Denver was in the bottom three out of 50 major cities. And then as we know, the state of Colorado is the number-- is the third state relative to remote work and then city of Boulder is number one. While I factor that in, we don't have the same operating environment that we did in 2019 or prior to the pandemic. How do we get back to the transit usage that we had before? I think there's so many extenuating factors going forward relative to how we're delivering the service, but also having the vehicle capacity, the people power, and the reliability aspect, which bring us full circle to state of good repair, and the other aspects that have caused people to shy away from utilizing our network because we were sacrificing one element for something else relative to delivery. And I bring that up because as we talk about the people power, we clearly saw that our operating workforce was decreasing in 2016 as it was across the country, but more specifically, having other ancillary services that were readily available were people whereby were working extra shifts, and then we didn't have enough people for daily pull out on those other routes. And so I'm providing that context to say, to get back, there are certain things that the agency can surely do. But to get back to those numbers within the period of time that you specify would be very challenging, just because of the different operating characteristics that have been altered by factors that are no fault of this agency's.
+Julien Bouquet	[8637.854-8638.315]	Director Ruscha.
+Joyann Ruscha	[8638.315-8678.722]	Thank you, sir. So I have a question for legal. So recognizing this has to be submitted shortly, I-- I'm going to be careful with my words. Can we make significant changes at this juncture after all of the public comment process? Or is that something that we-- I guess I don't know if it's a yes, no, or a gray area, and I wanted to get a bit of feedback on that. Not to disparage the motion. I just also want to understand the potential legal implications.
+Debra Johnson	[8684.175-8753.579]	I will address that question and then I'll ask Mr. Green to expound. I think if anything, as we talk about public engagement and talk about the agencies, the perception of the agency being trustworthy, going forward and getting public engagement quite naturally and then not leveraging it for the betterment of the constituencies that we serve, I think, pose a risk as it relates to the agency in reference to the public perception. There is leeway relative to the circular in light of what can be done. We are sitting here on May 28, recognizing that we have a new administration and that we do need to have a Title VI program that's submitted, and we have been engaged on this topic since January. That's not to negate any amendments or anything like that. I am just trying to answer the question. But more specifically, Mr. Green, since you are very well versed in 4702.1b, would yield the floor to you. And that's the citation for the FTA circular that we're talking about.
+Carl Green	[8754.359-8762.388]	Yes. Thank you so much, GM/CEO Johnson. Oh. Apologies. Apologies.
+Julien Bouquet	[8762.855-8764.050]	Sensitive microphone.
+Carl Green	[8764.291-8836.518]	Yes. Apologies. But to piggyback off of what GM/CEO Johnson has noted, I would couch that as the bigger risk is when we think about establishing policy as it relates to 4702.1b, the FTA Title VI circular, it does call upon the agency to do a lot of outreach and public involvement to ensure that we are collecting that feedback to inform decisions. So at the ground level, if we think about public involvement in Title VI, it's part and parcel of what the Title VI program stands for, ensuring that folks in the community are able to inform the decision, such as the policy. But with respect to the circular, we can, i.e. the Board of Directors could adopt a different threshold. So, for example, the one that Director Benker has put forth. Although we received a lot of feedback indicating the 25% threshold and 36 month cumulative change, et cetera, all that's packaged in within the proposed update, there is an exception to that within the circular where it states where the Board is ultimately approving the policy.
+Julien Bouquet	[8838.768-8848.753]	Thank you. Director Ruscha? OK. Director Guissinger and then Director Larsen. Oh, perfect. Director Larsen. And then Harwick.
+Matt Larsen	[8851.219-8980.751]	Thank you. I guess my question is, I looked through a lot of the Title VI updates that were for service changes, this Title VI analyses that were in the Board packet. And it seemed like most of the time-- sometimes there was a little bit of disparate impact on one route or the other, but mostly it sort of ended up that, in the aggregate, there wasn't really much, and there were legitimate justifications for what there was on an individual basis. I guess my basic question is with regard to this update and the changes that we're proposing. I mean, is there really a problem here? Are we just making this harder for ourselves? Because it doesn't seem like we're trying to generally start out making service changes with an intention of causing disparate impact, one place or the other. We make them, I guess, for a variety of reasons, and on balance they don't really seem to, under our current setup, ever, ever look like they were somehow some bad intent or just inattention to who we are serving. It seems we do a lot of analysis and then basically do what we would have done anyways. So why put a greater burden, regulate ourselves more than we have to? And why not just give us the freedom to operate as we would as much as we can, given that we don't-- it doesn't necessarily seem like it's been a problem for a long time? At least from what I could see. I mean, there weren't that many Title VI complaints in the information that was provided. I don't know. My basic question is, why would we make things harder for ourselves? Thanks.
+Julien Bouquet	[8982.762-8983.687]	Thank you. Ms. Johnson.
+Debra Johnson	[8983.687-9040.532]	Thank you very much. The one thing I would share, Director Larsen, is we look at the modification that's been put forward for your consideration, like a 36 month period as we're adding back service. There could be unforeseen consequences as we do them in a segmented fashion. And so that's one element as a whole. Because if we're making modifications going forward, there could be an adverse impact. And so that's what I would showcase there. Keeping in mind to the point that you raised. When we talk about the aspects of DIDB, it's what can we do as an agency to help mitigate that to your point going forward. But it's just to ensure that we have a program whereby we are not causing undue harm to certain population segments.
+Julien Bouquet	[9043.158-9043.158]	Director Larsen.
+Matt Larsen	[9043.158-9105.549]	But it just seems like, when I was reading the documents, that there's always a legitimate justification for everything we want to do or there's always this will have a disparate impact but we have a legitimate justification for doing this so we're just going to do it. I mean, how many times in the last however many years has it been that we did this analysis, we looked at all the service changes we wanted to do, and we were like, OK, no, we're not going to do this list of service changes. We're going to cross out these ones because the aggregate impact is too much. I mean, does that happen? I just didn't-- from what I read in the packet, I don't know if I caught everything, but it didn't seem like there were a lot of those. Or is this happening at an earlier stage where when Bob and service says, let's just send a bunch of buses to Cherry Hills Village, somebody says, no, no, that's not going to work out, before it even gets to this point. You know?
+Debra Johnson	[9108.102-9131.911]	I'm sorry. Thank you for the question. For me, I've only been here for five years, and I came in the height of the pandemic, and we've been adding back service and not. So that's difficult for me to answer just because we have not been in a situation whereby it's been the opposite. Carl, do you have anything to add?
+Carl Green	[9132.838-9212.885]	Yeah, I would just highlight, Chairman, if I may. Since January 2023, there was about 270 service change recommendations that have been implemented, and roughly 24-26 of those 276 were considered major service changes. And out of that 26, to Director Larsen's point, there has been 13 potential disparate impacts. And to your point, there was a substantial legitimate justification. I wouldn't necessarily couch it as an exercise, but I would say we work, the Transit Equity Office within the Civil Rights Division, works hand in glove with Jessie Carter and his team, Service Development. And as we are having those conversations after the service change recommendation are put forth and we analyze it, if there is a potential disparate impact, more often than not, to your point and to my earlier earlier point, that Title VI is not a stopping mechanism. And I wouldn't necessarily state that it's burdensome because it's one of our responsibilities to make sure that we are equitably distributing services across our service area. But more often than not, there is a legitimate justification to put forth the service recommendation as it is presented to the Board.
+Julien Bouquet	[9215.941-9234.941]	Thank you. Director? OK. I had Director Harwick. And just as a reminder, we're currently in discussion regarding this first motion. Just want to make sure that-- first amendment, excuse me. First amendment. So make sure comments are around that. Director Harwick.
+Ian Harwick	[9234.941-9322.319]	Mine will be comments about this but also moving forward as well, because I am in support of this Title VI. Not the amendment, just a straight Title VI. I don't think moving from 10% to 20% is going to increase ridership. I think that right now it allows our staff the ability to really center equity and effectively protect our communities. And while I get that Broomfield feels like they want more service, I don't think this is going to get it there. I think this is the 11th hour, and I think that it's really imperative that our staff has worked extremely hard on this. They've had to jump through a whole variety of hoops for a bunch of different Board members. And I think that we're here, they've done an incredible job. And I think that this is-- they are the subject matter experts, and it's our opportunity here to put our trust in them, our belief in them. And I think that we owe them that. And we have been talking about this since January, so we're well into four months. And I think that it is key that we support this Title Vi as is, and we allow them to move forward and we allow them to start handing this off to the feds and we can move forward. That's where I'm at. Thank you.
+Julien Bouquet	[9322.819-9328.154]	Thank you, Director. Any further conversation on this amendment? Secretary Nicholson.
+Chris Nicholson	[9328.154-9357.593]	So this is for our deputy General Counsel. If we were to pass this tonight, what's the legal risk to the agency when it comes to our federal Title VI approval as a result of this change? Is this going to have any-- would this have any legal repercussions or could we just feel pretty comfortable that we could do this and not have the federal government take issue with it?
+Julien Bouquet	[9359.319-9360.437]	In regards to the amendment, Secretary?
+Chris Nicholson	[9361.222-9361.222]	Yeah.
+Julien Bouquet	[9364.745-9365.046]	OK. Deputy Counsel.
+Melanie Snyder	[9369.252-9373.646]	There we go. Excuse me. Thank you, Director Nicholson. I don't have concerns.
+Julien Bouquet	[9376.785-9376.785]	Secretary.
+Chris Nicholson	[9379.028-9379.389]	That is all.
+Julien Bouquet	[9380.771-9381.523]	Yeah, Treasurer Benker.
+Karen Benker	[9383.856-9448.682]	Here is where I do not understand. In 2019, we had the service. My area, my district, as many others, have grown. For example, the town of Erie just a few years ago was 20,000. Now it's 40,000 two, three years later. And when I met with Erie, they said, hey, we're planning on going to 80,000 in just the next couple of years. I also read in the Denver Post that the town of Erie is the 15th fastest city in the country in terms of population growth. So my question is if we had this service prior to the pandemic and it was serving all of these communities, why is it so difficult to get that restored?
+Julien Bouquet	[9453.332-9453.642]	Ms. Johnson.
+Debra Johnson	[9453.642-9553.176]	So thank you, Director Benker. What I'm going to say goes back to the previous comments that I had before, recognizing that RTD is a regional service, and the way the service was outlined, for all intents and purposes, was bringing individuals into the central business district. That level of ridership isn't there. And that's not to negate that there is some elements centered on a need to move people to and fro. Hence, that's why there was the advent of the partnership program and one of the reasons why Erie basically wanted to join the district, because they were looking to put forward an application for the partnership program. And I know you're just using that as an example, but just wanted to further iterate that, because for all intents and purposes, as we're looking to provide mobility options, the intent behind the partnership program was more or less like a pilot in the sense that let's see how many people are utilizing this means of connection prior to putting out a 40 foot or 60 foot R tick that costs more money per revenue hour and doesn't yield the same return on investment relative to the cost per boarding. Does that help or did I complicate it more? No? OK.
+Julien Bouquet	[9554.518-9556.600]	Thank you. Director Guzman and then Director Guissinger.
+Michael Guzman	[9557.661-9652.496]	So I would urge us to cleanly pass this through tonight, getting back to the motion before us, I would like to ask one question, which is the 10% to 20% is still not going to prevent us from adding services. It is simply a filter through which to look, if I understand this correctly, that we are not unintentionally harming community with protected status under the Title VI legislation, or those that might be disproportionately burdened or impacted by their financial and economic status within the region. The only purpose we need to pass this is because it is due, because it is the law, and it is how we ensure that we are able to receive our federal funding, which is approximately 25% of our total budget. So I just want to make sure I understand. What has been presented here does not tell the Board, no, we cannot provide transit service. It is simply a way to look at it and say, we may have an issue if it reaches a certain threshold that we need to be aware of in order to be able to approve changes in service, fare changes, or other changes that would create a potential burden on specific communities as defined within the Title VI language. Is that correct, or am I completely lost in this conversation?
+Carl Green	[9654.711-9655.328]	Chair, OK for me?
+Julien Bouquet	[9655.832-9656.379]	Absolutely, Mr. Green.
+Carl Green	[9656.379-9726.683]	If I'm tracking Director Guzman, I'll try to answer the question from what I hear, and if you have any double back, then I'll respond to it. So the current 10%, so if we think about different thresholds for DIDB and we are in-- based off of the desk audit, we're in the middle tier of having a threshold that allows us as an agency, which ultimately each service equity analyses is approved by the Board of Directors, where it allows us-- again, to your point, when we're thinking about BIPOC or Black, Indigenous, people of color for disparate impact or low income communities for disproportionate burden, it allows us to make a well-informed, eyes-wide-open decision of better understanding of who's more likely to receive more of the impact. And when we're thinking about service increases, we're thinking about the fair share of benefits where if there is a service reduction, we're looking at who's more likely to receive more of the burden. So to your point, Director Guzman, it allows us to just get a better understanding of the level of impact that we can have on a particular community. It does not prevent us from moving forward.
+Michael Guzman	[9729.089-9736.330]	Thank you. I would just urge a no vote, and let's move on to the policy.
+Julien Bouquet	[9737.700-9743.505]	All right. Director Guissinger, I'm going to have you as our final comment on this specific amendment.
+Lynn Guissinger	[9744.061-9761.663]	I'll be super quick. That last explanation that Mr. Green gave helped me in terms of just giving us a better holistic view. But I shared Director Larsen's view of, are we just making this harder for ourselves, creating more work? Is that not right?
+Julien Bouquet	[9763.445-9763.676]	Mr. Green.
+Carl Green	[9763.676-9849.241]	Yeah, that's a great follow up question. I wouldn't say it's making it harder because when we think about what we're ultimately trying to achieve and a percentage that's mathematically consistent relative to the populations that we serve. So in doing this work, given my background, and doing an assessment of whether if we-- and that's why we didn't want to make any modifications of increasing or decreasing the major service change, we just wanted to keep it consistent, is with doing this work or even doing an analysis of previous run boards or equity analyzes, 20% is something where you wouldn't see anything. And that's a disservice when we think about our populations within our service area, specifically, as we look at our Census data, where 38.1% is BIPOC, 13.1%-- or 14.1%, rather for low income. Right? And then if we look the onboard survey, 56% are considered BIPOC. And so I say all that to say, just to wrap it up, is that 10% threshold for DIDB allows us to make an informed decision that is backed by not only our desk audit, but the years of experience and knowing, having a better understanding of ultimately what we're trying to achieve.
+Lynn Guissinger	[9852.179-9852.550]	Thank you.
+Julien Bouquet	[9852.940-9869.475]	Thank you. All right, let's do a roll call vote. As a reminder, it is the first amendment being introduced, as you all can see on that screen, with Director Benker as the mover and Director Paglieri as the second. Again, we're voting on this first amendment. Treasurer Benker.
+Karen Benker	[9870.636-9870.636]	Yes.
+Julien Bouquet	[9871.677-9873.909]	Director Buzek is gone. Director Catlin.
+Peggy Catlin	[9875.841-9875.841]	No.
+Julien Bouquet	[9876.901-9877.502]	Director Guissinger.
+Lynn Guissinger	[9880.725-9880.725]	No.
+Julien Bouquet	[9882.183-9882.684]	Director Gutschenritter.
+Chris Gutschenritter	[9883.024-9909.223]	No.
+Julien Bouquet	[9909.223-9909.223]	Director Guzman.
+Michael Guzman	[9909.223-9909.223]	No.
+Julien Bouquet	[9909.223-9909.223]	Director Harwick.
+Ian Harwick	[9909.223-9909.223]	No.
+Julien Bouquet	[9909.223-9909.223]	Director Larsen.
+Matt Larsen	[9909.223-9909.223]	No.
+Julien Bouquet	[9909.223-9909.223]	Director Nicholson.
+Chris Nicholson	[9909.223-9909.223]	Yes.
+Julien Bouquet	[9909.223-9909.223]	First Vice Chair O'Keefe.
+Patrick O'Keefe	[9909.223-9909.223]	No.
+Julien Bouquet	[9909.223-9909.223]	Director Paglieri.
+Brett Paglieri	[9909.223-9909.223]	No.
+Julien Bouquet	[9911.900-9912.434]	Director Ruscha.
+Joyann Ruscha	[9912.611-9912.967]	No.
+Julien Bouquet	[9913.145-9915.856]	Director Whitmore.
+Troy Whitmore	[9916.380-9917.429]	No.
+Julien Bouquet	[9919.278-9921.863]	I'm a yes, but the motion will fail. And we have 3 to 10. OK. Moving on. Yes, Director?
+Karen Benker	[9922.204-9924.075]	I would like to withdraw the next two amendments.
+Julien Bouquet	[9924.771-9925.238]	Next two amendments?
+Karen Benker	[9925.592-9925.592]	Yes.
+Julien Bouquet	[9926.495-9929.676]	OK. The next two amendments have been withdrawn.
+Chris Nicholson	[9931.373-9939.420]	They were never introduced, so they're not really withdrawn. But now you would return back to the debate on the main motion, which is to approve the Title VI program update.
+Julien Bouquet	[9940.102-9943.162]	Excellent. Back to the main motion at hand. Director O'Keefe.
+Patrick O'Keefe	[9945.008-10088.267]	So I contemplated a no vote out of principle on this action. There's a few things going on. First of all, it should never get to the last minute. The Board should never be asked to pass things because it's due in two days. And I know there's a lot of things that go into the delay. But that's just not the right-- that's not the right urgency to place on the Board to act. Secondly, I don't know very much about this topic, and I have sat in on two operations committee meetings. I've talked to a bunch of people. I've done my own research. And I still am looking for a succinct description of the program. I would note that there was a wonderful book written by Robert Caro. It's called The Power Broker. I'm sure a lot of people in this room know it. Talks a lot about bad policy decisions on disadvantaged communities and how those decisions were made and the harmful outcome of those decisions. It is 15 pages shorter than our packet tonight. He won the Pulitzer Prize for a 1,200 page treatise on impact by public infrastructure. I would request that when we're passing along documents as part of a packet, it needs to have a point, and it should be summarized from the committee for the rest of the Board. Simply passing things along for us does not help me understand this better. I'm probably a yes vote tonight, but I was a no vote until about an hour and a half ago. And so just, when you are putting together packets on complex questions for the Board, giving us reams of paper does not help us get to a better decision. So that's something, a request for the two, three-ish Committee Chairs as you're putting together topics like this, and that would be very helpful for me to make better decisions. Thanks.
+Julien Bouquet	[10088.848-10093.897]	Thank you, Director O'Keefe. Any further comments or questions on the main motion? Director Guzman.
+Michael Guzman	[10093.897-10159.097]	I would just like to mention that the Denver City Council unanimously submitted a proclamation for RTD on May 19, 2025. It is in the director's emails. It was sent over by City Council, that they wholeheartedly support the 2025-2028 Title VI program to include the proposed updates to major service change, disparate impact, and fare equity policies, as well as updates to RTD's public participation plan and language access plan, which we are voting on now, and that the clerk and recorder of the City and County of Denver did affix the seal, making it official. I believe that that is necessary. There's a whole proclamation. You can read through it. But former Board Director Lewis-- sorry, We had two Lewises and I wanted to make sure I said it right. Did work with city council member Serena Gutierrez Gonzalez. And the unanimity of that vote is remarkable from our city council. So they stand behind this as well with us to move this forward. Thank you.
+Julien Bouquet	[10159.919-10161.893]	Thank you, Director Guzman. Director Larsen.
+Matt Larsen	[10163.647-10262.017]	I'm going to be a no vote, I think it's kind of, like I said, we're constraining our freedom to operate. We're spending a lot of energy and effort to track this. And I know the intentions behind that are good, but I think, just as a matter of principle, we shouldn't be trying to over-- regulating ourselves more. We should be thinking, there's not really a lot of evidence that we have disparately or ever had any recent plans to expand service or decrease service in a way that causes a disparate impact on these populations. And I honestly believe that if we focused 100% just on increasing ridership, which is what I think we should be doing, and not trying to expand our purview about when maybe we shouldn't increase ridership. I don't know. If it's legitimate, we'll do it anyways. I really think if we were focusing strictly on increasing ridership, we would actually-- it would all be disparately impacted in favor of all the communities we're worried about, just based on the way population is distributed in the area. And I would like for us to move towards a paradigm of focusing much, much more on increasing ridership across the board and less on finding possible reasons to not increase ridership. So I'll be a no vote. Thanks.
+Julien Bouquet	[10262.960-10264.304]	Thank you, Director Larsen. Secretary Nicholson.
+Chris Nicholson	[10264.304-10347.965]	So I sat through two committee meetings, a study session, and a town hall, all on this topic. And I should say expertly facilitated by our co-chairs and by our Chair of Finance and our staff. And I feel like I'm just starting to get a decent understanding of it. I came into this knowing nothing about this, and I was an absolute no when we first started. And my public remarks made that very clear. But I want to commend staff and our Board leadership who were willing to indulge because I came to understand it. I came to understand what it was for. I came to understand how it works. And I don't necessarily agree with all of it and I think we could use more data in addition to the data we have now to determine this. But if we don't pass this, we lose federal funding. So there's a good reason to pass it even if you don't like it. But on top of that, I just think our staff did their jobs. They have demonstrated to me this is the right thing to do, despite my skepticism. And so I'm definitely voting for it tonight.
+Julien Bouquet	[10348.814-10362.183]	Thank you. Any further comments on the main motion? OK. Seeing none, we had Catlin as the mover and Guzman as the second. There is indication that there will be no votes so I will be doing a roll call vote on this. Treasure Benker.
+Karen Benker	[10362.436-10363.351]	No.
+Julien Bouquet	[10365.854-10366.194]	Director Catlin.
+Peggy Catlin	[10366.194-10367.416]	Yes.
+Julien Bouquet	[10370.080-10370.450]	Director Guissinger.
+Lynn Guissinger	[10371.461-10371.461]	Yes.
+Julien Bouquet	[10373.584-10373.584]	Director Gutschenritter.
+Chris Gutschenritter	[10373.584-10373.584]	Yes.
+Julien Bouquet	[10373.584-10374.535]	Director Guzman.
+Michael Guzman	[10374.535-10375.687]	Yes.
+Julien Bouquet	[10376.247-10376.557]	Director Harwick.
+Ian Harwick	[10376.557-10377.269]	Yes.
+Julien Bouquet	[10379.031-10379.361]	Director Larsen.
+Matt Larsen	[10380.293-10380.293]	No.
+Julien Bouquet	[10381.008-10381.439]	Director Nicholson.
+Chris Nicholson	[10381.439-10382.681]	I'm in.
+Julien Bouquet	[10384.133-10384.779]	First Vice Chair O'Keefe.
+Patrick O'Keefe	[10385.855-10385.855]	Yes.
+Julien Bouquet	[10386.476-10388.880]	Director Paglieri.
+Brett Paglieri	[10388.880-10388.880]	Yes.
+Julien Bouquet	[10389.801-10390.743]	Director Ruscha.
+Joyann Ruscha	[10390.743-10390.743]	Yep.
+Julien Bouquet	[10392.565-10393.271]	Second Vice Chair Whitmore.
+Troy Whitmore	[10393.271-10393.907]	Yes.
+Julien Bouquet	[10394.909-10418.443]	I'm also a yes. So the motion, the main motion will pass 11, 2, and 2 absent. Yes. That math adds up. OK. Moving on. We're going to be moving to our next recommended action, which is the budget transfer articulated buses supporting Colfax Bus Rapid Transit or BRT service. Do I have a mover?
+Michael Guzman	[10419.553-10420.100]	So moved, Guzman.
+Julien Bouquet	[10420.534-10422.437]	Guzman is the mover. Do I have a second?
+Troy Whitmore	[10422.437-10422.437]	Second.
+Julien Bouquet	[10424.400-10424.400]	I have--
+Joyann Ruscha	[10424.400-10424.400]	Wait. Sir.
+Julien Bouquet	[10424.941-10424.941]	Yeah?
+Joyann Ruscha	[10425.662-10433.273]	Oh, wait. Well, I could be wrong. I'm sorry, I forgot we started late. I thought we hit our four hour mark. Please ignore me.
+Julien Bouquet	[10434.475-10434.475]	Oh.
+Joyann Ruscha	[10434.835-10434.835]	Sorry.
+Julien Bouquet	[10434.975-10444.263]	Guzman is the mover. Whitmore is the second. Any discussion on it? Yeah, Director Paglieri?
+Brett Paglieri	[10444.263-10467.106]	I just wanted to say a few quick words about why I will not be voting for this. I was not necessarily sure how this would further the clean energy and zero emission goals of the State of Colorado and therefore will just be voting no. Thank you.
+Julien Bouquet	[10469.652-10471.560]	Any further conversation? Secretary Nicholson.
+Chris Nicholson	[10471.560-10562.785]	Yeah, so I understand the importance of what we're doing here. I think that these buses in particular-- in my religion, there's a thing. Why is this night different from all other nights? Why are these buses different from all other buses? These are going to be the flagship of our flagship BRT line, and if these suck, it will kill BRT. And if they are not comfortable, if they are not just awesome in every way possible-- you can make a lot of choices when you buy a bus about how nice it's going to be in the same way can make a lot of choices about how when you buy a car, about how nice it's going to be. And so I just want to lean in here, and I do have one question to say that we need to pull the stops out. We need to make sure we're giving you enough money, GM/CEO Johnson, to make sure we're buying top of the line, to make sure that these are things that when they run through my district, people go, wow, I want to get on that. Not, wow, that doesn't look very nice. And so my question for you is, how do you know that the amount of money that we're authorizing today is enough to get top of the line? And how many bites at the apple are we going to get to make sure that you are buying the right buses for this incredibly important project?
+Julien Bouquet	[10564.421-10568.119]	Ms. Johnson, is 51 million enough to make them not suck?
+Debra Johnson	[10568.525-10575.235]	Yeah. So thank you very much, Mr. Chair, and thank you for the question.
+Julien Bouquet	[10576.285-10577.634]	My apologies. That was unprofessional.
+Debra Johnson	[10577.819-10655.405]	Keep it in mind, this is a budget transfer. And full transparency, Director Nicholson emailed me about this because I think there was some confusion about where we are. There is yet to be a solicitation. There's yet to be specifications. So these monies that are being transferred or needed for all intents and purposes so we can start a procurement. Now, keeping in mind there's a couple of elements. These buses have to be dedicated because this is designated as a bus rapid transit project as defined by the Federal Transit Administration. There are certain criteria that we have to ensure that we adhere to. This will be a dedicated fleet just by virtue of the configuration of BRT, with it being a center running platform. So when you talk about it being top of the line, that's yet to be seen in reference to what we had before us, because there's only two original equipment manufacturers in the United States, there's only so many suppliers, there are certain seats, and there is a national task force on which I sit, where we're talking about doing away with customization, because that increases prices. I bet you don't know how many shades of white there is with new flyer industries.
+Chris Nicholson	[10655.676-10655.676]	24.
+Debra Johnson	[10656.216-10656.877]	How many?
+Chris Nicholson	[10657.557-10657.557]	24.
+Debra Johnson	[10657.678-10679.478]	23. I think I told you that earlier. So the point of the matter is, as we talk about this, we're going to do our due diligence and we're going to ensure it's a competitive solicitation. And we do understand the aspects, because that's what separates bus rapid transit from general fixed route service. Thank you.
+Julien Bouquet	[10680.337-10680.337]	Secretary.
+Chris Nicholson	[10680.826-10687.285]	I really appreciate it and I look forward to you coming back often to update us on how the purchase is going.
+Speaker	[10689.931-10690.911]	Yes. And what white.
+Julien Bouquet	[10690.911-10691.350]	Director Guzman.
+Michael Guzman	[10691.789-10740.929]	Just really quickly. With regards to this, moving this money from the unrestricted fund is simply to begin the procurement process. And although it's not part of the 2025 budget, we do need to get started on it. However, I would suggest that as we go forward, these buses are meant to be purchased in finality by 2027 to begin this service, and that is work that we will dutifully do on Finance and Planning to ensure that it is included in all necessary documents that come before this Board for approval. And I am certain that our new CFO is up to the task on that. So rest assured, Directors, we're not wantonly spending money. But we do need to authorize this for the procurement of the buses at this point. Thank you.
+Julien Bouquet	[10741.261-10759.207]	Thank you, Director. Any further discussion on this item? All right. There is a no-- oh, no. Sounds good. All right, it was indicated there will be a no vote, so I will do a roll call vote. Again, this is the budget transfer articulated buses supporting Colfax BRT service. Treasurer Benker.
+Karen Benker	[10759.540-10760.307]	Yes.
+Julien Bouquet	[10761.289-10761.629]	Director Catlin.
+Peggy Catlin	[10761.629-10762.230]	Yes.
+Julien Bouquet	[10763.352-10765.015]	Director Guissinger.
+Lynn Guissinger	[10765.376-10766.096]	Yes.
+Julien Bouquet	[10766.096-10766.096]	Director Gutschenritter.
+Chris Gutschenritter	[10766.096-10766.096]	Yes.
+Julien Bouquet	[10766.858-10767.159]	Director Guzman.
+Michael Guzman	[10767.159-10767.939]	Yes.
+Julien Bouquet	[10768.380-10768.700]	Director Harwick.
+Ian Harwick	[10768.700-10769.221]	Yep.
+Julien Bouquet	[10769.702-10770.042]	Director Larsen.
+Matt Larsen	[10770.042-10770.544]	Yes.
+Julien Bouquet	[10770.964-10772.226]	Director Nicholson.
+Chris Nicholson	[10772.226-10775.211]	Nicholson go brr.
+Peggy Catlin	[10775.211-10775.211]	What?
+Chris Nicholson	[10775.932-10777.535]	Sorry that was a bad internet ref-- yes.
+Julien Bouquet	[10778.977-10780.329]	Nicholson is a yes. Director O'Keefe.
+Patrick O'Keefe	[10783.190-10783.190]	Yes.
+Julien Bouquet	[10783.190-10785.493]	Director O'Keefe is a yes. Director Paglieri.
+Brett Paglieri	[10786.074-10786.074]	No.
+Julien Bouquet	[10786.815-10788.287]	Director Paglieri is a no. Director Ruscha.
+Joyann Ruscha	[10788.857-10788.857]	Yes.
+Julien Bouquet	[10789.778-10790.109]	Director Whitmore.
+Troy Whitmore	[10790.109-10791.520]	Yes.
+Julien Bouquet	[10793.523-10799.200]	OK. So that passes 12, 1, and 2. All right. Thank you, folks. So we have one--
+Jack Kroll	[10800.011-10806.069]	Chairman Bouquet, could you remind us over here? We missed who the mover and the seconder were on that.
+Julien Bouquet	[10806.799-10807.585]	I had Guzman and Whitmore.
+Jack Kroll	[10808.281-10808.532]	OK. Thank you.
+Julien Bouquet	[10809.403-10841.268]	Thank you. OK. Excellent. Thank you all again for your patience. We do have one more item, and that is the equitable transit oriented development policy amendment. So for the Board of Directors to approve the amendment to resolution number two, series of 2021, which created the equitable transit oriented development policy that permits and encourages the development of affordable housing on RTD real property in order to include guidelines for disposing of RTD real property below fair market value or rent. Do we have a motion?
+Michael Guzman	[10841.600-10842.522]	So moved, Guzman.
+Julien Bouquet	[10842.522-10843.808]	Guzman is the mover. Do we have a second?
+Ian Harwick	[10843.808-10843.808]	Second.
+Julien Bouquet	[10844.445-10860.757]	I have Harwick as the second. I do understand that on this item, we have some proposed amendments from Director Nicholson and Director Ruscha. Since Director Nicholson's amendment was circulated to the Board first, we will start there. Director Nicholson, please now make your motion to amend.
+Chris Nicholson	[10861.675-10875.340]	Yes. I'd like to move to amend the ETOD policy. And I'm hoping that GM/CEO-- not GM/CEO. That Mr. Kroll can put up that language on the screen.
+Speaker	[10876.808-10877.019]	It's there.
+Chris Nicholson	[10877.890-10879.914]	Great. May I?
+Julien Bouquet	[10881.470-10884.037]	Would you like to read the motion and then we'll get a second?
+Chris Nicholson	[10884.374-10928.443]	Thank you. Yeah. So move to amend the policy such that Section 5 of the equitable transit oriented development policy regarding negotiated land price be updated as follows. To raise the maximum negotiated land price discount to 75% from 50% and add the following additional factors to favorably consider projects which include more accessible units than required by law, limit residential parking, are deeply affordable, emphasize priority groups as identified by the Colorado Housing and Finance Authority, and incorporate smaller footprint retail, including below market rate units-- below market rate retail, excuse me, that prioritizes local businesses and entrepreneurs.
+Julien Bouquet	[10929.125-10929.125]	Excellent.
+Jack Kroll	[10933.271-10933.847]	Do we have a second?
+Julien Bouquet	[10933.847-10934.077]	And do we have a second on that?
+Ian Harwick	[10934.793-10934.793]	Second.
+Julien Bouquet	[10935.454-10940.003]	Harwick is the second. Secretary, would you like to discuss further?
+Chris Nicholson	[10940.281-10953.246]	Thank you. Yes. Before I get into my remarks, I'd like to ask Executive Manager Kroll to briefly describe the five pieces of written public comment that we received on this recommended action from some of our local public officials.
+Jack Kroll	[10954.083-10985.484]	Yes. So four of the written public comment items were submitted by individuals specifically supportive of the change Director Nicholson is offering. And those four individuals were the mayor of Boulder, a city council member from Boulder, a city council member from Westminster, and the Colorado Cross Disability Coalition. And then the fifth letter was submitted by SWEEP in joint with Conservation Colorado and Denver Streets Partnership, which spoke more broadly to the overall changes being offered this evening.
+Julien Bouquet	[10988.799-10989.110]	Perfect. Secretary.
+Chris Nicholson	[10989.881-11146.485]	Thank you. And thank you, Mr. Executive Manager Kroll. So here at RTD, we make lives better through connections. Tonight as a Board, we have an opportunity to do that in a particularly powerful way. Our rider surveys tell a clear story. Over half of our passengers live below 200% of the federal poverty level, and they are far less likely to own a car. Our riders with disabilities use RTD at disproportionately high rates, as do other vulnerable populations in our community. Yet only a fraction of affordable housing developed near our stations truly meets the needs of our most dedicated riders. Communities in our state have struggled to create housing targeted at our ridership. Inclusionary zoning has mostly led to housing at 60% AMI, about $51,000 a year in earnings. This housing is necessary, but priced well out of reach for someone making only $31,000, which is 200% of the federal poverty line. This amendment empowers RTD to deepen our land discount offerings up to 75% to incentivize projects specifically tailored to the actual economic realities of our riders. Here's how that can work in practice. Just this month, Denver Health donated the land to create Tapestry, a deeply affordable, accessible, transit- oriented housing project. It supports a range of affordability from 30% to 80% as well as far more three bedroom and even four bedroom units than most affordable projects being built today. It targets accessibility because distance to transit is a major barrier for people with disabilities to use transit. This holds for all types of disabilities, and unfortunately, painfully few class A fully accessible units exist in the RTD service area. By creating greater incentives for developers, we can do a lot to play our part in fixing that. It's late, so I won't go through the argument for reduced parking and service of CFHA's priority populations. You all have an email from me with that data. But I do want Director Harwick to speak after me to address the language, he added on smaller footprint and below market retail. Community is about more than housing, and I enthusiastically added his language for the reasons he'll highlight. This framework recognizes that we are not the housing policy experts. It increases the scope of our tools and trusts our staff to use them effectively to bring us thoughtful projects, projects that align with our strategic priority of community value and enable us to grow ridership by putting the people who most need transit where they can best be served by it. I ask your support for this amendment.
+Julien Bouquet	[11147.469-11147.870]	Thank you. Director Harwick.
+Ian Harwick	[11149.512-11225.430]	Yeah. So I wanted to make sure that when we're talking about TOD, that we're really thinking also about mixed use TOD. And I'm wildly in favor of anything that we can do to bring more housing, let alone affordable housing, to our park and rides. I do think it's really key that we also think about what are the businesses that we are bringing in there. And having spent a lot of time working at Starbucks and a good friend of mine works at Starbucks, I'm also really in favor of coffee shops like Prodigy and smaller shops. But also thinking about when I've traveled to travel to other communities throughout the world, there oftentimes are smaller retail shops that give young entrepreneurs that opportunity to start a business and not be burdened by a larger footprint that some of our larger restaurants or larger retail shops can. They can cover those costs. So this, to me, was a way to encourage local businesses to start up or expand give them the opportunity in a place that we all-- when we go to a park and ride and there's not something there to grab that quick bite to eat, I want to give them that opportunity, everyone that opportunity. One to shop there and sell there.
+Julien Bouquet	[11227.089-11231.507]	Thank you, Director Harwick. Any further discussion on this amendment? Director Ruscha?
+Joyann Ruscha	[11232.082-11254.313]	Mr. Chair, maybe you can help me here. So I had a comment, but I had a comment on the main motion. But we moved to amendments. But recognizing that Secretary Nicholson's language can't exist without the motion language or the way it's drafted. May I just make a general comment? Does that make sense? It would apply to both, but I don't know if I would be called out of order. And I'm tired. I will do what you say.
+Julien Bouquet	[11254.520-11256.347]	You know what? Why not? Let's give it a try.
+Joyann Ruscha	[11256.564-11363.337]	OK, thanks. I'm doing my best. So this morning, we got an email from staff that addressed some outstanding questions that I still had, just so I knew what I was voting on. And the issue-- I have heartburn over just the main motion because the way it's written. We, as a Board, are not just expanding the bounds of what a policy is. We're also signing away 30 plus years of precedent of having this guardrail that says, before you go dispense a real property, get our preliminary authorization. So I am already a little bit uncomfortable. And also the policy says that if a developer, as it relates to housing, cannot meet our 50% standard, they could still get a major discount and it could be millions and millions of dollars. And so those two combined and just recognizing that these deals take a long, long time. They're not summer projects. In some, it means that all of that is going to happen. And then it's going to come back to the Board when all of those decisions have been made. So for that, because I'm struggling with the original proposal, but I can accept it for now, is why I can't vote yes on Secretary Nicholson's amendment, because we don't have guardrails that I would prefer. So I hope that was not out of order. And if it was, thanks for not calling me out of order.
+Julien Bouquet	[11363.561-11365.594]	Thank you. Thank you, Director Ruscha. Director Guzman.
+Michael Guzman	[11365.594-11502.983]	So ETOD has been discussed a number of times in the committee, and this is my concern. Although I am with you in spirit-- deeply affordable housing is really important-- I'm not sure that giving an additional 25% discount in our policy is wise for a number of reasons. I do believe, however-- and maybe Madam CEO or Ms. Chessy Brady might be able to speak to this. I'm not sure. What we were asked for in this policy was to give guidelines to begin negotiation that would eventually come back to this Board. Let's say a developer comes to us and just brings us an amazing proposal that includes everything that you could want in a development and more. I don't see why they wouldn't necessarily come back to us and say, hey, they're willing to do all of these things-- they being staff-- and asking for an additional amount of up to whatever amount makes sense to give that discount from the Board that we would consider properly and then be able to authorize in that moment. But in order to begin the process, we were simply asked to give authorization for them to work within a parameter. That way, there was no confusion that they would be able to do a 30% to 50% discount as was written in the original policy. Beyond that, the Board would still have authority, as I understand it, if we were asked to offer an additional discount for more. I don't know that we need to lock that into policy, and it does the one thing that I was trained by former Directors and members that are currently here not to do, which is bind future boards in a way that creates difficulty for us to do our job as the fiduciaries of the agency. And so I would like to ask that question. Is there anything that would prevent you from coming back to us if we were to receive such an excellent proposal that prevents you from saying, can we receive an additional discount to offer a developer, Board, and would you approve this so we can make a project work?
+Julien Bouquet	[11504.967-11508.663]	Ms. Brady. First off, thank you for your patience and greatly appreciate you sticking around tonight.
+Chessy Brady	[11508.993-11509.213]	Of course.
+Julien Bouquet	[11509.774-11510.414]	You're recognized.
+Chessy Brady	[11511.376-11534.731]	Thank you. No, there is nothing that would stop us from doing that. As you say, the point of the policy is to create guardrails and certainty within those guardrails. We would use the opinions of the Board to guide developers towards what we think the Board would be interested in, as we're negotiating with them, and we come back to the Board for approval of any given project.
+Karen Benker	[11535.906-11588.810]	Thank you. One more quick thing. And Director Benker, Treasurer Benker, the sales and the lease income from our real estate properties are put into a specific account. Can you guess which one? Because when we deeply discount things beyond where we should, we are saying no to the potential income that we could use for operations and maintenance and service provision elsewhere in the agency. So on balance, real estate and real property are a finite resource and dollars can be stretched thin. But how we use the opportunity to either receive money to prolong and serve the public further is a huge consideration in this. So although I am with you in spirit, I would be voting no on the amendment as it is right now.
+Julien Bouquet	[11589.711-11591.744]	Thank you, Director. Director Paglieri.
+Brett Paglieri	[11592.481-11656.952]	Thank you. I'll be brief. I really like the language that highlights these things that I deeply agree with. I am a little bit concerned about two things. The first is the language deeply affordable. It's a little bit ambiguous, if I'm saying that right. And I think using language like that can-- what's to say they discounted $100? To some, that's a deep discount. To others, that's nothing. So I'd recommend removing that word and just maybe also deeply affordable unless you can define it elsewhere. But I do want to leave this language. And the other thing is I just have a hard time giving a 75% discount even with these things that I want. And perhaps that this is a really limited circumstance that we'd give 75% But this is our property, and I really would like to see it sold for the highest value to benefit all. Thank you.
+Julien Bouquet	[11657.152-11659.385]	Thank you, Director. Treasurer Benker.
+Karen Benker	[11661.657-11680.279]	Just a quick question. Some of the surplus properties that we're talking about, we are not including our current park and rides. Correct? Would be excess land, perhaps around a park and ride, but not one of our park and rides. Just clarification.
+Chessy Brady	[11681.560-11726.927]	Thank you. So this policy is aimed at transit oriented development. So property that RTD owns at transit stations or near high frequency transit. Excess property and surplus property are definable terms that perhaps Michelle could help us with. But those are distinctive properties that the Board has named to be excess and surplus. And so I just want to separate that from a park and ride. A park and ride is certainly not excess or surplus. It may have underutilized land. It may have a large drainage area that is part of the park and ride, but not every development that we would consider on a park and ride would remove parking, if that's getting more to your question.
+Karen Benker	[11728.090-11728.441]	OK.
+Chessy Brady	[11728.441-11728.441]	Yes.
+Julien Bouquet	[11731.275-11731.776]	Secretary Nicholson.
+Chris Nicholson	[11731.776-11750.729]	I actually have some questions for Ms. Brady. So first off, Director Paglieri raised the concern about the term deep affordability. I think you and I know what that means, but maybe the rest of the Board doesn't, given it's a term of art. Can you elaborate on what that's referring to?
+Julien Bouquet	[11751.929-11752.130]	Ms. Brady.
+Chessy Brady	[11752.130-11766.937]	Sure, yes. Deep affordability is a term in the affordable housing network that means generally 30% to 40% of AMI. It is squishy, I think still, but generally it's understood to mean 30% to 40%.
+Julien Bouquet	[11767.338-11767.338]	Secretary.
+Chris Nicholson	[11769.905-11860.976]	So second question. I've heard a couple of concerns about 75% as a discount. I was hoping maybe you could speak to the-- because I mentioned it a little bit. But as someone who's an expert in the space, and I will say you and I worked pretty closely together on this language and went back and forth. You did a meeting with me. So this isn't just something that I wrote myself. This is something that got vetted pretty heavily by staff. What impact does a greater discount have on the types of projects that, in the affordable housing space, you tend to see people able to build? At least from where I sit, the reason for doing this is that when it comes to those deeply affordable, which are deeply subsidized units, when it comes to things like units that are fully accessible, those are expensive. They cost developers money, which is why, when you don't have those subsidies, those units don't get built. I think it's about half the projects that are in the CHFA Database have zero units at 30% AMI, and very few of them have anything with regard to accessibility. So I'm hoping you can maybe elaborate on-- you're the one who would be using this tool at the end of the day. How do you see it coming in handy with regard to what you're able to do? And then I have one last follow up.
+Julien Bouquet	[11862.981-11869.116]	Ms. Brady.
+Chessy Brady	[11873.804-11974.719]	Thank you. So affordable housing projects are notoriously difficult to finance. And I think if you use the example earlier of Tapestry and Denver Health. Denver Health, as you stated, as I assume it's correct, donated the land for Tapestry. I can assure you that development was still very difficult to finance. So even if we were giving the land at 100% discount, the projects would still not pencil, in many cases. And so our ability to discount the land to 75% as the Board prefers, in many cases, could get us over the hump from a project not being built to a project being built, and to that project having more affordable units as opposed to a higher, more of a middle income range. And that's the difference that the land discount makes. And that's the certainty that this policy helps me bring to conversations with developers. Gets them in the mindset of we're going to get some help here from RTD. We can focus on deeper affordability units. We can make bigger promises to CHFA or other financing entities that host in Denver. And it helps us keep the projects moving. And I'll be frank with you. As I said, Tapestry, even with 100% discount, it's still hard to do. This is not a silver bullet. But it moves the needle and it helps us actually keep projects afloat and get to the finish line.
+Julien Bouquet	[11975.399-11979.547]	Thank you, Ms. Brady. We're going to wrap up with Director O'Keefe and then Director Larsen.
+Patrick O'Keefe	[11980.307-12097.522]	Oh, I thought I got last word. So I support this amendment. I think it is a reasonable step toward developing communities that are very likely to use our services. I think increasing ridership is something we all agree on. This is a concrete way to do that. It also takes land not just for our benefit in ridership, but also puts improvements on it that helps the tax base. And I think the communities that we serve would rather see a housing project end up on that property where it becomes improved versus somewhere else. We're not the only game in town. There's a lot of discounts out there. And so we're not necessarily in a tight buyer's market. There's a lot of projects that can go forward. And I think we need to put our best deal, and at least give Chessy and the rest of the team the tools to bring the deal forward. I do want to put one plug-in. We talked about it. I don't think ground leases are the best tool in Colorado. First of all, it's not as common as other places in the world. And the other thing is, toward the end of your ground lease, no matter how long you make it, the property will fall into disrepair. They are not going to put money into physical facilities that are going to roll off their books. So for that reason, the discount's great and I love a sale versus a ground lease. And I know you'll keep that in mind as we go forward. And anyway, that's another argument in favor of that tactic.
+Julien Bouquet	[12100.182-12100.182]	Director Larsen.
+Matt Larsen	[12100.182-12138.264]	Thank you. I'm going to be a no vote on this. I don't agree with our transit oriented development policy as it is right now. I don't agree with the goal of trying to provide affordable housing or encourage it, incentivize it. I think we should be focused on trying to increase ridership. If we want to provide discounts on our land, we should provide them with the goal in mind of increasing the number of people that can live on the property, whatever is developed, and the amount of traffic that is on the property. So I'm a no on this.
+Julien Bouquet	[12139.355-12152.747]	Thank you, Director Larsen. All right. With the indication there is a no vote, I am going to do a roll call vote. As a reminder, we are voting on Director Nicholson's amendment. He was the mover and Director Harwick is the second Treasurer Benker.
+Karen Benker	[12153.147-12153.147]	Yes.
+Julien Bouquet	[12156.651-12156.981]	Director Catlin.
+Peggy Catlin	[12156.981-12158.773]	Yes.
+Julien Bouquet	[12159.920-12160.320]	Director Guissinger.
+Lynn Guissinger	[12161.041-12161.041]	Yes.
+Julien Bouquet	[12161.602-12162.013]	Director Gutschenritter.
+Chris Gutschenritter	[12162.944-12162.944]	Yes.
+Julien Bouquet	[12163.484-12163.825]	Director Guzman.
+Michael Guzman	[12163.825-12164.446]	No.
+Julien Bouquet	[12165.607-12165.917]	Director Harwick.
+Ian Harwick	[12165.917-12166.408]	Yes.
+Julien Bouquet	[12167.569-12167.930]	Director Larsen.
+Matt Larsen	[12167.930-12169.271]	No.
+Julien Bouquet	[12170.553-12170.933]	Secretary Nicholson.
+Chris Nicholson	[12170.933-12171.794]	Yes.
+Julien Bouquet	[12172.916-12173.477]	First Vice Chair O'Keefe.
+Patrick O'Keefe	[12173.477-12174.558]	Yes.
+Julien Bouquet	[12175.339-12175.739]	Director Paglieri.
+Brett Paglieri	[12176.600-12176.600]	Yes.
+Julien Bouquet	[12177.421-12177.742]	Director Ruscha.
+Joyann Ruscha	[12177.742-12181.016]	Sorry, no.
+Julien Bouquet	[12182.227-12183.365]	And finally, Second Vice Chair Whitmore.
+Troy Whitmore	[12183.365-12184.210]	Yes.
+Julien Bouquet	[12185.317-12215.121]	And I am a yes. That amendment will pass 10, 2-- excuse me. 10, 3, and 2. Yes. 10 yes, 3 no, 2 absent. That is the math. OK. Moving on. We are going to do our second amendment, which was brought forward by Director Ruscha. And Director Ruscha, would you like to introduce the language of the amendment?
+Joyann Ruscha	[12217.286-12221.684]	It's being brought forth by Directors Ruscha and Guzman, and I--
+Michael Guzman	[12221.684-12225.716]	I can make the motion. Sorry.
+Joyann Ruscha	[12226.197-12227.387]	I think he has the language in front of him.
+Julien Bouquet	[12227.919-12228.239]	Director Guzman.
+Michael Guzman	[12228.239-12263.953]	Thank you, Mr. Chair. We would like to make a motion to add the language to the end of this policy that says, additionally, no project will be eligible for any discounts unless it complies with the greater of the following. 5% of all units are accessible to persons with mobility disabilities, and an additional 2% of all units are accessible to persons with hearing or visual disabilities, or two, current US Department of Housing Urban Development accessibility requirements. Do we have a second? We have Ruscha as the second. Mr. Kroll, I'm sorry.
+Jack Kroll	[12264.464-12277.241]	Just to clarify, Director Guzman, as I understood you reading that into the record, the highlighted portion above would be deleted. And is not included in your motion. Correct?
+Michael Guzman	[12277.241-12277.241]	Correct.
+Julien Bouquet	[12279.985-12284.712]	So the language we see, this would substitute the language? OK, perfect.
+Michael Guzman	[12285.452-12287.886]	Simplifying it to the bare minimum to get this done.
+Julien Bouquet	[12289.778-12290.039]	Director Ruscha.
+Joyann Ruscha	[12291.764-12297.190]	I was happy to speak to the motion, but I wasn't sure if we were-- I'm tired. Is that OK?
+Julien Bouquet	[12298.411-12298.656]	Mhm.
+Joyann Ruscha	[12298.656-12298.656]	OK.
+Julien Bouquet	[12298.656-12302.331]	We got Guzman as the mover and Ruscha as the second, and we're up for conversation.
+Joyann Ruscha	[12302.636-12302.816]	OK.
+Julien Bouquet	[12302.816-12303.372]	You're up, Director Ruscha.
+Joyann Ruscha	[12303.917-12438.784]	Thank you sir. OK. So just for everyone's edification, we struck the first sentence. It was a two sentence amendment. Just recognizing that we didn't have full staff concurrence on the first sentence, which would have applied this accessibility minimum to market rate housing. And sometimes you shoot for the stars and land on the moon. The second sentence, which just applies to the HUD requirement to affordable housing, we did get staff concurrence. That was the context behind that. I sent out like a Q&A, frequently asked questions in anticipation of some questions. So I'm happy to entertain any or we can address them. I will say that we worked for three weeks and some change on this with housing advocates and folks who had worked in the space, and people had worked at CHFA and at the state level on similar policy and advocacy organizations and then staff and legal. So, I mean, just-- I'm sorry. I am tired. In case anybody has any questions about what this is, I think it just simplify it and say that HUD has a current minimum accessibility requirement for funding. And it's 5% of units are accessible to persons with mobility disabilities. Additional 2% of units are accessible to persons with hearing or visual disabilities. And so a lot of times in these projects, that HUD requirement is going to kick in. But not all projects are going to have HUD dollars. So just recognizing that a lot of jurisdictions take that HUD standard, which is-- maybe Ms. Brady can correct me, but I think it's 20 plus years, 30 plus years old now. And they also incorporate that into their policies or their code or statute. We did the same. Good for goose, good for gander. I will stop there unless anyone else has further questions or comments.
+Julien Bouquet	[12440.314-12446.592]	Questions or comments on this amendment? Director Catlin, then Secretary Nicholson.
+Peggy Catlin	[12447.571-12500.046]	I appreciate the thought going into this, but I believe that the first amendment that we passed does give a lot of latitude towards Chessy and her staff to negotiate, and I fear that this one might be a little bit too regulatory and prescriptive. And if that's the HUD requirement and somebody is applying for a HUD grant, then this would be taken care of automatically. So right now, I'm willing to listen to other discussions, but I fear that it would not give Ms. Brady and her staff the maximum flexibility to look at the comprehensive merits of a proposal.
+Julien Bouquet	[12503.309-12504.871]	Yeah, Ms. Brady.
+Chessy Brady	[12506.312-12525.712]	Would you like me to comment? So this is a bare minimum requirement that Denver already requires, for example, and the Colorado Department of Housing is already considering a higher threshold of requirement. So I have no concerns about incorporating this. I think it's already going to be taken care of in most cases.
+Peggy Catlin	[12526.375-12530.436]	If I might? That's kind of my point. It seems a little bit redundant.
+Julien Bouquet	[12534.190-12534.591]	Secretary Nicholson.
+Chris Nicholson	[12534.591-12538.924]	I'd like to offer an amendment, if that's all right.
+Julien Bouquet	[12540.844-12541.218]	To the Amendment?
+Chris Nicholson	[12541.606-12541.806]	Thank you.
+Julien Bouquet	[12543.249-12546.258]	Just to clarify, that was a question. You would like to offer an amendment to the amendment?
+Chris Nicholson	[12546.817-12548.842]	Yes. Sub-amendment.
+Julien Bouquet	[12549.002-12550.099]	Mr. Kroll?
+Jack Kroll	[12550.840-12580.832]	Technically, the initial motion on the table is to amend the ETOD policy, and this is an amendment to that amendment. And at this point would be amending an amendment to an amendment, which is not allowed under Robert's Rules. So you would need to tackle this amendment as it's being presented. And then, if you feel so inclined, offer an amendment to whatever or whatever state the policy is in at that point.
+Julien Bouquet	[12581.971-12582.868]	Rock on. Secretary.
+Chris Nicholson	[12583.769-12623.509]	Yeah. So at that point, I would say I'd have to be a no for the very simple reason. Where it says no project will be eligible, we're talking about an equitable TOD policy here, which is specifically focused on using our land to facilitate the-- literally the policy is about giving discounts. I can't see putting something like this in there unless it is related to said discount. So I'd be fine if it said, additionally, no project receiving a discount will be eligible for any discounts, et cetera, unless it complies with. But I don't necessarily think it makes sense to do market rate policy in an ETOD policy.
+Julien Bouquet	[12623.905-12627.860]	Thank you, Secretary. Treasurer Benker and then Director Ruscha.
+Karen Benker	[12628.471-12642.614]	Just real quick. Have you perhaps considered something more positive, saying something along the lines, greater consideration would be given a project if these items were attained? As opposed to make it mandatory.
+Julien Bouquet	[12646.040-12647.322]	Director Ruscha or Director Guzman.
+Karen Benker	[12647.662-12649.746]	Again, sort of an amendment, but just a thought.
+Joyann Ruscha	[12650.807-12687.544]	So I just want to address what Secretary Nicholson said. I might have missed part of the closed captioning, but I think you said you don't think we should be applying accessibility minimums to market rate. OK. That's exactly. We don't. So this amendment doesn't do that. And the second piece. The reason why it doesn't say it doesn't reference discounts is because-- so this goes at the end of the policy, which is all-- the way it's nested under the paragraph, this is talking about when discounts apply, if that makes sense. It does what you said you wanted it to do. It's just late.
+Julien Bouquet	[12688.518-12688.779]	Nicholson.
+Chris Nicholson	[12688.779-12720.381]	Thank you. And then I guess the only question I have for-- and this is actually for Ms. Brady, if that's OK. Because you mentioned that Denver has a policy that supersedes or that matches this, and the state currently is considering a policy that would supersede it, but currently does not. Under what circumstances would this have any effect at all? In what circumstances can you imagine in your professional capacity do you see this being something that would matter?
+Julien Bouquet	[12721.869-12722.069]	Ms. Brady.
+Chessy Brady	[12722.069-12751.308]	Yes. In a jurisdiction that doesn't currently require accessible units-- and Director Ruscha has mentioned some. I'm not aware of them, but this is not my area of expertise. But in a jurisdiction that does not already have those requirements, that is not accepting HUD money, and, if Colorado Department of Housing changes their rules, does not accept department of housing money, then that project would then be subject to this policy requirement.
+Julien Bouquet	[12753.665-12754.726]	Thank you, Ms. Brady. Secretary.
+Chris Nicholson	[12755.117-12767.551]	Yeah. Just, I guess for Director Ruscha or Director Guzman. Are there any jurisdictions in the RDD service area that don't have that same requirement that Denver does?
+Julien Bouquet	[12769.951-12770.341]	Either Directors.
+Joyann Ruscha	[12772.154-12836.694]	Yeah. I think I'm pretty smart, but I'm not qualified to talk about 53 separate jurisdictions. So I'm just going to have to lean into this is ETOD and the E in it is equitable. We spent a lot of time talking about equity today, including spending a significant amount of time talking about people with disabilities. And so just, again, recognizing that the HUD requirement is about equity and not excluding people on the basis of disability from accessing affordable housing, because the Fair Housing Act, the ADA, and other areas of anti-discrimination law, including state law, don't effectively cover that aspect. Sorry, that was more than what you asked. But no, I can't answer your question, just like you probably couldn't answer my question about every single jurisdiction in the RTD region that has something regarding parking minimums. It's a broad concept.
+Julien Bouquet	[12838.355-12843.089]	Thank you, Director Ruscha. Any further conversation on this amendment. Director Guzman.
+Michael Guzman	[12843.089-12918.859]	I will offer this last thing, and then we probably should go to a vote. But very simply put, we need to make sure that we are protecting the vulnerable. Providing access to these housing units, even in the City and County of Denver's building codes, is not clear. It's as clear as mud. There is reference to this if certain dollars are used, but stacking in the way that developers work, it's not necessarily required. We aspire to a certain ICAA rule, but it's not clear if that means that they have to do this or not in order to get licensed. And so, to be fair to ourselves and to ensure that we are taking care of the ADA community and providing those accessible units, I would like to see this in the policy. I would be fine, by the way, to adjust language on this, to say we would consider giving additional discount, but I don't want any project to go forward that doesn't meet a bare minimum requirement that's established. And although it is established in other places, it is not established in our policy. And we are the government of this region and we should take it seriously that we have a due diligence and responsibility to those members of our community that would need this. Thank you.
+Julien Bouquet	[12920.242-12920.562]	Director Harwick.
+Ian Harwick	[12920.562-12985.552]	I always have to follow you, Director Guzman. But obviously, I'm very in support. Any time that we can be supportive of our communities most in need, those suffering from a whole variety of disabilities, I want to be able to put our best foot forward there. And while we can't call out specific jurisdictions, if there is that chance that there is a jurisdiction that isn't meeting this requirement, then we should make sure we're getting there. And if in the process the state comes up with something better or something in the future, that's OK. But I think that this is like a safety net in my mind about how to really get there for this community. And I think that also, as we're tying-- as these developments spur up around our transit, that's also giving them better access to the resources and giving them that the life that they want and the freedom of movement that we so cherish. So I'm highly in support of this. Thank you.
+Julien Bouquet	[12985.933-12987.583]	Secretary, less than 30 seconds.
+Chris Nicholson	[12987.976-13030.383]	This question is for Chessy. My understanding with this language is that it applies to buildings with elevators in it. And so with single stair buildings, that there are different policies around equitable access because of the challenges, obviously in a single stair building, of getting people into the second, the third, the fourth, the fifth floor. You're probably the biggest expert on this in the room. Do you see any concerns with this language when it comes to buildings with stairs only versus elevators?
+Julien Bouquet	[13031.716-13031.716]	Ms. Brady.
+Chessy Brady	[13031.716-13057.471]	I am not the biggest expert on this in the room, but I would say that equitable-- I do know that equitable access and accessible units are different things and have different requirements. And so we're talking specifically about accessible units. We're tending to be talking about larger buildings because we do want them to be dense at stations, so I think they're typically going to be elevator buildings. But yeah, I don't have any concerns about that.
+Julien Bouquet	[13058.070-13071.091]	Thank you, Ms. Brady. Let's do the roll call vote. Again, this is the amendment offered by Director Guzman and Director Ruscha. Treasurer Benker. Director Catlin.
+Peggy Catlin	[13071.091-13072.883]	No.
+Julien Bouquet	[13074.244-13074.605]	Director Guissinger.
+Lynn Guissinger	[13076.186-13076.186]	Yes.
+Julien Bouquet	[13076.286-13076.666]	Director Gutschenritter.
+Chris Gutschenritter	[13078.087-13078.087]	Yes.
+Julien Bouquet	[13078.848-13079.148]	Director Guzman.
+Michael Guzman	[13079.148-13079.689]	Yes.
+Julien Bouquet	[13080.670-13080.970]	Director Harwick.
+Ian Harwick	[13080.970-13081.410]	Yep.
+Julien Bouquet	[13082.551-13082.901]	Director Larsen.
+Matt Larsen	[13084.153-13084.153]	No.
+Julien Bouquet	[13085.354-13085.734]	Director Nicholson.
+Chris Nicholson	[13085.734-13088.496]	Yes.
+Julien Bouquet	[13089.617-13089.938]	Director O'Keefe.
+Patrick O'Keefe	[13089.938-13092.938]	No.
+Julien Bouquet	[13093.960-13094.548]	Director Paglieri.
+Brett Paglieri	[13095.523-13095.523]	No.
+Julien Bouquet	[13096.425-13096.906]	Director Ruscha.
+Joyann Ruscha	[13098.609-13098.609]	Yes.
+Julien Bouquet	[13099.711-13100.192]	Director Whitmore.
+Troy Whitmore	[13100.192-13100.472]	Yes.
+Julien Bouquet	[13103.318-13115.661]	I'm also a yes. So that'll pass. 1, 2, 3, 4. I think I got 10 yeses, 3 nos, and 2 absent. OK.
+Jack Kroll	[13117.070-13117.746]	There are 4 nos.
+Julien Bouquet	[13117.991-13119.383]	Excuse me, four nos. Thank you.
+Jack Kroll	[13119.894-13120.807]	So 9, 4, and 2.
+Julien Bouquet	[13121.235-13140.319]	9, 4 and 2. My apologies. We'll save that for the record. OK. Now moving on back to the main motion as amended. Do we have any further discussion on the main motion? OK. I will do a roll call vote for the main motion, as amended. Treasurer Benker.
+Karen Benker	[13142.762-13143.002]	Yes.
+Julien Bouquet	[13143.002-13143.243]	Director Catlin.
+Peggy Catlin	[13143.243-13144.024]	Yes.
+Julien Bouquet	[13145.099-13146.541]	Director Guissinger.
+Lynn Guissinger	[13146.961-13148.183]	Yes.
+Julien Bouquet	[13148.183-13148.183]	Director Gutschenritter.
+Chris Gutschenritter	[13148.183-13148.183]	Yes.
+Julien Bouquet	[13148.623-13148.994]	Director Guzman.
+Michael Guzman	[13148.994-13150.025]	Yes.
+Julien Bouquet	[13150.465-13150.845]	Director Harwick.
+Ian Harwick	[13150.845-13151.246]	Yes.
+Julien Bouquet	[13152.047-13153.348]	Director Larsen.
+Matt Larsen	[13153.348-13153.348]	No.
+Julien Bouquet	[13154.910-13155.341]	Director Nicholson.
+Chris Nicholson	[13155.341-13156.372]	Yes.
+Julien Bouquet	[13156.973-13157.373]	Director O'Keefe.
+Patrick O'Keefe	[13157.373-13158.054]	Yes.
+Julien Bouquet	[13158.494-13160.477]	Director Paglieri.
+Brett Paglieri	[13160.477-13160.477]	Yes.
+Julien Bouquet	[13162.539-13163.050]	Director Ruscha.
+Joyann Ruscha	[13163.050-13163.580]	Yes.
+Julien Bouquet	[13164.141-13164.481]	Director Whitmore.
+Troy Whitmore	[13164.481-13165.102]	Yes.
+Julien Bouquet	[13165.883-13185.325]	I am also a yes. It will pass. 12 yes, 1 no, 2 absent. Thank you. All right. Moving on. That was all our recommended actions. Board of Director activities. I think you're all good on that. Other matters?
+Speaker	[13188.563-13189.496]	Amen, buddy.
+Julien Bouquet	[13190.560-13191.201]	Director Guzman.
+Michael Guzman	[13191.201-13215.577]	I got one quick. Sorry. Thank you, Mr. Chair, for approving the travel consideration for lodging and assistance to go to the NTI Public Engagement course in Florida. Really packed, but came in really handy because as soon as I returned, we held the town hall to do exactly what I was sent to go learn about. So I appreciate that. And I was grateful for the assistance from staff and from Director Ruscha to be able to host that town hall. Thanks.
+Julien Bouquet	[13217.300-13219.654]	Secretary-- thank you, Director Guzman. Secretary Nicholson.
+Chris Nicholson	[13219.654-13238.660]	I just wanted to flag that this weekend is the reopening of Downtown Celebration on Saturday and Sunday. So if you like RTD, please come take it to downtown and enjoy our lovely food and all the other cool stuff. Most of the mall is back and running and we're very excited about it, so.
+Julien Bouquet	[13238.988-13263.954]	Any other matters? OK. I got a quick one. It's only going to take 19 minutes. Just joking. My only other matter is please make sure that you Directors fill out that form that was due last week, extended to Monday morning. Please make sure you guys take care of that. The survey. Thank you. With that being said, do I have a motion to adjourn? Director Ruscha.
+Chris Gutschenritter	[13264.317-13264.317]	Second.
+Julien Bouquet	[13264.317-13286.461]	And a second from Gutschenritter. You guys all have a lovely night. Thank you all for your patience.

--- a/videos/May_Board_Meeting/matched_dtw.json
+++ b/videos/May_Board_Meeting/matched_dtw.json
@@ -1,107 +1,17 @@
 [
   {
-    "text": "Julien Bouquet: I'll now call the Wednesday, May 28 RTD Board meeting to order.",
+    "text": "Julien Bouquet: I'll now call the Wednesday, May 28 RTD Board meeting to order. We're convened as of 7:00 PM. I would respectfully ask everyone to remain muted unless you're recognized to speak. Thank you all for joining us this evening. As the Board has moved to in-person meetings for monthly gatherings, please note that committee meetings of the RTD Board of Directors will still be held remotely via Zoom, and will be audio and video recorded. The meeting recordings, along with the unofficial minutes of the meetings, will be posted as soon as practical on the Board's website. Visit rtd-denver.com. And a livestream of this meeting is also available via RTD's YouTube page. During tonight's meeting, we're also providing communication access real-time translation, also known as CART. Anyone who would like to access this service should send an email to the RTD Board Office at rtd.boardoffice@rtd-denver.com and a link will be provided. Additionally, the CART transcript can be automatically translated into Spanish for anyone who would like access to a live transcript of this meeting in Spanish. I'll now ask Secretary Nicholson, could you please lead us in the Pledge of Allegiance?",
     "start": 0.335,
-    "end": 33.67716666666666
-  },
-  {
-    "text": "We're convened as of 7:00 PM.",
-    "start": 34.076,
-    "end": 35.395166666666654
-  },
-  {
-    "text": "I would respectfully ask everyone to remain muted unless you're recognized to speak.",
-    "start": 35.839,
-    "end": 41.348846153846154
-  },
-  {
-    "text": "Thank you all for joining us this evening.",
-    "start": 41.848,
-    "end": 43.986500000000014
-  },
-  {
-    "text": "As the Board has moved to in-person meetings for monthly gatherings, please note that committee meetings of the RTD Board of Directors will still be held remotely via Zoom, and will be audio and video recorded.",
-    "start": 44.913,
-    "end": 57.14355555555554
-  },
-  {
-    "text": "The meeting recordings, along with the unofficial minutes of the meetings, will be posted as soon as practical on the Board's website.",
-    "start": 58.267,
-    "end": 65.49768181818182
-  },
-  {
-    "text": "Visit rtd-denver.com.",
-    "start": 66.343,
-    "end": 66.7813125
-  },
-  {
-    "text": "And a livestream of this meeting is also available via RTD's YouTube page.",
-    "start": 67.219625,
-    "end": 72.91768749999993
-  },
-  {
-    "text": "During tonight's meeting, we're also providing communication access real-time translation, also known as CART.",
-    "start": 74.011,
-    "end": 78.75414285714291
-  },
-  {
-    "text": "Anyone who would like to access this service should send an email to the RTD Board Office at rtd.boardoffice@rtd-denver.com and a link will be provided.",
-    "start": 79.86,
-    "end": 90.12683333333331
-  },
-  {
-    "text": "Additionally, the CART transcript can be automatically translated into Spanish for anyone who would like access to a live transcript of this meeting in Spanish.",
-    "start": 91.259,
-    "end": 100.91516666666658
-  },
-  {
-    "text": "I'll now ask Secretary Nicholson, could you please lead us in the Pledge of Allegiance?",
-    "start": 102.243,
     "end": 106.30206666666672
   },
   {
-    "text": "Chris Nicholson: I pledge allegiance to the flag of the United States of America, and to the Republic for which it stands.",
+    "text": "Chris Nicholson: I pledge allegiance to the flag of the United States of America, and to the Republic for which it stands. One nation, under God, indivisible, with liberty and justice for all.",
     "start": 111.963,
-    "end": 120.33972000000013
-  },
-  {
-    "text": "One nation, under God, indivisible, with liberty and justice for all.",
-    "start": 120.78060000000013,
     "end": 128.872
   },
   {
-    "text": "Julien Bouquet: Thank you, Secretary.",
+    "text": "Julien Bouquet: Thank you, Secretary. I will now read the land acknowledgment. The RTD Board of Directors acknowledges the land on which our buses and trains operate is their traditional territory of the Ute, Cheyenne, Arapaho, and other contemporary tribal nations that are historically tied to these lands. We honor our Indigenous elders who have traveled, inhabited, and stewarded these mountains, hills, and plains throughout generations. May this acknowledgment demonstrate a commitment to working to dismantle the ongoing legacies of inequity of the Native and all historically oppressed peoples, and recognize their current and future contributions in the district as we move forward. I'll now call the roll. Treasurer Benker.",
     "start": 128.872,
-    "end": 129.36599999999999
-  },
-  {
-    "text": "I will now read the land acknowledgment.",
-    "start": 130.735,
-    "end": 133.4298571428571
-  },
-  {
-    "text": "The RTD Board of Directors acknowledges the land on which our buses and trains operate is their traditional territory of the Ute, Cheyenne, Arapaho, and other contemporary tribal nations that are historically tied to these lands.",
-    "start": 134.66,
-    "end": 146.63583333333298
-  },
-  {
-    "text": "We honor our Indigenous elders who have traveled, inhabited, and stewarded these mountains, hills, and plains throughout generations.",
-    "start": 147.759,
-    "end": 154.73844444444453
-  },
-  {
-    "text": "May this acknowledgment demonstrate a commitment to working to dismantle the ongoing legacies of inequity of the Native and all historically oppressed peoples, and recognize their current and future contributions in the district as we move forward.",
-    "start": 155.635,
-    "end": 169.15737837837878
-  },
-  {
-    "text": "I'll now call the roll.",
-    "start": 170.694,
-    "end": 171.3828
-  },
-  {
-    "text": "Treasurer Benker.",
-    "start": 171.856,
     "end": 172.156
   },
   {
@@ -130,13 +40,8 @@
     "end": 177.703
   },
   {
-    "text": "Julien Bouquet: Director Chandler is an excused absence.",
+    "text": "Julien Bouquet: Director Chandler is an excused absence. Director Guissinger.",
     "start": 179.105,
-    "end": 181.10749999999996
-  },
-  {
-    "text": "Director Guissinger.",
-    "start": 183.125,
     "end": 183.4955
   },
   {
@@ -215,12 +120,7 @@
     "end": 207.04950000000002
   },
   {
-    "text": "Julien Bouquet: Director Ruscha.",
-    "start": 207.04950000000002,
-    "end": 207.04950000000002
-  },
-  {
-    "text": "Director Ruscha.",
+    "text": "Julien Bouquet: Director Ruscha. Director Ruscha.",
     "start": 207.04950000000002,
     "end": 207.04950000000002
   },
@@ -230,18 +130,8 @@
     "end": 213.947
   },
   {
-    "text": "Julien Bouquet: OK.",
+    "text": "Julien Bouquet: OK. Thank you. And Second Vice Chair Whitmore.",
     "start": 214.518,
-    "end": 214.94742857142856
-  },
-  {
-    "text": "Thank you.",
-    "start": 215.16214285714284,
-    "end": 215.37685714285712
-  },
-  {
-    "text": "And Second Vice Chair Whitmore.",
-    "start": 215.5915714285714,
     "end": 216.742
   },
   {
@@ -250,768 +140,68 @@
     "end": 216.91199999999998
   },
   {
-    "text": "Julien Bouquet: Awesome.",
+    "text": "Julien Bouquet: Awesome. We have 13 present, two absent. Pardon me. Moving on to our retiree awards. There are no retiree awards for this evening. Second quarter retiree awards will be announced at the June 24 Board of Directors meeting. Next is our public participation period, which is open to anyone who would like to address the Board. As we have both in-person and remote attendees, in-person comments will go first, followed by those who are participating remotely. For those attending in person, please come up to the podium when your name is called. If you have not already signed up to speak and would like to do so, please approach the podium, when I call for any additional speakers. For those attending virtually, if you wish to speak and have not already done so, please raise your virtual hand or press star 9 on your phone. Staff will unmute you when it is your turn to speak. If you're dialed in, press star 6 to toggle your mute settings. Please bear in mind that by participating in this process, you are being recorded. If you do not wish to be recorded, then your comments will have to be submitted via writing. If any speaker has documentation or reference materials for the Board, or if any member of the public would like to submit written comments, please email those materials to the Board Office at rtd.directors@rtd-denver.com. During this time, the Board will not offer any direct comments or responses. However, if you'd like to be contacted regarding your public comment, please email the RTD Board Office at rtd.directors@rtd- denver.com. Speakers should begin their remarks by stating their names and will have up to three minutes to provide their comments. Our first speaker tonight will be Joan Peck, Longmont mayor.",
     "start": 218.304,
-    "end": 218.304
-  },
-  {
-    "text": "We have 13 present, two absent.",
-    "start": 218.865,
-    "end": 221.91999999999996
-  },
-  {
-    "text": "Pardon me.",
-    "start": 223.633,
-    "end": 223.7835
-  },
-  {
-    "text": "Moving on to our retiree awards.",
-    "start": 225.817,
-    "end": 227.1853333333333
-  },
-  {
-    "text": "There are no retiree awards for this evening.",
-    "start": 227.8,
-    "end": 229.65850000000003
-  },
-  {
-    "text": "Second quarter retiree awards will be announced at the June 24 Board of Directors meeting.",
-    "start": 230.324,
-    "end": 235.3350666666667
-  },
-  {
-    "text": "Next is our public participation period, which is open to anyone who would like to address the Board.",
-    "start": 236.956,
-    "end": 241.6857777777776
-  },
-  {
-    "text": "As we have both in-person and remote attendees, in-person comments will go first, followed by those who are participating remotely.",
-    "start": 242.886,
-    "end": 250.0794000000001
-  },
-  {
-    "text": "For those attending in person, please come up to the podium when your name is called.",
-    "start": 251.881,
-    "end": 255.54526666666655
-  },
-  {
-    "text": "If you have not already signed up to speak and would like to do so, please approach the podium, when I call for any additional speakers.",
-    "start": 256.569,
-    "end": 262.62660000000056
-  },
-  {
-    "text": "For those attending virtually, if you wish to speak and have not already done so, please raise your virtual hand or press star 9 on your phone.",
-    "start": 263.618,
-    "end": 270.61970370370426
-  },
-  {
-    "text": "Staff will unmute you when it is your turn to speak.",
-    "start": 271.95,
-    "end": 274.4263636363639
-  },
-  {
-    "text": "If you're dialed in, press star 6 to toggle your mute settings.",
-    "start": 274.694,
-    "end": 278.2194999999998
-  },
-  {
-    "text": "Please bear in mind that by participating in this process, you are being recorded.",
-    "start": 279.421,
-    "end": 282.8799285714285
-  },
-  {
-    "text": "If you do not wish to be recorded, then your comments will have to be submitted via writing.",
-    "start": 284.008,
-    "end": 287.54494444444475
-  },
-  {
-    "text": "If any speaker has documentation or reference materials for the Board, or if any member of the public would like to submit written comments, please email those materials to the Board Office at rtd.directors@rtd-denver.com.",
-    "start": 288.425,
-    "end": 301.81541666666703
-  },
-  {
-    "text": "During this time, the Board will not offer any direct comments or responses.",
-    "start": 302.887,
-    "end": 306.2331538461536
-  },
-  {
-    "text": "However, if you'd like to be contacted regarding your public comment, please email the RTD Board Office at rtd.directors@rtd- denver.com.",
-    "start": 307.033,
-    "end": 317.187
-  },
-  {
-    "text": "Speakers should begin their remarks by stating their names and will have up to three minutes to provide their comments.",
-    "start": 317.187,
-    "end": 322.5336000000004
-  },
-  {
-    "text": "Our first speaker tonight will be Joan Peck, Longmont mayor.",
-    "start": 324.357,
     "end": 328.68330000000014
   },
   {
-    "text": "Joan Peck: Good evening.",
+    "text": "Joan Peck: Good evening. Chair Bouquet and Director Johnson and Board, thank you so much for letting me address you tonight. I am here representing not only the city of Longmont, but the Front Range Passenger Rail District Board, which I am the secretary of. I want you to know right off the bat that the Board has as many questions about this new draft of IGA that you do. So we are looking at it, scrutinizing it as well, but are very, very excited about the prospect of being able to work together and see this rail come to completion. I also want to thank this Board for the partnership that we have with our RIDE Longmont. We have exceeded 27,000 rides since December, which far outpaced the parent company of Via in Seattle. So we're really proud of that, and that is directly because of the partnership we are doing with you. So thank you very much. I am also going to ask for the LX1 to be restored. I get a little frustrated when you use ridership as a reason for not restoring that, because Bustang now, which is at the Firestone hub, is packed. Those buses are packed and that ridership should belong to RTD. And it makes me sad that that bus was cut and our people now aren't interested that much in RTD because Bustang is taking care of it and getting our money. I also want to let you know that I'm going to-- I'm switching hats here from the FRPR Board as well as city of Longmont. I want you to know that I am very excited about this rail for many reasons. First of all, it's an economic driver, and it is a huge project that I think that we should take pride in together. And to think about-- I know the cost is huge on both sides, but when we first heard about the cost of the Northwest corridor in about 2017, it was $1.2 or $1.4 billion. And now BNSF's value to you, to RTD, is 650 million. So that is quite a difference, and part of that is due to the fact that the last three cities on the Northwest corridor, Westminster, Broomfield, and Louisville are being taken off of your plate and FRPR is going to operate them. I don't know, as none of us know, how that funding is going to work out. But what I would like to offer and invite the RTD Executive Board. I think, I believe that when we sit down face to face and work out what it is we think can happen-- because our boards are the ones that are going to decide this, one way or the other. We're the ones that are going to vote. So if you would think about the Executive Committee and the Executive Board or Committee of FRPR and RTD sitting down together and just diving into this IGA and trying to figure out what can we vote for, what will really work for both of us, both districts. For me, that would be better in being able to see people face to face, emotions, talking and just working through it. Because I never like going through third parties telling us what we should or shouldn't be doing. But I understand that the Joint Service is probably going to happen. How do we want it to happen? And it is our boards that will decide that in the end. So thank you very much, and let's just keep rolling along.",
     "start": 335.033,
-    "end": 335.59178947368423
-  },
-  {
-    "text": "Chair Bouquet and Director Johnson and Board, thank you so much for letting me address you tonight.",
-    "start": 336.15057894736844,
-    "end": 345.0912105263159
-  },
-  {
-    "text": "I am here representing not only the city of Longmont, but the Front Range Passenger Rail District Board, which I am the secretary of.",
-    "start": 346.551,
-    "end": 353.9033333333329
-  },
-  {
-    "text": "I want you to know right off the bat that the Board has as many questions about this new draft of IGA that you do.",
-    "start": 354.203,
-    "end": 362.6846000000005
-  },
-  {
-    "text": "So we are looking at it, scrutinizing it as well, but are very, very excited about the prospect of being able to work together and see this rail come to completion.",
-    "start": 363.799,
-    "end": 375.23867741935567
-  },
-  {
-    "text": "I also want to thank this Board for the partnership that we have with our RIDE Longmont.",
-    "start": 376.521,
-    "end": 385.84299999999973
-  },
-  {
-    "text": "We have exceeded 27,000 rides since December, which far outpaced the parent company of Via in Seattle.",
-    "start": 386.485,
-    "end": 395.03841176470576
-  },
-  {
-    "text": "So we're really proud of that, and that is directly because of the partnership we are doing with you.",
-    "start": 396.254,
-    "end": 401.0023846153843
-  },
-  {
-    "text": "So thank you very much.",
-    "start": 401.318,
-    "end": 402.5516
-  },
-  {
-    "text": "I am also going to ask for the LX1 to be restored.",
-    "start": 404.661,
-    "end": 409.00407692307675
-  },
-  {
-    "text": "I get a little frustrated when you use ridership as a reason for not restoring that, because Bustang now, which is at the Firestone hub, is packed.",
-    "start": 409.386,
-    "end": 423.0936428571428
-  },
-  {
-    "text": "Those buses are packed and that ridership should belong to RTD.",
-    "start": 424.244,
-    "end": 429.55243749999977
-  },
-  {
-    "text": "And it makes me sad that that bus was cut and our people now aren't interested that much in RTD because Bustang is taking care of it and getting our money.",
-    "start": 430.08328124999974,
-    "end": 443.67236363636357
-  },
-  {
-    "text": "I also want to let you know that I'm going to-- I'm switching hats here from the FRPR Board as well as city of Longmont.",
-    "start": 445.84,
-    "end": 458.2433636363633
-  },
-  {
-    "text": "I want you to know that I am very excited about this rail for many reasons.",
-    "start": 459.054,
-    "end": 465.6150555555551
-  },
-  {
-    "text": "First of all, it's an economic driver, and it is a huge project that I think that we should take pride in together.",
-    "start": 466.542,
-    "end": 474.0178333333332
-  },
-  {
-    "text": "And to think about-- I know the cost is huge on both sides, but when we first heard about the cost of the Northwest corridor in about 2017, it was $1.2 or $1.4 billion.",
-    "start": 474.406,
-    "end": 489.6794761904762
-  },
-  {
-    "text": "And now BNSF's value to you, to RTD, is 650 million.",
-    "start": 490.119,
-    "end": 496.87263636363616
-  },
-  {
-    "text": "So that is quite a difference, and part of that is due to the fact that the last three cities on the Northwest corridor, Westminster, Broomfield, and Louisville are being taken off of your plate and FRPR is going to operate them.",
-    "start": 498.229,
-    "end": 518.5923529411764
-  },
-  {
-    "text": "I don't know, as none of us know, how that funding is going to work out.",
-    "start": 521.456,
-    "end": 526.2044375000005
-  },
-  {
-    "text": "But what I would like to offer and invite the RTD Executive Board.",
-    "start": 527.382,
-    "end": 532.7258400000004
-  },
-  {
-    "text": "I think, I believe that when we sit down face to face and work out what it is we think can happen-- because our boards are the ones that are going to decide this, one way or the other.",
-    "start": 533.1711600000004,
-    "end": 548.0189259259263
-  },
-  {
-    "text": "We're the ones that are going to vote.",
-    "start": 548.409,
-    "end": 549.5482499999997
-  },
-  {
-    "text": "So if you would think about the Executive Committee and the Executive Board or Committee of FRPR and RTD sitting down together and just diving into this IGA and trying to figure out what can we vote for, what will really work for both of us, both districts.",
-    "start": 550.512,
-    "end": 573.4364000000005
-  },
-  {
-    "text": "For me, that would be better in being able to see people face to face, emotions, talking and just working through it.",
-    "start": 575.063,
-    "end": 584.6599999999999
-  },
-  {
-    "text": "Because I never like going through third parties telling us what we should or shouldn't be doing.",
-    "start": 585.918,
-    "end": 591.2140000000003
-  },
-  {
-    "text": "But I understand that the Joint Service is probably going to happen.",
-    "start": 592.667,
-    "end": 596.6052000000001
-  },
-  {
-    "text": "How do we want it to happen?",
-    "start": 597.523,
-    "end": 598.7941428571431
-  },
-  {
-    "text": "And it is our boards that will decide that in the end.",
-    "start": 599.748,
-    "end": 603.0177499999996
-  },
-  {
-    "text": "So thank you very much, and let's just keep rolling along.",
-    "start": 604.197,
     "end": 609.7563333333331
   },
   {
-    "text": "Julien Bouquet: Thank you, Mayor Peck.",
+    "text": "Julien Bouquet: Thank you, Mayor Peck. Next up, we have Dr. Kay Baumann.",
     "start": 612.094,
-    "end": 612.7105000000001
-  },
-  {
-    "text": "Next up, we have Dr.",
-    "start": 613.838,
-    "end": 614.9031428571427
-  },
-  {
-    "text": "Kay Baumann.",
-    "start": 615.1694285714284,
     "end": 615.1694285714284
   },
   {
-    "text": "Kay Palmer Marsh: Well, good afternoon.",
+    "text": "Kay Palmer Marsh: Well, good afternoon. My name is Reverend Dr. Kay Palmer Marsh, and I'm from Longmont, Colorado. And I want to congratulate-- and thank you for having us all here. I really appreciate it. Thank you, Board, for the public participation. I want to thank you for what you've done in the past. You've had courage, vision, and guts to start this FasTracks program. I mean, I remember when I first moved to Denver 40 years ago, there was no such thing. I came from Chicago. And there was no such thing, and the Board had this vision and you went forward with it. And now there's a little bit of-- I think more than a little bit of hesitation about coming in all the way up to Longmont. Well, I want you to know that Longmont is a wonderful place. We just don't trust you all that much anymore because we've been paying for all the tax-- been paying taxes since 2005. But we're looking forward to this Board having the courage and the guts and the vision to make this happen for our community and communities down the line that have been paying taxes since 2005 on this. We voted to support this, and we still support it. It's just a little touchy right now. I do want to address equity. We look at equity in Longmont as how come Highlands Ranch has access to this wonderful rail? How come Boulder has so many buses? And in Longmont, we don't have so many buses. We keep getting cut. And of course, we don't have our rail yet either. And so we look at equity in a different way than you do. I also know that you have looked at equity in terms of-- in a different way that doesn't really make sense to us when we look at Boulder being very high income and having all their buses and good transportation. Highlands Ranch is another good example of a fairly high income community that has access to passenger rail. We, in Longmont, look for a more-- shall I say, a looser version of the equity argument. Right now it looks like the equity argument is being used so that we won't get it. On the other hand. I've heard some good things. I'm excited about what could happen. Again, Longmont is still-- we're developing trust, I hope, with the RTD. My neighbors don't particularly trust you. When I was walking around with one petition or another, they didn't want to even let me in the door when I said RTD. So thank you for this opportunity and I strongly support the Northwest Rail and I hope you will too.",
     "start": 615.1694285714284,
-    "end": 625.112
-  },
-  {
-    "text": "My name is Reverend Dr.",
-    "start": 625.466,
-    "end": 627.0486666666667
-  },
-  {
-    "text": "Kay Palmer Marsh, and I'm from Longmont, Colorado.",
-    "start": 627.4443333333334,
-    "end": 629.8183333333334
-  },
-  {
-    "text": "And I want to congratulate-- and thank you for having us all here.",
-    "start": 630.916,
-    "end": 634.1514999999998
-  },
-  {
-    "text": "I really appreciate it.",
-    "start": 634.482,
-    "end": 635.2934999999999
-  },
-  {
-    "text": "Thank you, Board, for the public participation.",
-    "start": 635.604,
-    "end": 638.128285714286
-  },
-  {
-    "text": "I want to thank you for what you've done in the past.",
-    "start": 639.311,
-    "end": 642.2314999999998
-  },
-  {
-    "text": "You've had courage, vision, and guts to start this FasTracks program.",
-    "start": 643.017,
-    "end": 649.7096666666666
-  },
-  {
-    "text": "I mean, I remember when I first moved to Denver 40 years ago, there was no such thing.",
-    "start": 650.731,
-    "end": 656.1966249999999
-  },
-  {
-    "text": "I came from Chicago.",
-    "start": 656.581,
-    "end": 657.4345
-  },
-  {
-    "text": "And there was no such thing, and the Board had this vision and you went forward with it.",
-    "start": 657.7189999999999,
-    "end": 664.1725454545449
-  },
-  {
-    "text": "And now there's a little bit of-- I think more than a little bit of hesitation about coming in all the way up to Longmont.",
-    "start": 664.535,
-    "end": 672.3077777777771
-  },
-  {
-    "text": "Well, I want you to know that Longmont is a wonderful place.",
-    "start": 674.508,
-    "end": 677.3716666666661
-  },
-  {
-    "text": "We just don't trust you all that much anymore because we've been paying for all the tax-- been paying taxes since 2005.",
-    "start": 679.113,
-    "end": 685.6276875000005
-  },
-  {
-    "text": "But we're looking forward to this Board having the courage and the guts and the vision to make this happen for our community and communities down the line that have been paying taxes since 2005 on this.",
-    "start": 687.204,
-    "end": 704.0154999999993
-  },
-  {
-    "text": "We voted to support this, and we still support it.",
-    "start": 705.033,
-    "end": 707.8806000000004
-  },
-  {
-    "text": "It's just a little touchy right now.",
-    "start": 709.117,
-    "end": 711.1081428571431
-  },
-  {
-    "text": "I do want to address equity.",
-    "start": 712.361,
-    "end": 714.1293333333332
-  },
-  {
-    "text": "We look at equity in Longmont as how come Highlands Ranch has access to this wonderful rail?",
-    "start": 715.444,
-    "end": 727.0139999999997
-  },
-  {
-    "text": "How come Boulder has so many buses?",
-    "start": 727.839,
-    "end": 732.3192857142855
-  },
-  {
-    "text": "And in Longmont, we don't have so many buses.",
-    "start": 733.086,
-    "end": 736.1126666666667
-  },
-  {
-    "text": "We keep getting cut.",
-    "start": 736.551,
-    "end": 737.2717499999999
-  },
-  {
-    "text": "And of course, we don't have our rail yet either.",
-    "start": 737.913,
-    "end": 740.6299999999995
-  },
-  {
-    "text": "And so we look at equity in a different way than you do.",
-    "start": 741.578,
-    "end": 744.5918461538467
-  },
-  {
-    "text": "I also know that you have looked at equity in terms of-- in a different way that doesn't really make sense to us when we look at Boulder being very high income and having all their buses and good transportation.",
-    "start": 744.863,
-    "end": 764.3659999999994
-  },
-  {
-    "text": "Highlands Ranch is another good example of a fairly high income community that has access to passenger rail.",
-    "start": 765.483,
-    "end": 771.8735882352937
-  },
-  {
-    "text": "We, in Longmont, look for a more-- shall I say, a looser version of the equity argument.",
-    "start": 772.933,
-    "end": 780.0900714285718
-  },
-  {
-    "text": "Right now it looks like the equity argument is being used so that we won't get it.",
-    "start": 781.29,
-    "end": 786.3262352941174
-  },
-  {
-    "text": "On the other hand.",
-    "start": 788.144,
-    "end": 788.879
-  },
-  {
-    "text": "I've heard some good things.",
-    "start": 789.124,
-    "end": 790.104
-  },
-  {
-    "text": "I'm excited about what could happen.",
-    "start": 790.509,
-    "end": 793.4489999999998
-  },
-  {
-    "text": "Again, Longmont is still-- we're developing trust, I hope, with the RTD.",
-    "start": 794.017,
-    "end": 801.4887500000003
-  },
-  {
-    "text": "My neighbors don't particularly trust you.",
-    "start": 802.228,
-    "end": 804.0430000000001
-  },
-  {
-    "text": "When I was walking around with one petition or another, they didn't want to even let me in the door when I said RTD.",
-    "start": 804.4060000000002,
-    "end": 812.7362666666671
-  },
-  {
-    "text": "So thank you for this opportunity and I strongly support the Northwest Rail and I hope you will too.",
-    "start": 813.0901333333338,
     "end": 820.5013333333336
   },
   {
-    "text": "Julien Bouquet: Thank you, Reverend Dr.",
+    "text": "Julien Bouquet: Thank you, Reverend Dr. Madelyn Marsh is our next speaker.",
     "start": 822.603,
-    "end": 823.6677000000001
-  },
-  {
-    "text": "Madelyn Marsh is our next speaker.",
-    "start": 824.0226000000001,
     "end": 825.7971000000003
   },
   {
-    "text": "Madelyn Marsh: Thank you, Board members, for allowing us to speak tonight.",
+    "text": "Madelyn Marsh: Thank you, Board members, for allowing us to speak tonight. My name is Madelyn Marsh. I'm also from Longmont, and I voted for FasTracks in my very first election. I was a brand new 18- year-old in 2004, and here we are 21 years later, and we still don't-- instead of a train to Longmont or more dedicated bus services, even, you have cut services to Longmont. And so it's frustrating to be here asking for more or for what we voted for and what you're legally obligated to provide based on the results of that election. In the 21 years since I voted for that, I ended up living in Chicago for a few years. I enjoyed a robust public transit system. I enjoyed the-- I took the bus, I took trains to work. I took trains to play. I took trains to the suburbs, to the city. And it was an economic driver for every community that was involved. There's bustling downtowns wherever you go. And like others have said, the people in Longmont are not inclined to trust RTD because the trust has been broken, that we keep getting pushed off and pushed off and pushed off. And so I would ask that you vote in favor of the Northwest Rail expansion, but also that you don't limit it to three trips every weekday, but that you have the vision to allow us to bring our money to Denver, to other communities for entertainment purposes as well as work purposes. Thank you very much for your time.",
     "start": 829.602,
-    "end": 832.7061000000004
-  },
-  {
-    "text": "My name is Madelyn Marsh.",
-    "start": 833.091,
-    "end": 833.8774
-  },
-  {
-    "text": "I'm also from Longmont, and I voted for FasTracks in my very first election.",
-    "start": 834.094,
-    "end": 840.4764000000001
-  },
-  {
-    "text": "I was a brand new 18- year-old in 2004, and here we are 21 years later, and we still don't-- instead of a train to Longmont or more dedicated bus services, even, you have cut services to Longmont.",
-    "start": 840.933,
-    "end": 856.8790000000017
-  },
-  {
-    "text": "And so it's frustrating to be here asking for more or for what we voted for and what you're legally obligated to provide based on the results of that election.",
-    "start": 857.2586666666684,
-    "end": 869.9151851851851
-  },
-  {
-    "text": "In the 21 years since I voted for that, I ended up living in Chicago for a few years.",
-    "start": 871.221,
-    "end": 877.1941578947367
-  },
-  {
-    "text": "I enjoyed a robust public transit system.",
-    "start": 877.546,
-    "end": 880.6351428571431
-  },
-  {
-    "text": "I enjoyed the-- I took the bus, I took trains to work.",
-    "start": 881.91,
-    "end": 885.2130000000002
-  },
-  {
-    "text": "I took trains to play.",
-    "start": 885.473,
-    "end": 886.5945999999999
-  },
-  {
-    "text": "I took trains to the suburbs, to the city.",
-    "start": 886.935,
-    "end": 889.1234444444449
-  },
-  {
-    "text": "And it was an economic driver for every community that was involved.",
-    "start": 889.377,
-    "end": 892.2782499999995
-  },
-  {
-    "text": "There's bustling downtowns wherever you go.",
-    "start": 892.963,
-    "end": 895.4529999999997
-  },
-  {
-    "text": "And like others have said, the people in Longmont are not inclined to trust RTD because the trust has been broken, that we keep getting pushed off and pushed off and pushed off.",
-    "start": 896.349,
-    "end": 910.0316363636367
-  },
-  {
-    "text": "And so I would ask that you vote in favor of the Northwest Rail expansion, but also that you don't limit it to three trips every weekday, but that you have the vision to allow us to bring our money to Denver, to other communities for entertainment purposes as well as work purposes.",
-    "start": 910.252,
-    "end": 932.0791666666667
-  },
-  {
-    "text": "Thank you very much for your time.",
-    "start": 933.6672500000001,
     "end": 935.3187500000003
   },
   {
-    "text": "Julien Bouquet: Thank you, Madelyn.",
+    "text": "Julien Bouquet: Thank you, Madelyn. I have Connor Shea as our next speaker.",
     "start": 936.274,
-    "end": 936.7013333333333
-  },
-  {
-    "text": "I have Connor Shea as our next speaker.",
-    "start": 937.555,
     "end": 939.3592499999999
   },
   {
-    "text": "Connor Shea: Good evening, Board.",
+    "text": "Connor Shea: Good evening, Board. My name is Connor Shea and I live in the Baker neighborhood of Denver. I'm here representing the Baker Historic Neighborhood Association as a member of its board. I live a few blocks from the Alameda station, and I use RTD's bus and rail services pretty frequently. As you're probably aware, Denver is in the process of considering a women's soccer league stadium at the former Gates Rubber Factory site, just west of the I-25 and Broadway Station. As the stadium will be across from the freight rail tracks-- across the freight rail tracks from the RTD station, transit riders need to cross over the FasTracks to reach the stadium from the various RTD bus and rail stations-- bus and rail connections at the station. Currently, the only pedestrian access route from the Broadway Station is the Southern Bridge, sometimes referred to as the bridge to nowhere. That path will be about 3/4 of a mile going from the station to the stadium, and then the same distance going back after a soccer game or other event at the venue. As a neighborhood, we intend to push for a North Bridge to the site connecting the station and stadium as directly as possible. And I'm here to ask for RTD's cooperation on this, since a bridge would require the use of RTD land on the Broadway Station. North Bridge has been in most past plans for development of the site but is considered optional as part of the non-binding agreement between the city and the stadium owners that city council passed a few weeks ago. The North Bridge connection would mean only one quarter mile of walking to go from the RTD station to the stadium. In total, the bridge would-- a North Bridge would save a full mile of walking, about 20 minutes, when going to the stadium and then back after an event ends. We believe that the shorter distance with the North Pedestrian Bridge would encourage significantly more transit usage when going to events at the stadium. The Broadway Station is accessible from the D, E, and H lines without a transfer, and all other lines with only one transfer. It's also accessible from a variety of bus routes. That would reduce traffic and emissions coming through our neighborhood and the other neighborhoods adjacent to the stadium. North Bridge would be good for our neighborhood, for the safety of pedestrians and transit users, as they won't have to cross as many streets when accessing the stadium, and would be good for RTD and extra fares and customers from events at the stadium. The extra bridge would provide better connections and redundancy for pedestrians. It would especially improve accessibility for folks with limited mobility. I'm here to ask for RTD's cooperation and support on getting this included in the stadium project, as we work on negotiating a community benefits agreement with the developer over the next few months. I sent an email to the Board and CEO Johnson about this on Friday and would be happy to receive any emails from the Board or CEO if anyone has any further questions about that. Thank you very much for your time.",
     "start": 952.692,
-    "end": 953.1859999999999
-  },
-  {
-    "text": "My name is Connor Shea and I live in the Baker neighborhood of Denver.",
-    "start": 954.495,
-    "end": 956.9687142857136
-  },
-  {
-    "text": "I'm here representing the Baker Historic Neighborhood Association as a member of its board.",
-    "start": 957.72,
-    "end": 961.8307857142859
-  },
-  {
-    "text": "I live a few blocks from the Alameda station, and I use RTD's bus and rail services pretty frequently.",
-    "start": 962.688,
-    "end": 967.2997894736851
-  },
-  {
-    "text": "As you're probably aware, Denver is in the process of considering a women's soccer league stadium at the former Gates Rubber Factory site, just west of the I-25 and Broadway Station.",
-    "start": 968.557,
-    "end": 977.4747419354826
-  },
-  {
-    "text": "As the stadium will be across from the freight rail tracks-- across the freight rail tracks from the RTD station, transit riders need to cross over the FasTracks to reach the stadium from the various RTD bus and rail stations-- bus and rail connections at the station.",
-    "start": 978.528,
-    "end": 993.6923404255331
-  },
-  {
-    "text": "Currently, the only pedestrian access route from the Broadway Station is the Southern Bridge, sometimes referred to as the bridge to nowhere.",
-    "start": 995.224,
-    "end": 1001.4342727272729
-  },
-  {
-    "text": "That path will be about 3/4 of a mile going from the station to the stadium, and then the same distance going back after a soccer game or other event at the venue.",
-    "start": 1001.77,
-    "end": 1013.1928333333342
-  },
-  {
-    "text": "As a neighborhood, we intend to push for a North Bridge to the site connecting the station and stadium as directly as possible.",
-    "start": 1014.652,
-    "end": 1020.1118260869571
-  },
-  {
-    "text": "And I'm here to ask for RTD's cooperation on this, since a bridge would require the use of RTD land on the Broadway Station.",
-    "start": 1020.74,
-    "end": 1027.456958333333
-  },
-  {
-    "text": "North Bridge has been in most past plans for development of the site but is considered optional as part of the non-binding agreement between the city and the stadium owners that city council passed a few weeks ago.",
-    "start": 1029.7776,
-    "end": 1039.5665599999982
-  },
-  {
-    "text": "The North Bridge connection would mean only one quarter mile of walking to go from the RTD station to the stadium.",
-    "start": 1041.093,
-    "end": 1048.4187142857165
-  },
-  {
-    "text": "In total, the bridge would-- a North Bridge would save a full mile of walking, about 20 minutes, when going to the stadium and then back after an event ends.",
-    "start": 1049.947,
-    "end": 1059.0373448275839
-  },
-  {
-    "text": "We believe that the shorter distance with the North Pedestrian Bridge would encourage significantly more transit usage when going to events at the stadium.",
-    "start": 1059.713,
-    "end": 1067.7570344827593
-  },
-  {
-    "text": "The Broadway Station is accessible from the D, E, and H lines without a transfer, and all other lines with only one transfer.",
-    "start": 1068.0292068965525,
-    "end": 1073.74482758621
-  },
-  {
-    "text": "It's also accessible from a variety of bus routes.",
-    "start": 1074.819,
-    "end": 1077.1043333333332
-  },
-  {
-    "text": "That would reduce traffic and emissions coming through our neighborhood and the other neighborhoods adjacent to the stadium.",
-    "start": 1077.3899999999999,
-    "end": 1082.246333333333
-  },
-  {
-    "text": "North Bridge would be good for our neighborhood, for the safety of pedestrians and transit users, as they won't have to cross as many streets when accessing the stadium, and would be good for RTD and extra fares and customers from events at the stadium.",
-    "start": 1084.552847826087,
-    "end": 1098.6261521739136
-  },
-  {
-    "text": "The extra bridge would provide better connections and redundancy for pedestrians.",
-    "start": 1099.687,
-    "end": 1103.0803333333333
-  },
-  {
-    "text": "It would especially improve accessibility for folks with limited mobility.",
-    "start": 1103.4196666666667,
-    "end": 1106.4736666666668
-  },
-  {
-    "text": "I'm here to ask for RTD's cooperation and support on getting this included in the stadium project, as we work on negotiating a community benefits agreement with the developer over the next few months.",
-    "start": 1108.455,
-    "end": 1117.8990625000001
-  },
-  {
-    "text": "I sent an email to the Board and CEO Johnson about this on Friday and would be happy to receive any emails from the Board or CEO if anyone has any further questions about that.",
-    "start": 1119.378,
-    "end": 1129.3215428571405
-  },
-  {
-    "text": "Thank you very much for your time.",
-    "start": 1130.255,
     "end": 1131.0615714285714
   },
   {
-    "text": "Julien Bouquet: Thank you for your comments, sir.",
+    "text": "Julien Bouquet: Thank you for your comments, sir. I will now move to online participants, Mr. Kroll, does anyone have their virtual hand raised?",
     "start": 1132.258,
-    "end": 1133.0254999999997
-  },
-  {
-    "text": "I will now move to online participants, Mr.",
-    "start": 1134.681,
-    "end": 1137.546
-  },
-  {
-    "text": "Kroll, does anyone have their virtual hand raised?",
-    "start": 1137.8664444444446,
     "end": 1140.1095555555564
   },
   {
-    "text": "Jack Kroll: Yes.",
+    "text": "Jack Kroll: Yes. At this time, we have a number of folks with their hands raised. The first is former RTD Director Claudia Folska.",
     "start": 1141.203,
-    "end": 1141.203
-  },
-  {
-    "text": "At this time, we have a number of folks with their hands raised.",
-    "start": 1141.4189999999999,
-    "end": 1144.0109999999986
-  },
-  {
-    "text": "The first is former RTD Director Claudia Folska.",
-    "start": 1144.647,
     "end": 1147.468
   },
   {
-    "text": "Julien Bouquet: Ms.",
+    "text": "Julien Bouquet: Ms. Folska.",
     "start": 1150.594,
-    "end": 1150.594
-  },
-  {
-    "text": "Folska.",
-    "start": 1150.754,
     "end": 1150.754
   },
   {
-    "text": "Jack Kroll: So, Ms.",
+    "text": "Jack Kroll: So, Ms. Folska, it looks like you briefly came off mute and then went right back on. You are unmuted.",
     "start": 1161.627,
-    "end": 1161.8474999999999
-  },
-  {
-    "text": "Folska, it looks like you briefly came off mute and then went right back on.",
-    "start": 1162.128,
-    "end": 1165.454399999999
-  },
-  {
-    "text": "You are unmuted.",
-    "start": 1166.792,
     "end": 1167.3559999999998
   },
   {
-    "text": "Claudia Folska: Whew.",
+    "text": "Claudia Folska: Whew. This is a huge achievement, guys. Oh, God. I was so thrilled to hear the earlier special session. And kudos to all of you, especially General Manager/CEO Debra Johnson. What a great accomplishment. Lisa Kaufman, Diane. And now I'm forgetting her last name. But I mean, everybody was really amazing. I would ask the Chair to afford me a little bit more time, as it's customary for former Directors to be granted additional time as they have institutional knowledge to share and inform the Board. Would that be OK with you, Mr. Chair?",
     "start": 1167.961,
-    "end": 1169.371
-  },
-  {
-    "text": "This is a huge achievement, guys.",
-    "start": 1169.371,
-    "end": 1171.1843333333334
-  },
-  {
-    "text": "Oh, God.",
-    "start": 1172.742,
-    "end": 1173.3325
-  },
-  {
-    "text": "I was so thrilled to hear the earlier special session.",
-    "start": 1174.564,
-    "end": 1179.1834545454553
-  },
-  {
-    "text": "And kudos to all of you, especially General Manager/CEO Debra Johnson.",
-    "start": 1179.6967272727281,
-    "end": 1185.342727272729
-  },
-  {
-    "text": "What a great accomplishment.",
-    "start": 1186.196,
-    "end": 1187.8475
-  },
-  {
-    "text": "Lisa Kaufman, Diane.",
-    "start": 1188.538,
-    "end": 1190.1666666666665
-  },
-  {
-    "text": "And now I'm forgetting her last name.",
-    "start": 1191.782,
-    "end": 1194.3560000000004
-  },
-  {
-    "text": "But I mean, everybody was really amazing.",
-    "start": 1194.7850000000005,
-    "end": 1197.359000000001
-  },
-  {
-    "text": "I would ask the Chair to afford me a little bit more time, as it's customary for former Directors to be granted additional time as they have institutional knowledge to share and inform the Board.",
-    "start": 1197.768,
-    "end": 1214.8427999999967
-  },
-  {
-    "text": "Would that be OK with you, Mr.",
-    "start": 1215.746,
-    "end": 1217.0667500000004
-  },
-  {
-    "text": "Chair?",
-    "start": 1217.2868750000005,
     "end": 1217.2868750000005
   },
   {
@@ -1020,353 +210,23 @@
     "end": 1218.438
   },
   {
-    "text": "Claudia Folska: Thank you very much.",
+    "text": "Claudia Folska: Thank you very much. I appreciate that. So I was reflecting on my early days on the Board, and we were desperately trying to find the money to do the R line, which goes through district B and F, I think. I don't remember. But anyway, and Phil Washington was our Executive Director then, and he had this brilliant motto. He always said, every day, practically, we will build as much as we can as fast as we can, no matter what. But when it came time to find the money for the R line, he would pick up any nickel under any rock. And you can ask him that. And those are his words. And he opened up a meeting, a luncheon for all business leaders, small and large, to figure out, this is what we have to work with. How can we do it? And it took a series of IGAs to get this thing done. Lots of them. So we're on the way, we're moving along. Everything is great. And then Bruce Benson, who was the president of the University of Colorado, comes over to the Board and says, hey, hey. No, no, no. We need you to change the alignment of the R line and take it off of Montview Boulevard, right through Anschutz Medical Center campus. Now, you can imagine-- we're like, what? How is this-- I mean, this was a huge shock, blow to all of us. And what were we going to do? Well, you know what that means? It requires 10 votes. A super majority. And guess what? Those folks in Longmont, in the north, they weren't having it. They were not going to do it. But it required all of us, each and every one of us, to have those one on one discussions and promise, promise the people in the north, let's just get this one thing done and then we can move on to the north. Now it's their turn. Now it's time to finish the Northwest Rail. And those numbers, the finances and all of that, they'll come out. You guys will figure it out. Everybody is coming together. All those different entities, and then IGA is so critical to proceed and move forward and do what the voters elected to have done. FasTracks, they elected you to finish it. You may not even like it, but it's not you. It's the people that voted for it. It's the RTD's obligation. And by the way, of the 3.1 million people living in the district, 97% of them don't even use RTD and they're paying for that train. And now you have this wonderful, exciting, incredible opportunity to finish it and even connect beyond the district into Fort Collins. What a boon for everybody and for the entire state, quite frankly. So I'm like, you can probably tell I'm so excited and proud of you guys. It's like, whew. About time. Now, the other topic that's on my mind is Access-on-Demand. Your annual operating budget is $1.32 billion. And if you're thinking about equity and 20% of the population, roughly, a little more, little less, are people with disabilities, then 20% of that operating budget is closer to $264 million, and Access-on-Demand isn't anywhere close to that. I don't think either one of these recommendations to the Board makes sense at all, and I would encourage you to look at it again. I mean, the numbers keep changing, by the way, for the subsidies, $16 to now $22 for Access-on-Demand. Now it's 100 for Access-a-Ride. And why not think-- like, Einstein said you can get from point A to B with logic, but you can get everywhere with your imagination. What if you applied the Access-on-Demand model to Access-a-Ride using those vehicles? You could start with a little pilot and see how it worked. You could even use it to pick up other people. There's no prohibition from other people using those paratransit vehicles, and most of the time they're sitting in a parking lot with a driver sleeping. So of course, I haven't seen that. But I've been told--",
     "start": 1219.529,
-    "end": 1220.0997500000003
+    "end": 1523.167923076922
   },
   {
-    "text": "I appreciate that.",
-    "start": 1220.31,
-    "end": 1222.3386666666665
-  },
-  {
-    "text": "So I was reflecting on my early days on the Board, and we were desperately trying to find the money to do the R line, which goes through district B and F, I think.",
-    "start": 1223.992,
-    "end": 1241.8731470588264
-  },
-  {
-    "text": "I don't remember.",
-    "start": 1242.435,
-    "end": 1243.1460000000002
-  },
-  {
-    "text": "But anyway, and Phil Washington was our Executive Director then, and he had this brilliant motto.",
-    "start": 1243.5015000000003,
-    "end": 1250.9825999999985
-  },
-  {
-    "text": "He always said, every day, practically, we will build as much as we can as fast as we can, no matter what.",
-    "start": 1251.954,
-    "end": 1258.669227272727
-  },
-  {
-    "text": "But when it came time to find the money for the R line, he would pick up any nickel under any rock.",
-    "start": 1259.65,
-    "end": 1267.632555555556
-  },
-  {
-    "text": "And you can ask him that.",
-    "start": 1268.064,
-    "end": 1268.964833333333
-  },
-  {
-    "text": "And those are his words.",
-    "start": 1269.946,
-    "end": 1271.0187999999998
-  },
-  {
-    "text": "And he opened up a meeting, a luncheon for all business leaders, small and large, to figure out, this is what we have to work with.",
-    "start": 1271.307,
-    "end": 1281.3541153846172
-  },
-  {
-    "text": "How can we do it?",
-    "start": 1281.977,
-    "end": 1282.6970000000003
-  },
-  {
-    "text": "And it took a series of IGAs to get this thing done.",
-    "start": 1283.578,
-    "end": 1287.4866666666676
-  },
-  {
-    "text": "Lots of them.",
-    "start": 1288.342,
-    "end": 1288.7293333333332
-  },
-  {
-    "text": "So we're on the way, we're moving along.",
-    "start": 1288.983,
-    "end": 1291.038
-  },
-  {
-    "text": "Everything is great.",
-    "start": 1291.385,
-    "end": 1291.9856666666667
-  },
-  {
-    "text": "And then Bruce Benson, who was the president of the University of Colorado, comes over to the Board and says, hey, hey.",
-    "start": 1293.047,
-    "end": 1302.4196808510637
-  },
-  {
-    "text": "No, no, no.",
-    "start": 1303.6628936170212,
-    "end": 1303.6628936170212
-  },
-  {
-    "text": "We need you to change the alignment of the R line and take it off of Montview Boulevard, right through Anschutz Medical Center campus.",
-    "start": 1304.0772978723403,
-    "end": 1313.6085957446805
-  },
-  {
-    "text": "Now, you can imagine-- we're like, what?",
-    "start": 1314.188,
-    "end": 1317.1863333333333
-  },
-  {
-    "text": "How is this-- I mean, this was a huge shock, blow to all of us.",
-    "start": 1317.714,
-    "end": 1322.928916666666
-  },
-  {
-    "text": "And what were we going to do?",
-    "start": 1323.623,
-    "end": 1324.7570000000005
-  },
-  {
-    "text": "Well, you know what that means?",
-    "start": 1324.966,
-    "end": 1326.4676666666667
-  },
-  {
-    "text": "It requires 10 votes.",
-    "start": 1327.209,
-    "end": 1329.046285714286
-  },
-  {
-    "text": "A super majority.",
-    "start": 1329.6587142857145,
-    "end": 1330.8835714285717
-  },
-  {
-    "text": "And guess what?",
-    "start": 1331.536,
-    "end": 1332.3373333333334
-  },
-  {
-    "text": "Those folks in Longmont, in the north, they weren't having it.",
-    "start": 1333.299,
-    "end": 1336.8871818181815
-  },
-  {
-    "text": "They were not going to do it.",
-    "start": 1337.947,
-    "end": 1339.7152857142853
-  },
-  {
-    "text": "But it required all of us, each and every one of us, to have those one on one discussions and promise, promise the people in the north, let's just get this one thing done and then we can move on to the north.",
-    "start": 1339.99,
-    "end": 1353.7421951219515
-  },
-  {
-    "text": "Now it's their turn.",
-    "start": 1354.927,
-    "end": 1356.2184999999997
-  },
-  {
-    "text": "Now it's time to finish the Northwest Rail.",
-    "start": 1357.21,
-    "end": 1361.1343750000005
-  },
-  {
-    "text": "And those numbers, the finances and all of that, they'll come out.",
-    "start": 1361.675,
-    "end": 1365.2738333333336
-  },
-  {
-    "text": "You guys will figure it out.",
-    "start": 1366.041,
-    "end": 1367.1260000000004
-  },
-  {
-    "text": "Everybody is coming together.",
-    "start": 1367.904,
-    "end": 1368.9705000000004
-  },
-  {
-    "text": "All those different entities, and then IGA is so critical to proceed and move forward and do what the voters elected to have done.",
-    "start": 1369.346,
-    "end": 1379.2695416666645
-  },
-  {
-    "text": "FasTracks, they elected you to finish it.",
-    "start": 1380.182,
-    "end": 1381.987125
-  },
-  {
-    "text": "You may not even like it, but it's not you.",
-    "start": 1382.726,
-    "end": 1385.1956000000002
-  },
-  {
-    "text": "It's the people that voted for it.",
-    "start": 1385.51,
-    "end": 1387.4668571428576
-  },
-  {
-    "text": "It's the RTD's obligation.",
-    "start": 1387.973,
-    "end": 1389.8809999999999
-  },
-  {
-    "text": "And by the way, of the 3.1 million people living in the district, 97% of them don't even use RTD and they're paying for that train.",
-    "start": 1391.645,
-    "end": 1402.8594230769218
-  },
-  {
-    "text": "And now you have this wonderful, exciting, incredible opportunity to finish it and even connect beyond the district into Fort Collins.",
-    "start": 1403.845,
-    "end": 1412.7116666666677
-  },
-  {
-    "text": "What a boon for everybody and for the entire state, quite frankly.",
-    "start": 1413.215,
-    "end": 1417.7112500000005
-  },
-  {
-    "text": "So I'm like, you can probably tell I'm so excited and proud of you guys.",
-    "start": 1418.681,
-    "end": 1424.211933333334
-  },
-  {
-    "text": "It's like, whew.",
-    "start": 1424.868,
-    "end": 1425.7887999999998
-  },
-  {
-    "text": "About time.",
-    "start": 1426.2491999999997,
-    "end": 1426.7095999999997
-  },
-  {
-    "text": "Now, the other topic that's on my mind is Access-on-Demand.",
-    "start": 1428.263,
-    "end": 1433.3854999999999
-  },
-  {
-    "text": "Your annual operating budget is $1.32 billion.",
-    "start": 1436.235,
-    "end": 1439.891571428572
-  },
-  {
-    "text": "And if you're thinking about equity and 20% of the population, roughly, a little more, little less, are people with disabilities, then 20% of that operating budget is closer to $264 million, and Access-on-Demand isn't anywhere close to that.",
-    "start": 1441.242,
-    "end": 1460.7107777777771
-  },
-  {
-    "text": "I don't think either one of these recommendations to the Board makes sense at all, and I would encourage you to look at it again.",
-    "start": 1462.056,
-    "end": 1470.4873999999995
-  },
-  {
-    "text": "I mean, the numbers keep changing, by the way, for the subsidies, $16 to now $22 for Access-on-Demand.",
-    "start": 1470.913,
-    "end": 1477.8355714285715
-  },
-  {
-    "text": "Now it's 100 for Access-a-Ride.",
-    "start": 1479.05,
-    "end": 1480.768285714286
-  },
-  {
-    "text": "And why not think-- like, Einstein said you can get from point A to B with logic, but you can get everywhere with your imagination.",
-    "start": 1482.639,
-    "end": 1493.411666666668
-  },
-  {
-    "text": "What if you applied the Access-on-Demand model to Access-a-Ride using those vehicles?",
-    "start": 1494.11,
-    "end": 1501.0015624999987
-  },
-  {
-    "text": "You could start with a little pilot and see how it worked.",
-    "start": 1501.962,
-    "end": 1505.0282499999994
-  },
-  {
-    "text": "You could even use it to pick up other people.",
-    "start": 1505.908,
-    "end": 1507.8727
-  },
-  {
-    "text": "There's no prohibition from other people using those paratransit vehicles, and most of the time they're sitting in a parking lot with a driver sleeping.",
-    "start": 1508.492,
-    "end": 1518.487933333334
-  },
-  {
-    "text": "So of course, I haven't seen that.",
-    "start": 1519.675,
-    "end": 1521.421461538461
-  },
-  {
-    "text": "But I've been told-- Julien Bouquet: Former Director Folska, if you could wrap up your comments.",
-    "start": 1521.7125384615379,
-    "end": 1525.778764705882
-  },
-  {
-    "text": "You're about double the time right now.",
-    "start": 1526.0342941176466,
+    "text": "Julien Bouquet: Former Director Folska, if you could wrap up your comments. You're about double the time right now.",
+    "start": 1523.479,
     "end": 1527.5674705882345
   },
   {
-    "text": "Claudia Folska: OK.",
+    "text": "Claudia Folska: OK. I appreciate it. Thank you. I think that's it. So I would encourage you, sign the IGA. Go forward with that. Vote yes on it. And ask staff to go back and start using their imagination for better Access-on-Demand for everybody. Thank you very much for your time.",
     "start": 1528.344,
-    "end": 1528.62425
-  },
-  {
-    "text": "I appreciate it.",
-    "start": 1528.62425,
-    "end": 1529.1847500000001
-  },
-  {
-    "text": "Thank you.",
-    "start": 1529.545,
-    "end": 1529.725
-  },
-  {
-    "text": "I think that's it.",
-    "start": 1529.925,
-    "end": 1531.1564999999998
-  },
-  {
-    "text": "So I would encourage you, sign the IGA.",
-    "start": 1531.647,
-    "end": 1534.5283235294119
-  },
-  {
-    "text": "Go forward with that.",
-    "start": 1534.9399411764707,
-    "end": 1536.1747941176473
-  },
-  {
-    "text": "Vote yes on it.",
-    "start": 1536.586411764706,
-    "end": 1537.8212647058826
-  },
-  {
-    "text": "And ask staff to go back and start using their imagination for better Access-on-Demand for everybody.",
-    "start": 1538.2328823529415,
-    "end": 1545.230382352942
-  },
-  {
-    "text": "Thank you very much for your time.",
-    "start": 1545.722,
     "end": 1546.888571428571
   },
   {
-    "text": "Julien Bouquet: Thank you, Former Director Folska.",
+    "text": "Julien Bouquet: Thank you, Former Director Folska. Mr. Kroll, our next participant.",
     "start": 1548.16,
-    "end": 1549.3639999999998
-  },
-  {
-    "text": "Mr.",
-    "start": 1550.006,
-    "end": 1550.006
-  },
-  {
-    "text": "Kroll, our next participant.",
-    "start": 1550.2908,
     "end": 1551.1451999999997
   },
   {
@@ -1375,223 +235,38 @@
     "end": 1554.73575
   },
   {
-    "text": "Julien Bouquet: Former Director Tisdale.",
+    "text": "Julien Bouquet: Former Director Tisdale. You're recognized.",
     "start": 1555.584,
-    "end": 1556.6591999999998
-  },
-  {
-    "text": "You're recognized.",
-    "start": 1557.1967999999997,
     "end": 1557.7343999999996
   },
   {
-    "text": "Doug Tisdale: Thank you very much.",
+    "text": "Doug Tisdale: Thank you very much. I appreciate the opportunity to visit with you this evening. I am Doug Tisdale, Former Director for District H. And I apologize, you're only seeing a picture of me instead of my face in person, but I guess that's the restriction. In any event, I'll try to keep this within the time constraints. The comment was made during public participation earlier. Highlands Ranch has access to rail. At the risk of being struck by lightning for contesting the testimony of a Reverend, Highlands Ranch does not have access to rail. The Southwest rail extension, what I affectionately refer to as the SWRE is one of the unfinished corridors of FasTracks. My successor, as District H Director, made a reference to that in the special meeting earlier today, many hours ago. The legislature, at the urging of the governor, only prioritize service for the Northwest Rail, with no reference to the Southwest Rail extension, the SWRE. I must confess that I must have been an inadequate voice on behalf of the SWRE. I apologize to my former constituents, and can only hope that my successor, as Vice Chair of this Board, will be more impactful. That said, kudos to all of you for proceeding with the steps toward Northwest Rail completion. I can only hope that we find the political will, the political courage to address the SWRE with the same kind of passion. Thank you very much, Mr. Chairman.",
     "start": 1560.901,
-    "end": 1561.6817500000002
-  },
-  {
-    "text": "I appreciate the opportunity to visit with you this evening.",
-    "start": 1562.102,
-    "end": 1566.1376
-  },
-  {
-    "text": "I am Doug Tisdale, Former Director for District H.",
-    "start": 1566.606,
-    "end": 1571.4773333333326
-  },
-  {
-    "text": "And I apologize, you're only seeing a picture of me instead of my face in person, but I guess that's the restriction.",
-    "start": 1572.0862499999992,
-    "end": 1580.33690909091
-  },
-  {
-    "text": "In any event, I'll try to keep this within the time constraints.",
-    "start": 1580.6926818181828,
-    "end": 1584.2248888888896
-  },
-  {
-    "text": "The comment was made during public participation earlier.",
-    "start": 1586.284,
-    "end": 1589.6649999999997
-  },
-  {
-    "text": "Highlands Ranch has access to rail.",
-    "start": 1590.584,
-    "end": 1593.9715
-  },
-  {
-    "text": "At the risk of being struck by lightning for contesting the testimony of a Reverend, Highlands Ranch does not have access to rail.",
-    "start": 1595.991,
-    "end": 1608.3090869565208
-  },
-  {
-    "text": "The Southwest rail extension, what I affectionately refer to as the SWRE is one of the unfinished corridors of FasTracks.",
-    "start": 1609.77,
-    "end": 1618.521761904762
-  },
-  {
-    "text": "My successor, as District H Director, made a reference to that in the special meeting earlier today, many hours ago.",
-    "start": 1619.795,
-    "end": 1629.7671500000004
-  },
-  {
-    "text": "The legislature, at the urging of the governor, only prioritize service for the Northwest Rail, with no reference to the Southwest Rail extension, the SWRE.",
-    "start": 1630.933,
-    "end": 1644.259720000001
-  },
-  {
-    "text": "I must confess that I must have been an inadequate voice on behalf of the SWRE.",
-    "start": 1645.476,
-    "end": 1652.9440000000006
-  },
-  {
-    "text": "I apologize to my former constituents, and can only hope that my successor, as Vice Chair of this Board, will be more impactful.",
-    "start": 1654.223,
-    "end": 1665.4076086956543
-  },
-  {
-    "text": "That said, kudos to all of you for proceeding with the steps toward Northwest Rail completion.",
-    "start": 1666.697,
-    "end": 1674.2241874999986
-  },
-  {
-    "text": "I can only hope that we find the political will, the political courage to address the SWRE with the same kind of passion.",
-    "start": 1675.427,
-    "end": 1685.688315789473
-  },
-  {
-    "text": "Thank you very much, Mr.",
-    "start": 1686.991,
-    "end": 1688.3923333333332
-  },
-  {
-    "text": "Chairman.",
-    "start": 1688.7426666666665,
     "end": 1688.7426666666665
   },
   {
-    "text": "Julien Bouquet: Thank you, Former Director Tisdale Mr.",
+    "text": "Julien Bouquet: Thank you, Former Director Tisdale Mr. Kroll, our next speaker.",
     "start": 1689.434,
-    "end": 1691.657
-  },
-  {
-    "text": "Kroll, our next speaker.",
-    "start": 1691.9322499999998,
     "end": 1692.4827500000001
   },
   {
-    "text": "Jack Kroll: Yes.",
+    "text": "Jack Kroll: Yes. Next we have Maitri Lazaroff.",
     "start": 1696.883,
-    "end": 1696.883
-  },
-  {
-    "text": "Next we have Maitri Lazaroff.",
-    "start": 1697.6573333333333,
     "end": 1700.7546666666665
   },
   {
-    "text": "Maitri Lazaroff: Hello.",
+    "text": "Maitri Lazaroff: Hello. I'm Maitri Lazaroff, and I am not here to talk about Northwest Rail. I am an RTD rider, and I was formerly a regular rider of the E line. And the reason I say former is, like many other riders, I was pushed off the light rail a year ago due to the fact that I could no longer rely on it as reliable transportation. And now that issue that caused me to be pushed off of the train is solved. And I know there's already been a little bit of outreach on this. There's an article on your website, but it is my opinion that RTD needs to be as loud as possible with this. It's a sad fact that the majority of people in the metro don't ride transit, and we need to yell to get news like this out, because it's hard for it to spread with light announcements and word of mouth. We have lost, as of 2024, 21.6% of E line riders and 31.4% of H line riders. And not only is that a massive hit to the light rail system, but it bleeds to the rest of the system by people not being able to make those transfers. We saw ridership decreases on all three of our rail lines last year. And it's just, Directors making Reddit posts just really isn't enough. Could we maybe give two weeks of free fares to try and really get eyes back on the system to try and really make an effort to undo this ridership destruction that we've seen on our light rail? And especially on the Southeast corridor. Thank you. That's my time.",
     "start": 1700.7546666666665,
-    "end": 1701.589
-  },
-  {
-    "text": "I'm Maitri Lazaroff, and I am not here to talk about Northwest Rail.",
-    "start": 1702.482,
-    "end": 1707.786923076923
-  },
-  {
-    "text": "I am an RTD rider, and I was formerly a regular rider of the E line.",
-    "start": 1709.21,
-    "end": 1713.775
-  },
-  {
-    "text": "And the reason I say former is, like many other riders, I was pushed off the light rail a year ago due to the fact that I could no longer rely on it as reliable transportation.",
-    "start": 1713.775,
-    "end": 1723.85986111111
-  },
-  {
-    "text": "And now that issue that caused me to be pushed off of the train is solved.",
-    "start": 1724.448,
-    "end": 1729.3286249999985
-  },
-  {
-    "text": "And I know there's already been a little bit of outreach on this.",
-    "start": 1729.634,
-    "end": 1732.2047692307706
-  },
-  {
-    "text": "There's an article on your website, but it is my opinion that RTD needs to be as loud as possible with this.",
-    "start": 1732.439,
-    "end": 1740.6352500000005
-  },
-  {
-    "text": "It's a sad fact that the majority of people in the metro don't ride transit, and we need to yell to get news like this out, because it's hard for it to spread with light announcements and word of mouth.",
-    "start": 1742.6765714285714,
-    "end": 1756.487214285713
-  },
-  {
-    "text": "We have lost, as of 2024, 21.6% of E line riders and 31.4% of H line riders.",
-    "start": 1757.14,
-    "end": 1765.9814666666682
-  },
-  {
-    "text": "And not only is that a massive hit to the light rail system, but it bleeds to the rest of the system by people not being able to make those transfers.",
-    "start": 1767.254,
-    "end": 1777.6119285714271
-  },
-  {
-    "text": "We saw ridership decreases on all three of our rail lines last year.",
-    "start": 1777.977,
-    "end": 1781.8622307692297
-  },
-  {
-    "text": "And it's just, Directors making Reddit posts just really isn't enough.",
-    "start": 1783.178,
-    "end": 1787.7250769230761
-  },
-  {
-    "text": "Could we maybe give two weeks of free fares to try and really get eyes back on the system to try and really make an effort to undo this ridership destruction that we've seen on our light rail?",
-    "start": 1790.4622407407408,
-    "end": 1804.727462962964
-  },
-  {
-    "text": "And especially on the Southeast corridor.",
-    "start": 1805.0671111111121,
-    "end": 1806.765351851853
-  },
-  {
-    "text": "Thank you.",
-    "start": 1808.0196666666666,
-    "end": 1808.1933333333332
-  },
-  {
-    "text": "That's my time.",
-    "start": 1808.407,
     "end": 1809.021
   },
   {
-    "text": "Julien Bouquet: Thank you, Maitri.",
+    "text": "Julien Bouquet: Thank you, Maitri. Mr. Kroll, our next speaker.",
     "start": 1810.349,
-    "end": 1810.803
-  },
-  {
-    "text": "Mr.",
-    "start": 1811.53,
-    "end": 1811.53
-  },
-  {
-    "text": "Kroll, our next speaker.",
-    "start": 1811.8104,
     "end": 1812.6516000000004
   },
   {
-    "text": "Jack Kroll: Yes.",
+    "text": "Jack Kroll: Yes. Next, we have Richard Bamber.",
     "start": 1813.672,
-    "end": 1813.672
-  },
-  {
-    "text": "Next, we have Richard Bamber.",
-    "start": 1814.046,
     "end": 1815.5420000000001
   },
   {
@@ -1600,73 +275,13 @@
     "end": 1817.813
   },
   {
-    "text": "Richard Bamber: Good evening, and thank you for the opportunity to speak tonight.",
+    "text": "Richard Bamber: Good evening, and thank you for the opportunity to speak tonight. I'd like to talk about the Title VI changes, which are up for approval tonight. GBT is generally in support of these changes, although we know a yes vote, needs to be carried out against the backdrop that a review of the methodology is needed in the medium term. Currently, RTD's only reliable data source uses Census data about what sort of populations demographics live in certain neighborhoods. So we make lots of effort to ensure service outside the front doors of equity populations is sufficiently good that they're not left behind when service is improved and they're not unfairly targeted when service has to be cut. However, this approach only assumes equity populations only travel locally within the communities they reside. A good transit network can level up communities and spread wealth across its entire metro area. There's no point in running 15 minute frequency buses past the doorsteps of a low income or BIPOC community if they then have to transfer onto another bus which runs every 60 minutes and drops you a mile away from that well-paying employer. The current Title VI process fails to consider how a local transit network either succeeds or fails to service equity populations effectively, and it is because it considers the routes basically in silos. And this is why, while we support the Title VI, we support the agency's efforts, we believe that it could be made a much more effective process if new data sources are considered and the methodology is reviewed. Thank you very much for letting me speak tonight.",
     "start": 1820.665,
-    "end": 1824.6177272727264
-  },
-  {
-    "text": "I'd like to talk about the Title VI changes, which are up for approval tonight.",
-    "start": 1825.033,
-    "end": 1830.8468571428575
-  },
-  {
-    "text": "GBT is generally in support of these changes, although we know a yes vote, needs to be carried out against the backdrop that a review of the methodology is needed in the medium term.",
-    "start": 1832.138,
-    "end": 1844.141264705886
-  },
-  {
-    "text": "Currently, RTD's only reliable data source uses Census data about what sort of populations demographics live in certain neighborhoods.",
-    "start": 1844.485,
-    "end": 1852.503949999998
-  },
-  {
-    "text": "So we make lots of effort to ensure service outside the front doors of equity populations is sufficiently good that they're not left behind when service is improved and they're not unfairly targeted when service has to be cut.",
-    "start": 1853.648,
-    "end": 1867.3943913043488
-  },
-  {
-    "text": "However, this approach only assumes equity populations only travel locally within the communities they reside.",
-    "start": 1868.648,
-    "end": 1873.956800000001
-  },
-  {
-    "text": "A good transit network can level up communities and spread wealth across its entire metro area.",
-    "start": 1875.158,
-    "end": 1880.2833125000004
-  },
-  {
-    "text": "There's no point in running 15 minute frequency buses past the doorsteps of a low income or BIPOC community if they then have to transfer onto another bus which runs every 60 minutes and drops you a mile away from that well-paying employer.",
-    "start": 1881.026,
-    "end": 1896.091344827589
-  },
-  {
-    "text": "The current Title VI process fails to consider how a local transit network either succeeds or fails to service equity populations effectively, and it is because it considers the routes basically in silos.",
-    "start": 1897.372,
-    "end": 1910.9639090909088
-  },
-  {
-    "text": "And this is why, while we support the Title VI, we support the agency's efforts, we believe that it could be made a much more effective process if new data sources are considered and the methodology is reviewed.",
-    "start": 1911.788,
-    "end": 1926.1956052631606
-  },
-  {
-    "text": "Thank you very much for letting me speak tonight.",
-    "start": 1926.565,
     "end": 1928.0787777777782
   },
   {
-    "text": "Julien Bouquet: Thank you for your comments, Richard.",
+    "text": "Julien Bouquet: Thank you for your comments, Richard. Our next speaker, Mr. Kroll?",
     "start": 1929.35,
-    "end": 1930.6025000000004
-  },
-  {
-    "text": "Our next speaker, Mr.",
-    "start": 1930.873,
-    "end": 1931.6668
-  },
-  {
-    "text": "Kroll?",
-    "start": 1931.9314,
     "end": 1931.9314
   },
   {
@@ -1690,158 +305,28 @@
     "end": 1945.2155
   },
   {
-    "text": "Jo Elizabeth Pinto: Thank you.",
+    "text": "Jo Elizabeth Pinto: Thank you. I would like to talk quickly about two issues. The first is the Rockies Ride. My family went to the Rockies game last week, and we looked up how to get there on the RTD website, and there's a whole page dedicated to the Rockies Ride. But when we got to the stop, there were no buses, no people, no cars, no nothing. So we called the RTD, 299-6000, and the woman laughed and said, oh, we haven't had those buses for years. So the RTD needs to take down the Rockies Ride info from its website if it is no longer running those services, and it needs to keep its website updated about the services that are provided because people depend on that website to be accurate. The other thing that I need to talk about is Access-on-Demand. And my issue is that when you look at the Access-on-Demand and when you are talking about cutting services-- which, again, if we are 20% to 25% of the population that have disabilities, a little more, a little less, like Ms. Folska said, the idea to cut services based on the RTD schedule will leave people with no services on the weekends if the bus doesn't run on weekends to that part of the service area, or at night, or if they live more than 3/4 of a mile from a bus stop. And that will leave people stranded. And people with disabilities go places after 5 o'clock. They go places on the weekends. They go places. They don't just go to doctors that are open in the daytime. They go to shows, they go to restaurants, they go to malls on the weekends. They go all the same places you do. And it becomes really difficult when they get stranded in their homes except from 9:00 to 5:00, weekdays. So just take that into consideration when you make these cuts and imagine people who are disabled going to the same places you do, and imagine being stranded at home because you cut so that they can only go from 9:00 to 5:00 on weekdays. Also--",
     "start": 1945.501,
-    "end": 1945.711
+    "end": 2155.746
   },
   {
-    "text": "I would like to talk quickly about two issues.",
-    "start": 1946.642,
-    "end": 1950.7163000000005
-  },
-  {
-    "text": "The first is the Rockies Ride.",
-    "start": 1951.349,
-    "end": 1954.570666666667
-  },
-  {
-    "text": "My family went to the Rockies game last week, and we looked up how to get there on the RTD website, and there's a whole page dedicated to the Rockies Ride.",
-    "start": 1955.275,
-    "end": 1971.7483499999994
-  },
-  {
-    "text": "But when we got to the stop, there were no buses, no people, no cars, no nothing.",
-    "start": 1973.222,
-    "end": 1981.9443000000006
-  },
-  {
-    "text": "So we called the RTD, 299-6000, and the woman laughed and said, oh, we haven't had those buses for years.",
-    "start": 1982.855,
-    "end": 1994.2359333333347
-  },
-  {
-    "text": "So the RTD needs to take down the Rockies Ride info from its website if it is no longer running those services, and it needs to keep its website updated about the services that are provided because people depend on that website to be accurate.",
-    "start": 1995.854,
-    "end": 2021.3579999999995
-  },
-  {
-    "text": "The other thing that I need to talk about is Access-on-Demand.",
-    "start": 2023.63,
-    "end": 2029.5046153846165
-  },
-  {
-    "text": "And my issue is that when you look at the Access-on-Demand and when you are talking about cutting services-- which, again, if we are 20% to 25% of the population that have disabilities, a little more, a little less, like Ms.",
-    "start": 2031.328,
-    "end": 2055.6180540540527
-  },
-  {
-    "text": "Folska said, the idea to cut services based on the RTD schedule will leave people with no services on the weekends if the bus doesn't run on weekends to that part of the service area, or at night, or if they live more than 3/4 of a mile from a bus stop.",
-    "start": 2056.158,
-    "end": 2089.519403846146
-  },
-  {
-    "text": "And that will leave people stranded.",
-    "start": 2090.051346153838,
-    "end": 2092.7110576922987
-  },
-  {
-    "text": "And people with disabilities go places after 5 o'clock.",
-    "start": 2094.826,
-    "end": 2100.4695555555545
-  },
-  {
-    "text": "They go places on the weekends.",
-    "start": 2101.735,
-    "end": 2103.3875000000003
-  },
-  {
-    "text": "They go places.",
-    "start": 2104.099,
-    "end": 2104.099
-  },
-  {
-    "text": "They don't just go to doctors that are open in the daytime.",
-    "start": 2104.099,
-    "end": 2110.9831666666687
-  },
-  {
-    "text": "They go to shows, they go to restaurants, they go to malls on the weekends.",
-    "start": 2111.649,
-    "end": 2118.0687142857146
-  },
-  {
-    "text": "They go all the same places you do.",
-    "start": 2118.778,
-    "end": 2121.757374999999
-  },
-  {
-    "text": "And it becomes really difficult when they get stranded in their homes except from 9:00 to 5:00, weekdays.",
-    "start": 2122.163,
-    "end": 2130.995444444445
-  },
-  {
-    "text": "So just take that into consideration when you make these cuts and imagine people who are disabled going to the same places you do, and imagine being stranded at home because you cut so that they can only go from 9:00 to 5:00 on weekdays.",
-    "start": 2132.316,
-    "end": 2153.895400000003
-  },
-  {
-    "text": "Also-- Julien Bouquet: Jo, if you could wrap up your comments.",
-    "start": 2155.746,
-    "end": 2158.4471428571424
-  },
-  {
-    "text": "You're about 10 seconds over.",
-    "start": 2158.784785714285,
+    "text": "Julien Bouquet: Jo, if you could wrap up your comments. You're about 10 seconds over.",
+    "start": 2156.083642857143,
     "end": 2160.1353571428563
   },
   {
-    "text": "Jo Elizabeth Pinto: OK.",
+    "text": "Jo Elizabeth Pinto: OK. Thank you. The other thing is remember that these people with disabilities pay taxes to RTD the same way you do. Thank you. That's all I have to say.",
     "start": 2160.493,
-    "end": 2160.493
-  },
-  {
-    "text": "Thank you.",
-    "start": 2160.493,
-    "end": 2160.6835
-  },
-  {
-    "text": "The other thing is remember that these people with disabilities pay taxes to RTD the same way you do.",
-    "start": 2161.334,
-    "end": 2170.0630526315817
-  },
-  {
-    "text": "Thank you.",
-    "start": 2170.568,
-    "end": 2171.059
-  },
-  {
-    "text": "That's all I have to say.",
-    "start": 2171.57,
     "end": 2172.788333333334
   },
   {
-    "text": "Julien Bouquet: Thank you for your comments, Jo.",
+    "text": "Julien Bouquet: Thank you for your comments, Jo. Our next speaker, Mr. Kroll?",
     "start": 2173.092,
-    "end": 2174.193666666666
-  },
-  {
-    "text": "Our next speaker, Mr.",
-    "start": 2175.055,
-    "end": 2175.7521999999994
-  },
-  {
-    "text": "Kroll?",
-    "start": 2175.9845999999993,
     "end": 2175.9845999999993
   },
   {
-    "text": "Jack Kroll: Yes.",
+    "text": "Jack Kroll: Yes. Next we have Tim Keenan.",
     "start": 2176.67,
-    "end": 2176.67
-  },
-  {
-    "text": "Next we have Tim Keenan.",
-    "start": 2177.0571666666665,
     "end": 2178.605833333332
   },
   {
@@ -1850,148 +335,23 @@
     "end": 2180.406333333333
   },
   {
-    "text": "Jack Kroll: Tim?",
+    "text": "Jack Kroll: Tim? Looks like--",
     "start": 2194.135,
-    "end": 2194.9496666666664
+    "end": 2195.377
   },
   {
-    "text": "Looks like-- Tim Keenan: Can you hear me now?",
-    "start": 2194.9496666666664,
+    "text": "Tim Keenan: Can you hear me now?",
+    "start": 2195.487,
     "end": 2196.253800000001
   },
   {
-    "text": "Julien Bouquet: We can hear you, Tim.",
+    "text": "Julien Bouquet: We can hear you, Tim. Thank you.",
     "start": 2196.819,
-    "end": 2197.469833333334
-  },
-  {
-    "text": "Thank you.",
-    "start": 2197.62,
     "end": 2197.8
   },
   {
-    "text": "Tim Keenan: Alrighty.",
+    "text": "Tim Keenan: Alrighty. I'm Tim Keenan. Thanks for listening. I am a totally blind user of Access-a-Ride. I'm sorry. Of Access-- I'm not sure if you caught the beginning of that. I'm Tim Keenan. I'm a totally blind user of Access-on-Demand, and I live in Baker and work a fluctuating schedule out at Amazon in Aurora, which includes night and overnight shifts. So if you were to follow any of these recommendations, me and people like me, because I know there are a lot of people with disabilities who work out there, would not be able to use Access-on-Demand for at least one leg of their trip. In my case, that would eat into my paycheck by close to a third. And when you look at the numbers here, Access-on-Demand is probably the most efficient of your services. With fixed routes costing $19 per boarding, Access-on-Demand at $16 and Access-a-Ride at $60. So this is really working well, and to cut it, I think you need to decide whether this is in fact sustainable. I know there was-- the use was just blowing up and people got worried, and so they commissioned this review and all that. But really, it's helping a lot of people, and at 1.13% of your annual budget, it sounds pretty sustainable to me. Now, all that said, I don't know anyone who wouldn't-- I don't know anybody who would be against paying a fare. So if you add a $4.50 fare and that's $2.8 million of savings from the current numbers. That's doing something to put more money back into the system. And we certainly don't mind paying our way. But to cut the area in hours is going to leave some people who don't even have bus service in their area anymore, but used to, it's going to leave those people totally stranded without any kind of affordable transit option. So my ask would be that you keep the limit at 60 trips a month. This allows full time workers, 40 trips, and then 20 trips to do whatever they want or need to do. Get groceries and participate in the community. Maintain the current service area and hours so you're not creating transit deserts, and implement pricing that's fair that stays constant at $4.50 or $2.25 for RTD live that doesn't punish people for taking more trips like a tiered system would do, and it also doesn't have the added overhead that that system would have. So basically you can keep the program as it is now, add a fare, and keep this program doing what it does best, which is connect people with disabilities with their community.",
     "start": 2198.601,
-    "end": 2199.843
-  },
-  {
-    "text": "I'm Tim Keenan.",
-    "start": 2199.843,
-    "end": 2200.6843333333336
-  },
-  {
-    "text": "Thanks for listening.",
-    "start": 2201.145,
-    "end": 2201.692333333333
-  },
-  {
-    "text": "I am a totally blind user of Access-a-Ride.",
-    "start": 2202.767,
-    "end": 2206.6572499999997
-  },
-  {
-    "text": "I'm sorry.",
-    "start": 2207.253,
-    "end": 2207.7535
-  },
-  {
-    "text": "Of Access-- I'm not sure if you caught the beginning of that.",
-    "start": 2208.274,
-    "end": 2210.9338000000016
-  },
-  {
-    "text": "I'm Tim Keenan.",
-    "start": 2211.138,
-    "end": 2211.525333333333
-  },
-  {
-    "text": "I'm a totally blind user of Access-on-Demand, and I live in Baker and work a fluctuating schedule out at Amazon in Aurora, which includes night and overnight shifts.",
-    "start": 2211.739,
-    "end": 2224.241166666666
-  },
-  {
-    "text": "So if you were to follow any of these recommendations, me and people like me, because I know there are a lot of people with disabilities who work out there, would not be able to use Access-on-Demand for at least one leg of their trip.",
-    "start": 2224.852,
-    "end": 2236.6811555555496
-  },
-  {
-    "text": "In my case, that would eat into my paycheck by close to a third.",
-    "start": 2238.112,
-    "end": 2242.0175714285733
-  },
-  {
-    "text": "And when you look at the numbers here, Access-on-Demand is probably the most efficient of your services.",
-    "start": 2243.5924545454545,
-    "end": 2252.712714285713
-  },
-  {
-    "text": "With fixed routes costing $19 per boarding, Access-on-Demand at $16 and Access-a-Ride at $60.",
-    "start": 2253.1332857142843,
-    "end": 2259.862428571425
-  },
-  {
-    "text": "So this is really working well, and to cut it, I think you need to decide whether this is in fact sustainable.",
-    "start": 2261.345,
-    "end": 2271.688416666666
-  },
-  {
-    "text": "I know there was-- the use was just blowing up and people got worried, and so they commissioned this review and all that.",
-    "start": 2272.199,
-    "end": 2278.9055555555565
-  },
-  {
-    "text": "But really, it's helping a lot of people, and at 1.13% of your annual budget, it sounds pretty sustainable to me.",
-    "start": 2279.689,
-    "end": 2290.4726666666666
-  },
-  {
-    "text": "Now, all that said, I don't know anyone who wouldn't-- I don't know anybody who would be against paying a fare.",
-    "start": 2290.844,
-    "end": 2301.034749999997
-  },
-  {
-    "text": "So if you add a $4.50 fare and that's $2.8 million of savings from the current numbers.",
-    "start": 2301.4853035714254,
-    "end": 2315.452464285705
-  },
-  {
-    "text": "That's doing something to put more money back into the system.",
-    "start": 2320.888153846154,
-    "end": 2323.231615384617
-  },
-  {
-    "text": "And we certainly don't mind paying our way.",
-    "start": 2324.214,
-    "end": 2326.474999999999
-  },
-  {
-    "text": "But to cut the area in hours is going to leave some people who don't even have bus service in their area anymore, but used to, it's going to leave those people totally stranded without any kind of affordable transit option.",
-    "start": 2328.2,
-    "end": 2340.6631578947404
-  },
-  {
-    "text": "So my ask would be that you keep the limit at 60 trips a month.",
-    "start": 2342.583,
-    "end": 2349.2974000000013
-  },
-  {
-    "text": "This allows full time workers, 40 trips, and then 20 trips to do whatever they want or need to do.",
-    "start": 2349.652,
-    "end": 2355.7567692307675
-  },
-  {
-    "text": "Get groceries and participate in the community.",
-    "start": 2356.0959230769213,
-    "end": 2358.130846153844
-  },
-  {
-    "text": "Maintain the current service area and hours so you're not creating transit deserts, and implement pricing that's fair that stays constant at $4.50 or $2.25 for RTD live that doesn't punish people for taking more trips like a tiered system would do, and it also doesn't have the added overhead that that system would have.",
-    "start": 2360.895,
-    "end": 2383.661690476183
-  },
-  {
-    "text": "So basically you can keep the program as it is now, add a fare, and keep this program doing what it does best, which is connect people with disabilities with their community.",
-    "start": 2384.81,
     "end": 2399.877499999999
   },
   {
@@ -2000,43 +360,18 @@
     "end": 2401.096333333334
   },
   {
-    "text": "Tim Keenan: All set.",
+    "text": "Tim Keenan: All set. Thank you very much.",
     "start": 2402.121,
-    "end": 2402.3315000000002
-  },
-  {
-    "text": "Thank you very much.",
-    "start": 2402.582,
     "end": 2403.0327500000003
   },
   {
-    "text": "Julien Bouquet: Thank you for your comments, Tim.",
+    "text": "Julien Bouquet: Thank you for your comments, Tim. For the sake of the record, I'd like to note that Director Ruscha has joined us. Our next speaker, Mr. Kroll.",
     "start": 2403.944,
-    "end": 2404.7448333333327
-  },
-  {
-    "text": "For the sake of the record, I'd like to note that Director Ruscha has joined us.",
-    "start": 2405.326,
-    "end": 2408.311937499998
-  },
-  {
-    "text": "Our next speaker, Mr.",
-    "start": 2409.793,
-    "end": 2410.5021999999994
-  },
-  {
-    "text": "Kroll.",
-    "start": 2410.738599999999,
     "end": 2410.738599999999
   },
   {
-    "text": "Jack Kroll: Yes.",
+    "text": "Jack Kroll: Yes. Next we have Nate Trela.",
     "start": 2410.738599999999,
-    "end": 2411.376
-  },
-  {
-    "text": "Next we have Nate Trela.",
-    "start": 2411.6498333333334,
     "end": 2412.745166666666
   },
   {
@@ -2045,123 +380,8 @@
     "end": 2414.4339999999997
   },
   {
-    "text": "Nate Trela: Yeah.",
+    "text": "Nate Trela: Yeah. Hi. This is Nate Trela. Thank you once again for the chance to speak. Hopefully we're down the home stretch here in terms of finding a sustainable path forward for Access-on-Demand that still maintains this robust level of service and utility for the district residents that cannot use a fixed route service independently. I implore you to recognize a few facts that are in the staff's presentation that you're going to-- the public's going to hear tonight and that was in the agenda packet for this meeting and for the operations meeting a couple weeks ago. And there's some unanswered questions that you may already have as Board members, information that you should definitely, in my opinion, make sure as you're making decisions about the future of this program. In the agenda packet, it already talks about how the cost of an Access trip is just a fraction of the cost of a traditional access ride service. And I don't know if there has been any effort made to see if it's possible to try to encourage people to use Access-on-Demand instead of Access-a-Ride, if people are fully aware of the capabilities of it, if people are aware of how to use it, converting a few of those access ride trips to Access-on-Demand could yield significant savings in this whole process. Also, it's worth pointing out that you're more than doubling the number of trips provided to people who cannot use fixed route service with Access-on-Demand, as opposed to Access-a-Ride. That's a success. You're helping people make connections, get around, participate in the workforce, participate in society. As we've heard people talk about, shop, go out and get some entertainment, whether it's movies or music or what have you. Things have become possible with this program. Some of the answered questions in these proposals is in the tiered fare concept, it talks about needing to hire additional staff. Perhaps this is already going to be discussed later tonight, but it's not clear what that staff would do. And it's hard to fathom what would need to be added to-- what would need to be handled by added staff that couldn't be automated, couldn't be handled with a spreadsheet wizard and a knowledge of how to write some stuff in SQL. There are ways to gather a lot of different data and process a lot of numbers, analyze the numbers to make that tiered fare approach work. So it'd be good to know what those new hires would need to do. Both proposals call for cutting back, as we've talked about, the service area hours back to match Access-a-Ride. This isn't required as a supplemental premium service. Access-on-Demand doesn't have to line up with Access-a-Ride. That is a choice that's made. What's the question is, how would Access-a-Ride enforce the restricted hours proposed and contained both these plans because when the National Federation of the Blind of Colorado has spoken with RTD staff before, we've been told that, yes, geofencing to define the boundaries can be done.",
     "start": 2419.83,
-    "end": 2419.83
-  },
-  {
-    "text": "Hi.",
-    "start": 2419.83,
-    "end": 2419.83
-  },
-  {
-    "text": "This is Nate Trela.",
-    "start": 2420.0544,
-    "end": 2420.7276
-  },
-  {
-    "text": "Thank you once again for the chance to speak.",
-    "start": 2420.992,
-    "end": 2423.0746666666655
-  },
-  {
-    "text": "Hopefully we're down the home stretch here in terms of finding a sustainable path forward for Access-on-Demand that still maintains this robust level of service and utility for the district residents that cannot use a fixed route service independently.",
-    "start": 2424.698,
-    "end": 2443.258441860458
-  },
-  {
-    "text": "I implore you to recognize a few facts that are in the staff's presentation that you're going to-- the public's going to hear tonight and that was in the agenda packet for this meeting and for the operations meeting a couple weeks ago.",
-    "start": 2444.662,
-    "end": 2456.4449772727367
-  },
-  {
-    "text": "And there's some unanswered questions that you may already have as Board members, information that you should definitely, in my opinion, make sure as you're making decisions about the future of this program.",
-    "start": 2457.44,
-    "end": 2467.624027777773
-  },
-  {
-    "text": "In the agenda packet, it already talks about how the cost of an Access trip is just a fraction of the cost of a traditional access ride service.",
-    "start": 2468.736,
-    "end": 2481.719360000005
-  },
-  {
-    "text": "And I don't know if there has been any effort made to see if it's possible to try to encourage people to use Access-on-Demand instead of Access-a-Ride, if people are fully aware of the capabilities of it, if people are aware of how to use it, converting a few of those access ride trips to Access-on-Demand could yield significant savings in this whole process.",
-    "start": 2482.986,
-    "end": 2506.092208333333
-  },
-  {
-    "text": "Also, it's worth pointing out that you're more than doubling the number of trips provided to people who cannot use fixed route service with Access-on-Demand, as opposed to Access-a-Ride.",
-    "start": 2507.437,
-    "end": 2515.6025588235298
-  },
-  {
-    "text": "That's a success.",
-    "start": 2516.15,
-    "end": 2516.6706666666664
-  },
-  {
-    "text": "You're helping people make connections, get around, participate in the workforce, participate in society.",
-    "start": 2517.532,
-    "end": 2523.539857142855
-  },
-  {
-    "text": "As we've heard people talk about, shop, go out and get some entertainment, whether it's movies or music or what have you.",
-    "start": 2524.703,
-    "end": 2531.539193548384
-  },
-  {
-    "text": "Things have become possible with this program.",
-    "start": 2531.8364193548355,
-    "end": 2533.6197741935443
-  },
-  {
-    "text": "Some of the answered questions in these proposals is in the tiered fare concept, it talks about needing to hire additional staff.",
-    "start": 2534.588,
-    "end": 2543.8727500000005
-  },
-  {
-    "text": "Perhaps this is already going to be discussed later tonight, but it's not clear what that staff would do.",
-    "start": 2544.467,
-    "end": 2548.251388888892
-  },
-  {
-    "text": "And it's hard to fathom what would need to be added to-- what would need to be handled by added staff that couldn't be automated, couldn't be handled with a spreadsheet wizard and a knowledge of how to write some stuff in SQL.",
-    "start": 2549.216,
-    "end": 2566.855037037033
-  },
-  {
-    "text": "There are ways to gather a lot of different data and process a lot of numbers, analyze the numbers to make that tiered fare approach work.",
-    "start": 2568.325,
-    "end": 2577.674500000001
-  },
-  {
-    "text": "So it'd be good to know what those new hires would need to do.",
-    "start": 2578.101,
-    "end": 2581.7250000000017
-  },
-  {
-    "text": "Both proposals call for cutting back, as we've talked about, the service area hours back to match Access-a-Ride.",
-    "start": 2582.429,
-    "end": 2588.716315789474
-  },
-  {
-    "text": "This isn't required as a supplemental premium service.",
-    "start": 2591.337,
-    "end": 2593.7928947368437
-  },
-  {
-    "text": "Access-on-Demand doesn't have to line up with Access-a-Ride.",
-    "start": 2594.143736842107,
-    "end": 2597.3013157894775
-  },
-  {
-    "text": "That is a choice that's made.",
-    "start": 2598.023,
-    "end": 2598.923833333333
-  },
-  {
-    "text": "What's the question is, how would Access-a-Ride enforce the restricted hours proposed and contained both these plans because when the National Federation of the Blind of Colorado has spoken with RTD staff before, we've been told that, yes, geofencing to define the boundaries can be done.",
-    "start": 2601.106,
     "end": 2614.9706666666652
   },
   {
@@ -2170,48 +390,18 @@
     "end": 2617.294166666667
   },
   {
-    "text": "Nate Trela: Sure.",
+    "text": "Nate Trela: Sure. Sure. Just saying that the cutback of the hours is going to be incredibly complex to manage, and it's unclear how you could expect somebody to do that, especially when, again, the point of RTD is to be helping people make connections. Adding these layers of complexity to it does the exact opposite.",
     "start": 2617.978,
-    "end": 2617.978
-  },
-  {
-    "text": "Sure.",
-    "start": 2617.978,
-    "end": 2617.978
-  },
-  {
-    "text": "Just saying that the cutback of the hours is going to be incredibly complex to manage, and it's unclear how you could expect somebody to do that, especially when, again, the point of RTD is to be helping people make connections.",
-    "start": 2619.04,
-    "end": 2631.503166666669
-  },
-  {
-    "text": "Adding these layers of complexity to it does the exact opposite.",
-    "start": 2632.137,
     "end": 2634.904272727274
   },
   {
-    "text": "Julien Bouquet: Thank you, Nate.",
+    "text": "Julien Bouquet: Thank you, Nate. Our next speaker, Mr. Kroll.",
     "start": 2636.763,
-    "end": 2637.110333333333
-  },
-  {
-    "text": "Our next speaker, Mr.",
-    "start": 2638.105,
-    "end": 2638.7416
-  },
-  {
-    "text": "Kroll.",
-    "start": 2638.9538,
     "end": 2638.9538
   },
   {
-    "text": "Jack Kroll: Yes.",
+    "text": "Jack Kroll: Yes. Next we have Cody Bair.",
     "start": 2639.298,
-    "end": 2639.298
-  },
-  {
-    "text": "Next we have Cody Bair.",
-    "start": 2639.6184999999996,
     "end": 2640.900499999999
   },
   {
@@ -2220,108 +410,18 @@
     "end": 2642.690333333333
   },
   {
-    "text": "Cody Bair: Good evening and thank you RTD Board.",
+    "text": "Cody Bair: Good evening and thank you RTD Board. I am also here to talk about Access-a-Ride-- Access-on-Demand service, and have spoken about the topic at a few meetings before. Tonight I want to say that I agree with you what Dr. Folska and Tim Keenan said about this. Access-on-Demand cost is really a fraction of RTD's budget. At just 1.13% and just north of, I think $10 million, this is not a huge opportunity for RTD to save significantly on the budget and would be a huge loss of service for many Coloradoans in the RTD district with disabilities. Speaking to the current proposals that are out there. With the tiered proposal, one thing that I would urge the RTD Board to think about and questions to ask would be, how would we actually enforce the fares of the tiered proposal? This service is offered amongst Uber, Lyft, and a couple of other taxi platforms, neither of which share information or communicate with each other at all. To that point, even in the current system as a user, if I want to see how many trips I've used, I have to open each platform and count the number that have been taken in the month on that platform. I just don't see an administratively effective way to make the fare thing work without putting that burden on the rider, which would inherently cause issues for people keeping track of it. Second, to follow up on Nate's comments about the hours. You look at somebody who's a full time employee at Amazon like Tim and many others who would be affected by this, that's taking-- by cutting people's ability to use the service, we're taking tax revenue out of the Colorado economy. I'm not sure that that's something that makes a lot of sense for RTD. And people have built their lives around being able to access this service in its current state and any reduction and change of the service area or hours is a reduction in service, in my mind, and something that I would completely be against. Appreciate your guys' time tonight, and that concludes my comments.",
     "start": 2646.47,
-    "end": 2648.0497142857143
-  },
-  {
-    "text": "I am also here to talk about Access-a-Ride-- Access-on-Demand service, and have spoken about the topic at a few meetings before.",
-    "start": 2648.353,
-    "end": 2659.653863636368
-  },
-  {
-    "text": "Tonight I want to say that I agree with you what Dr.",
-    "start": 2660.577,
-    "end": 2666.5037368421026
-  },
-  {
-    "text": "Folska and Tim Keenan said about this.",
-    "start": 2666.9976315789445,
-    "end": 2670.9487894736794
-  },
-  {
-    "text": "Access-on-Demand cost is really a fraction of RTD's budget.",
-    "start": 2671.4426842105213,
-    "end": 2676.38163157894
-  },
-  {
-    "text": "At just 1.13% and just north of, I think $10 million, this is not a huge opportunity for RTD to save significantly on the budget and would be a huge loss of service for many Coloradoans in the RTD district with disabilities.",
-    "start": 2676.875526315782,
-    "end": 2701.4017741935504
-  },
-  {
-    "text": "Speaking to the current proposals that are out there.",
-    "start": 2702.326,
-    "end": 2705.920095238095
-  },
-  {
-    "text": "With the tiered proposal, one thing that I would urge the RTD Board to think about and questions to ask would be, how would we actually enforce the fares of the tiered proposal?",
-    "start": 2706.369357142857,
-    "end": 2720.745738095238
-  },
-  {
-    "text": "This service is offered amongst Uber, Lyft, and a couple of other taxi platforms, neither of which share information or communicate with each other at all.",
-    "start": 2721.255,
-    "end": 2733.144666666667
-  },
-  {
-    "text": "To that point, even in the current system as a user, if I want to see how many trips I've used, I have to open each platform and count the number that have been taken in the month on that platform.",
-    "start": 2733.769,
-    "end": 2749.688953488379
-  },
-  {
-    "text": "I just don't see an administratively effective way to make the fare thing work without putting that burden on the rider, which would inherently cause issues for people keeping track of it.",
-    "start": 2750.403,
-    "end": 2766.004718749996
-  },
-  {
-    "text": "Second, to follow up on Nate's comments about the hours.",
-    "start": 2767.489,
-    "end": 2772.5821000000005
-  },
-  {
-    "text": "You look at somebody who's a full time employee at Amazon like Tim and many others who would be affected by this, that's taking-- by cutting people's ability to use the service, we're taking tax revenue out of the Colorado economy.",
-    "start": 2773.1480000000006,
-    "end": 2791.1875862069
-  },
-  {
-    "text": "I'm not sure that that's something that makes a lot of sense for RTD.",
-    "start": 2791.636,
-    "end": 2796.3058888888904
-  },
-  {
-    "text": "And people have built their lives around being able to access this service in its current state and any reduction and change of the service area or hours is a reduction in service, in my mind, and something that I would completely be against.",
-    "start": 2796.6651111111128,
-    "end": 2815.4532424242407
-  },
-  {
-    "text": "Appreciate your guys' time tonight, and that concludes my comments.",
-    "start": 2816.164,
     "end": 2819.9304999999986
   },
   {
-    "text": "Julien Bouquet: Thank you for your comments, Cody.",
+    "text": "Julien Bouquet: Thank you for your comments, Cody. Mr. Kroll, our next speaker.",
     "start": 2821.41,
-    "end": 2822.3275000000003
-  },
-  {
-    "text": "Mr.",
-    "start": 2822.871,
-    "end": 2822.871
-  },
-  {
-    "text": "Kroll, our next speaker.",
-    "start": 2823.1265000000003,
     "end": 2823.6375000000007
   },
   {
-    "text": "Jack Kroll: Yes.",
+    "text": "Jack Kroll: Yes. The last speaker we have in the queue is Maryann Migliorelli.",
     "start": 2824.273,
-    "end": 2824.273
-  },
-  {
-    "text": "The last speaker we have in the queue is Maryann Migliorelli.",
-    "start": 2824.713,
     "end": 2827.5166363636376
   },
   {
@@ -2330,133 +430,13 @@
     "end": 2829.7287499999998
   },
   {
-    "text": "Maryann Migliorelli: Good evening, ladies and gentlemen.",
+    "text": "Maryann Migliorelli: Good evening, ladies and gentlemen. Thank you so much for your time and your attention. Tonight I would like to speak to you briefly about equity and the Access-on-Demand system and in RTD in general. We have been told by RTD members that we cannot have the multiple stop situation because that would not be equitable. We have been told that we can have certain things, but we can't have others. One of the things that we are now being told is that with this tiered system, we can have inequity in pricing. There is no place in the RTD system where riding more costs more per trip. This does not happen on Access-a-Ride. It does not happen anywhere in the fixed route system, on any light rail, on any bus. As a matter of fact, RTD went out of its way to remove the barriers to regional transit by removing the price barrier. But with the ideas of this tiered system, we are saying-- and you would be saying if you approve it-- that anybody who does more than 30 trips per month should have to pay more in order to use a system. That, ladies and gentlemen, is inequity. And that is not something that RTD should even have been entertaining that proposal. But you will do what is necessary, and I will thank you for the hard work that is involved in keeping our program alive. The other thought is in removing and putting the boundaries in that are the same for Access-a-Ride, there are many people who will be affected whose life plans, the places they live, the places they work, the places they choose to do business and entertain will all be affected. People have been provided a service, have been able to make these decisions about their lives because of the service that is provided, and taking service away creates further inequity and transit deficits. That is not something RTD should be looking for doing, and I sincerely hope that in every way that you can, you find a way to keep the Access-on-Demand program as open as it is right now. I personally do not know anybody who would object to paying the 4.50 or 2.25 fare as proposed. But adding additional fares and cutting service will make transit deficits that should not be considered. Right now, this program is moving people who have never had a chance to participate in public transit life in the way that we can right now. Please consider this when you're making your decisions. Thank you so much for your time and those who remember me before, if I was there, I would bring you warm chocolate cookies.",
     "start": 2832.955,
-    "end": 2834.1406000000006
-  },
-  {
-    "text": "Thank you so much for your time and your attention.",
-    "start": 2834.678,
-    "end": 2836.9127000000017
-  },
-  {
-    "text": "Tonight I would like to speak to you briefly about equity and the Access-on-Demand system and in RTD in general.",
-    "start": 2837.983,
-    "end": 2850.6584090909123
-  },
-  {
-    "text": "We have been told by RTD members that we cannot have the multiple stop situation because that would not be equitable.",
-    "start": 2852.364,
-    "end": 2864.4278571428563
-  },
-  {
-    "text": "We have been told that we can have certain things, but we can't have others.",
-    "start": 2865.558,
-    "end": 2869.9502666666676
-  },
-  {
-    "text": "One of the things that we are now being told is that with this tiered system, we can have inequity in pricing.",
-    "start": 2871.345,
-    "end": 2879.659090909095
-  },
-  {
-    "text": "There is no place in the RTD system where riding more costs more per trip.",
-    "start": 2880.656,
-    "end": 2887.515066666666
-  },
-  {
-    "text": "This does not happen on Access-a-Ride.",
-    "start": 2888.8288571428575,
-    "end": 2890.603142857144
-  },
-  {
-    "text": "It does not happen anywhere in the fixed route system, on any light rail, on any bus.",
-    "start": 2891.318,
-    "end": 2899.2163529411782
-  },
-  {
-    "text": "As a matter of fact, RTD went out of its way to remove the barriers to regional transit by removing the price barrier.",
-    "start": 2899.73,
-    "end": 2908.543391304343
-  },
-  {
-    "text": "But with the ideas of this tiered system, we are saying-- and you would be saying if you approve it-- that anybody who does more than 30 trips per month should have to pay more in order to use a system.",
-    "start": 2909.384,
-    "end": 2923.883299999997
-  },
-  {
-    "text": "That, ladies and gentlemen, is inequity.",
-    "start": 2924.89,
-    "end": 2927.043333333333
-  },
-  {
-    "text": "And that is not something that RTD should even have been entertaining that proposal.",
-    "start": 2928.074,
-    "end": 2933.29907142857
-  },
-  {
-    "text": "But you will do what is necessary, and I will thank you for the hard work that is involved in keeping our program alive.",
-    "start": 2934.462,
-    "end": 2942.019882352938
-  },
-  {
-    "text": "The other thought is in removing and putting the boundaries in that are the same for Access-a-Ride, there are many people who will be affected whose life plans, the places they live, the places they work, the places they choose to do business and entertain will all be affected.",
-    "start": 2943.875,
-    "end": 2969.043937500002
-  },
-  {
-    "text": "People have been provided a service, have been able to make these decisions about their lives because of the service that is provided, and taking service away creates further inequity and transit deficits.",
-    "start": 2970.993,
-    "end": 2986.890400000002
-  },
-  {
-    "text": "That is not something RTD should be looking for doing, and I sincerely hope that in every way that you can, you find a way to keep the Access-on-Demand program as open as it is right now.",
-    "start": 2988.348,
-    "end": 3002.9468571428583
-  },
-  {
-    "text": "I personally do not know anybody who would object to paying the 4.50 or 2.25 fare as proposed.",
-    "start": 3003.691,
-    "end": 3011.7915000000035
-  },
-  {
-    "text": "But adding additional fares and cutting service will make transit deficits that should not be considered.",
-    "start": 3012.2680000000037,
-    "end": 3019.415500000007
-  },
-  {
-    "text": "Right now, this program is moving people who have never had a chance to participate in public transit life in the way that we can right now.",
-    "start": 3020.213,
-    "end": 3029.957000000001
-  },
-  {
-    "text": "Please consider this when you're making your decisions.",
-    "start": 3030.871,
-    "end": 3033.1652499999996
-  },
-  {
-    "text": "Thank you so much for your time and those who remember me before, if I was there, I would bring you warm chocolate cookies.",
-    "start": 3033.914,
     "end": 3040.534999999997
   },
   {
-    "text": "Julien Bouquet: Thank you for your comments, Maryann.",
+    "text": "Julien Bouquet: Thank you for your comments, Maryann. Are there any members of the public who would like to-- excuse me. Mr. Kroll, any further online participants?",
     "start": 3042.541,
-    "end": 3043.942428571428
-  },
-  {
-    "text": "Are there any members of the public who would like to-- excuse me.",
-    "start": 3045.384,
-    "end": 3049.127055555556
-  },
-  {
-    "text": "Mr.",
-    "start": 3049.467333333334,
-    "end": 3049.467333333334
-  },
-  {
-    "text": "Kroll, any further online participants?",
-    "start": 3049.807611111112,
     "end": 3051.168722222223
   },
   {
@@ -2465,243 +445,33 @@
     "end": 3053.6004999999996
   },
   {
-    "text": "Julien Bouquet: Any members of the public who would like to make comments?",
+    "text": "Julien Bouquet: Any members of the public who would like to make comments? Feel free to come up to the podium. Seeing none, were there any emailed comments, Mr. Kroll?",
     "start": 3054.091,
-    "end": 3058.1005000000005
-  },
-  {
-    "text": "Feel free to come up to the podium.",
-    "start": 3058.355333333334,
-    "end": 3060.1391666666677
-  },
-  {
-    "text": "Seeing none, were there any emailed comments, Mr.",
-    "start": 3063.879,
-    "end": 3065.7335714285714
-  },
-  {
-    "text": "Kroll?",
-    "start": 3065.9882857142857,
     "end": 3065.9882857142857
   },
   {
-    "text": "Jack Kroll: There were a number.",
+    "text": "Jack Kroll: There were a number. I am not going to go through all 46 and read the names. However, you received 36 letters with respect to Northwest Rail and the IGA conversation that you held earlier today, five letters with respect to the ETOD policy you will consider later this evening, three letters with respect to Title VI policy or the program update that you all will consider later this evening. One regarding the National Women's Soccer League proposed stadium that was discussed earlier here in person, and one regarding paratransit AOD program modifications. All will be appended to the transcript of this meeting. And just as a reminder to Directors, a majority of these written public comment comments were submitted to the rtd.directors email group, which you all have access to and can see in real time.",
     "start": 3066.423,
-    "end": 3066.9487500000005
-  },
-  {
-    "text": "I am not going to go through all 46 and read the names.",
-    "start": 3067.144,
-    "end": 3070.0839999999985
-  },
-  {
-    "text": "However, you received 36 letters with respect to Northwest Rail and the IGA conversation that you held earlier today, five letters with respect to the ETOD policy you will consider later this evening, three letters with respect to Title VI policy or the program update that you all will consider later this evening.",
-    "start": 3070.509,
-    "end": 3089.2394500000037
-  },
-  {
-    "text": "One regarding the National Women's Soccer League proposed stadium that was discussed earlier here in person, and one regarding paratransit AOD program modifications.",
-    "start": 3090.268,
-    "end": 3100.2894782608664
-  },
-  {
-    "text": "All will be appended to the transcript of this meeting.",
-    "start": 3101.346,
-    "end": 3103.6175999999987
-  },
-  {
-    "text": "And just as a reminder to Directors, a majority of these written public comment comments were submitted to the rtd.directors email group, which you all have access to and can see in real time.",
-    "start": 3104.17,
     "end": 3116.47802941176
   },
   {
-    "text": "Julien Bouquet: Thank you, Mr.",
+    "text": "Julien Bouquet: Thank you, Mr. Kroll. With no other participants in the queue, we will now close public participation at this time. Moving on to our next item, external entities report. We have no external entity reports this month. Moving on to our next item. Discussion items. We have one discussion item on the agenda this evening, which is a holdover from last week's Operation Safety and Security Committee meeting. It is the Access-on-Demand program modifications. I would like to offer the floor to GM/CEO Debra Johnson for some opening remarks before introducing Ms. Vallejos.",
     "start": 3117.732,
-    "end": 3118.183
-  },
-  {
-    "text": "Kroll.",
-    "start": 3118.4085,
-    "end": 3118.4085
-  },
-  {
-    "text": "With no other participants in the queue, we will now close public participation at this time.",
-    "start": 3118.934,
-    "end": 3122.7112000000006
-  },
-  {
-    "text": "Moving on to our next item, external entities report.",
-    "start": 3124.203,
-    "end": 3126.8021111111107
-  },
-  {
-    "text": "We have no external entity reports this month.",
-    "start": 3127.147,
-    "end": 3130.1972500000006
-  },
-  {
-    "text": "Moving on to our next item.",
-    "start": 3131.812,
-    "end": 3133.15075
-  },
-  {
-    "text": "Discussion items.",
-    "start": 3133.4184999999998,
-    "end": 3133.6862499999997
-  },
-  {
-    "text": "We have one discussion item on the agenda this evening, which is a holdover from last week's Operation Safety and Security Committee meeting.",
-    "start": 3134.354,
-    "end": 3141.6685217391337
-  },
-  {
-    "text": "It is the Access-on-Demand program modifications.",
-    "start": 3142.021,
-    "end": 3144.508625000001
-  },
-  {
-    "text": "I would like to offer the floor to GM/CEO Debra Johnson for some opening remarks before introducing Ms.",
-    "start": 3145.565,
-    "end": 3151.1041666666665
-  },
-  {
-    "text": "Vallejos.",
-    "start": 3151.75,
     "end": 3151.75
   },
   {
-    "text": "Debra Johnson: Thank you very much, Mr.",
+    "text": "Debra Johnson: Thank you very much, Mr. Chair. Good afternoon or evening, Board members. Debra Johnson, General Manager and Chief Executive Officer. I am joined by Erin Vallejos, who serves as the Acting Assistant or Deputy Assistant General Manager of Bus Operations. And as indicated in your remarks, sir, we are here referencing the previous agendized topic at the Operations Safety and Security Committee that we did not get to and wanted to have this conversation with you all this evening. The intent of this presentation is to ground all Board members in our paratransit programs. But more specifically, what we are seeking from this body is some guidance relative to Access-on-Demand, which is a supplemental premium service as it relates to paratransit services, not the Americans with Disabilities Act of 1990 complementary paratransit services. And in doing so, this conversation will help us guide our path forward. Specifically, I think what's notable for everybody to understand that the current paratransit contracts that we have for Access-on-Demand do sunset at the end of December. We have had conversations relative to modifications. In absence of having some guidance, we run the risk of not having any type of services, and hence why it's so imperative is that we adhere to open and fair competition. In order to do a solicitation relative to services, we have to have some guidance relative to the specifications that would be included in a solicitation for a request for proposal. So this is not for you to make a decision relative to where we are, but provide guidance, because what we anticipate doing with said guidance and bringing forward these scenarios after meeting with some board members, i.e. Chair Ruscha and Director Chandler, that are both on the Operation Safety and Security Committee, is to seek that direction so we can then go out to the customer segments and garner a better understanding. While we've heard comments here, we have taken part in a myriad of different public participation engagements and want to ensure that we are being good fiscal stewards, but also ensuring that we are providing the independence and ability for all aspects of our population to be able to travel and move about to and fro. So with that being said, I will yield the floor to Ms. Vallejos to commence with the presentation. If we could have Board Office staff pull that up, that would be appreciated. Thank you.",
     "start": 3153.632,
-    "end": 3154.6593333333335
-  },
-  {
-    "text": "Chair.",
-    "start": 3154.916166666667,
-    "end": 3154.916166666667
-  },
-  {
-    "text": "Good afternoon or evening, Board members.",
-    "start": 3155.654,
-    "end": 3157.3554285714276
-  },
-  {
-    "text": "Debra Johnson, General Manager and Chief Executive Officer.",
-    "start": 3157.695714285713,
-    "end": 3160.077714285712
-  },
-  {
-    "text": "I am joined by Erin Vallejos, who serves as the Acting Assistant or Deputy Assistant General Manager of Bus Operations.",
-    "start": 3161.073,
-    "end": 3168.9655263157933
-  },
-  {
-    "text": "And as indicated in your remarks, sir, we are here referencing the previous agendized topic at the Operations Safety and Security Committee that we did not get to and wanted to have this conversation with you all this evening.",
-    "start": 3169.885,
-    "end": 3185.5149999999994
-  },
-  {
-    "text": "The intent of this presentation is to ground all Board members in our paratransit programs.",
-    "start": 3186.0947499999993,
-    "end": 3194.2112499999976
-  },
-  {
-    "text": "But more specifically, what we are seeking from this body is some guidance relative to Access-on-Demand, which is a supplemental premium service as it relates to paratransit services, not the Americans with Disabilities Act of 1990 complementary paratransit services.",
-    "start": 3194.811,
-    "end": 3212.265449999995
-  },
-  {
-    "text": "And in doing so, this conversation will help us guide our path forward.",
-    "start": 3212.693,
-    "end": 3218.092076923075
-  },
-  {
-    "text": "Specifically, I think what's notable for everybody to understand that the current paratransit contracts that we have for Access-on-Demand do sunset at the end of December.",
-    "start": 3219.603,
-    "end": 3229.472464285713
-  },
-  {
-    "text": "We have had conversations relative to modifications.",
-    "start": 3230.399,
-    "end": 3232.821153846154
-  },
-  {
-    "text": "In absence of having some guidance, we run the risk of not having any type of services, and hence why it's so imperative is that we adhere to open and fair competition.",
-    "start": 3233.2248461538466,
-    "end": 3243.997000000002
-  },
-  {
-    "text": "In order to do a solicitation relative to services, we have to have some guidance relative to the specifications that would be included in a solicitation for a request for proposal.",
-    "start": 3244.331800000002,
-    "end": 3255.0146363636363
-  },
-  {
-    "text": "So this is not for you to make a decision relative to where we are, but provide guidance, because what we anticipate doing with said guidance and bringing forward these scenarios after meeting with some board members, i.e.",
-    "start": 3255.898,
-    "end": 3268.639833333332
-  },
-  {
-    "text": "Chair Ruscha and Director Chandler, that are both on the Operation Safety and Security Committee, is to seek that direction so we can then go out to the customer segments and garner a better understanding.",
-    "start": 3269.88,
-    "end": 3284.6346153846166
-  },
-  {
-    "text": "While we've heard comments here, we have taken part in a myriad of different public participation engagements and want to ensure that we are being good fiscal stewards, but also ensuring that we are providing the independence and ability for all aspects of our population to be able to travel and move about to and fro.",
-    "start": 3284.9798461538476,
-    "end": 3305.2468421052668
-  },
-  {
-    "text": "So with that being said, I will yield the floor to Ms.",
-    "start": 3305.619,
-    "end": 3308.6669166666675
-  },
-  {
-    "text": "Vallejos to commence with the presentation.",
-    "start": 3309.024,
-    "end": 3311.2606666666675
-  },
-  {
-    "text": "If we could have Board Office staff pull that up, that would be appreciated.",
-    "start": 3311.748,
-    "end": 3315.0964285714267
-  },
-  {
-    "text": "Thank you.",
-    "start": 3315.574,
     "end": 3315.7645
   },
   {
-    "text": "Erin Vallejos: It's been a while since I've used these microphones.",
+    "text": "Erin Vallejos: It's been a while since I've used these microphones. Good evening, everyone. As GM/CEO Johnson said, I'm Erin Vallejos, the Acting Deputy Assistant General Manager for Bus Operations, and we are just going to go over just a quick overview. I think it's a lot of information that you've already seen, so we won't spend too much time on that. Just kind of hit on what the initial recommendation was that we made talk about some revised recommendations, and then again, open it up for discussion to get an idea of some direction.",
     "start": 3334.801,
-    "end": 3336.3602499999993
-  },
-  {
-    "text": "Good evening, everyone.",
-    "start": 3337.183,
-    "end": 3337.730333333333
-  },
-  {
-    "text": "As GM/CEO Johnson said, I'm Erin Vallejos, the Acting Deputy Assistant General Manager for Bus Operations, and we are just going to go over just a quick overview.",
-    "start": 3338.244,
-    "end": 3349.731499999997
-  },
-  {
-    "text": "I think it's a lot of information that you've already seen, so we won't spend too much time on that.",
-    "start": 3350.056,
-    "end": 3354.0118000000007
-  },
-  {
-    "text": "Just kind of hit on what the initial recommendation was that we made talk about some revised recommendations, and then again, open it up for discussion to get an idea of some direction.",
-    "start": 3354.961,
     "end": 3365.7475999999997
   },
   {
-    "text": "Julien Bouquet: Ms.",
+    "text": "Julien Bouquet: Ms. Vallejos, before, could you speak a little closer to the microphone?",
     "start": 3366.593,
-    "end": 3366.593
-  },
-  {
-    "text": "Vallejos, before, could you speak a little closer to the microphone?",
-    "start": 3366.793,
     "end": 3369.2986000000014
   },
   {
@@ -2715,483 +485,33 @@
     "end": 3371.1087500000003
   },
   {
-    "text": "Erin Vallejos: Of course.",
+    "text": "Erin Vallejos: Of course. OK, so just to highlight on this, again, as GM/CEO Johnson said. Access-a- Ride and Access-on-Demand are the two programs that we have. Access-a-Ride is RTD's federally required ADA complementary paratransit service. It does supplement our fixed route services. There is a fare payment required for these services and customers must meet the criteria set forth by the Americans with Disabilities Act of 1990 to be eligible. This is provided with all RTD branded Access-a-Ride vehicles that are all 100% accessible. And then Access-on-Demand is our supplemental premium paratransit service. It is a curb-to-curb taxi and rideshare service. It is available to current paratransit customers, so they must meet those eligibility criteria to qualify for Access-a-Ride to then use Access-on-Demand. And as it stands today, RTD pays the first $25 of the trip and the remaining portion is paid by the customer. And again, ability today to take 60 total trips. So just some quick operating statistics. The annual operating cost in 2024 for Access-a-Ride was just over 53 million, and the customer trips were just over 500,000. And again, these are RTD owned vehicles, and the contractors that operate this service have over 500 drivers, mechanics, and other staff. And then Access-on-Demand. Last year it was about just over $15.3 million for the budget. Just over 685,000 trips. And these are all provided by third party vehicles. So again, as we touched on, you must be eligible for Access-a-Ride to also use Access-on-Demand. There is a process that customers must go through that determines if a customer has a disabling condition that would prevent them from using our regular fixed route service. There's an application process, a medical verification process, and then an in-person assessment that customers must complete. And there are a couple of different types of eligibility that a customer could receive. Unconditional means you can have access to the full service for up to four years. Temporary. You might have a condition that's going to improve, recovering from surgery or something along those lines. And then conditional would be when there was something-- maybe you're sensitive to extreme hot or extreme cold, so you would be able to use it at those times, but not the full year. OK. And as we have touched on, this is something that you've probably seen as well. We are continuing to see an increase in Access-on-Demand usage. This is through 2024, but we continue to see that Access- on-Demand trend line going up into the start of this year. And Access-a-Ride, when you look at the trend line, while it is staying a little bit more stable, we are still seeing an increase in usage there as well. And as we've talked about, average monthly trips per customer. The majority of customers are falling into the category of taking up to 50 trips. That is about 90% of the customers when we last did the analysis, and about 10% of the customers again fall into that 51 to 60 category. So now I'm going to just remind everyone of what our initial recommendations were back in 2024. As it stands today again, quickly, there's a $0 base customer fare. The trip cap is 60 per month. Subsidy is up to $25 per trip. It is available within the entire district and it is available 24/7. Back when we came to you in November of 2024, we had proposed making changes, and this involved having a $4.50 base customer fare, which would be $2.25 for our LiVE eligible customers. We proposed a trip cap of $40 per month. The subsidy would go to $20 per trip, and then it was proposed to mirror both the current service area and the service hours. With this recommendation, there were going to be cost savings that the District would realize, and that was going to be about $5.8 million. So instead of the projected yearly spend being a little bit over 15 million, we would go down to about 9.4. OK, and as a result of some of the feedback and comments that we've heard, we did put together two additional revised scenarios. So scenario one is what I'm going to touch on first. So this has to do with an increased trip cap approach. So what we were proposing in this scenario is increasing the trip cap to 50 per month from the original 40 that was proposed. We are proposing as this is, again, as we've said, a premium supplemental service, a fare of $6.50 per trip, which would be $3.25 for our LiVE customers. Then the remainder of the proposal does remain the same. We were still proposing a subsidy per trip of $20, and we are proposing mirroring the current service area and service hours as that of our Access-a-Ride program. With this program, we did see actually a little bit of the yearly impact would be a cost savings of about 6.1 million, bringing our total spend to about a little over 9.1. With the 50 trips, that does allow for customers to still have-- given there's about 20 week days in a month that does allow for customers to still travel to work, but then does allow for some ancillary trips throughout the month. And then another scenario that we had put together is the tiered approach that we have discussed. With this approach, we would still maintain a trip cap of up to 60 trips per month, which matches what we have currently. There would be a $4.50 base customer fare for up to 30 trips, $5.50 for 31 to 50, and $6.50 for 51 to 60. And the remainder of the recommendation would remain the same. With this program, as some people have noted, due to the program structure and some of the manual aspects that exist with monitoring today, there would be a pretty big an increase in staff oversight that would result in additional staff headcount. Again, that had been noted, but as it stands today, the program does require quite a bit of manual intervention. There is also, as someone mentioned, the customers would need to be keeping a little bit closer track of their trips, and that could lead to confusion. It is something a customer would have to be regularly thinking, all right, where am I at for the month? Have I hit that 30 trips? So they know what to expect for their costs. With this program, we would see some reductions of just over $5 million. So it is a little bit less than some of the other recommendations that we've put forth, and it would bring our projected yearly spend to about $10.28 million a year. Oh, and actually. So proposed next steps. We are here, as GM/CEO Johnson has said, to just garner everyone's feedback and get some guidance on a path forward. The intent is to do outreach and engagement in June based on some of that guidance and engage with the community. We would be coming back for Board consideration in July with an actual recommended action to the committee, and then provided the committee advanced it at the Board meeting. And we would begin implementation in August with full implementation in October. And with that, I will open it up.",
     "start": 3371.279,
-    "end": 3371.6895
-  },
-  {
-    "text": "OK, so just to highlight on this, again, as GM/CEO Johnson said.",
-    "start": 3372.14,
-    "end": 3378.45296296296
-  },
-  {
-    "text": "Access-a- Ride and Access-on-Demand are the two programs that we have.",
-    "start": 3378.903888888886,
-    "end": 3383.864074074069
-  },
-  {
-    "text": "Access-a-Ride is RTD's federally required ADA complementary paratransit service.",
-    "start": 3384.535,
-    "end": 3390.444333333333
-  },
-  {
-    "text": "It does supplement our fixed route services.",
-    "start": 3391.163,
-    "end": 3393.8261428571436
-  },
-  {
-    "text": "There is a fare payment required for these services and customers must meet the criteria set forth by the Americans with Disabilities Act of 1990 to be eligible.",
-    "start": 3394.851,
-    "end": 3406.5448928571486
-  },
-  {
-    "text": "This is provided with all RTD branded Access-a-Ride vehicles that are all 100% accessible.",
-    "start": 3406.958,
-    "end": 3413.237466666665
-  },
-  {
-    "text": "And then Access-on-Demand is our supplemental premium paratransit service.",
-    "start": 3414.507,
-    "end": 3418.9297272727267
-  },
-  {
-    "text": "It is a curb-to-curb taxi and rideshare service.",
-    "start": 3420.153,
-    "end": 3423.593909090909
-  },
-  {
-    "text": "It is available to current paratransit customers, so they must meet those eligibility criteria to qualify for Access-a-Ride to then use Access-on-Demand.",
-    "start": 3424.638,
-    "end": 3434.9536666666636
-  },
-  {
-    "text": "And as it stands today, RTD pays the first $25 of the trip and the remaining portion is paid by the customer.",
-    "start": 3436.372,
-    "end": 3442.494454545455
-  },
-  {
-    "text": "And again, ability today to take 60 total trips.",
-    "start": 3443.668,
-    "end": 3447.1604444444442
-  },
-  {
-    "text": "So just some quick operating statistics.",
-    "start": 3448.336,
-    "end": 3450.256
-  },
-  {
-    "text": "The annual operating cost in 2024 for Access-a-Ride was just over 53 million, and the customer trips were just over 500,000.",
-    "start": 3450.82,
-    "end": 3458.3370454545448
-  },
-  {
-    "text": "And again, these are RTD owned vehicles, and the contractors that operate this service have over 500 drivers, mechanics, and other staff.",
-    "start": 3458.835,
-    "end": 3467.8239545454567
-  },
-  {
-    "text": "And then Access-on-Demand.",
-    "start": 3468.232,
-    "end": 3468.853222222222
-  },
-  {
-    "text": "Last year it was about just over $15.3 million for the budget.",
-    "start": 3469.163833333333,
-    "end": 3473.5123888888875
-  },
-  {
-    "text": "Just over 685,000 trips.",
-    "start": 3476.008,
-    "end": 3477.2010769230774
-  },
-  {
-    "text": "And these are all provided by third party vehicles.",
-    "start": 3477.59876923077,
-    "end": 3480.78030769231
-  },
-  {
-    "text": "So again, as we touched on, you must be eligible for Access-a-Ride to also use Access-on-Demand.",
-    "start": 3483.031,
-    "end": 3488.3590000000013
-  },
-  {
-    "text": "There is a process that customers must go through that determines if a customer has a disabling condition that would prevent them from using our regular fixed route service.",
-    "start": 3490.639,
-    "end": 3499.743827586207
-  },
-  {
-    "text": "There's an application process, a medical verification process, and then an in-person assessment that customers must complete.",
-    "start": 3501.05,
-    "end": 3507.758705882353
-  },
-  {
-    "text": "And there are a couple of different types of eligibility that a customer could receive.",
-    "start": 3508.158,
-    "end": 3512.2693333333305
-  },
-  {
-    "text": "Unconditional means you can have access to the full service for up to four years.",
-    "start": 3512.744,
-    "end": 3517.9202666666683
-  },
-  {
-    "text": "Temporary.",
-    "start": 3518.831,
-    "end": 3518.831
-  },
-  {
-    "text": "You might have a condition that's going to improve, recovering from surgery or something along those lines.",
-    "start": 3519.1536111111113,
-    "end": 3524.3153888888905
-  },
-  {
-    "text": "And then conditional would be when there was something-- maybe you're sensitive to extreme hot or extreme cold, so you would be able to use it at those times, but not the full year.",
-    "start": 3525.239,
-    "end": 3535.5204375000017
-  },
-  {
-    "text": "OK.",
-    "start": 3537.537,
-    "end": 3537.537
-  },
-  {
-    "text": "And as we have touched on, this is something that you've probably seen as well.",
-    "start": 3537.9136875,
-    "end": 3543.1873125000016
-  },
-  {
-    "text": "We are continuing to see an increase in Access-on-Demand usage.",
-    "start": 3544.324,
-    "end": 3548.1419166666647
-  },
-  {
-    "text": "This is through 2024, but we continue to see that Access- on-Demand trend line going up into the start of this year.",
-    "start": 3549.03,
-    "end": 3555.7706086956546
-  },
-  {
-    "text": "And Access-a-Ride, when you look at the trend line, while it is staying a little bit more stable, we are still seeing an increase in usage there as well.",
-    "start": 3556.097,
-    "end": 3565.3683000000005
-  },
-  {
-    "text": "And as we've talked about, average monthly trips per customer.",
-    "start": 3567.862,
-    "end": 3571.2157600000005
-  },
-  {
-    "text": "The majority of customers are falling into the category of taking up to 50 trips.",
-    "start": 3571.5884000000005,
-    "end": 3576.805360000001
-  },
-  {
-    "text": "That is about 90% of the customers when we last did the analysis, and about 10% of the customers again fall into that 51 to 60 category.",
-    "start": 3577.198,
-    "end": 3586.652928571426
-  },
-  {
-    "text": "So now I'm going to just remind everyone of what our initial recommendations were back in 2024.",
-    "start": 3588.989,
-    "end": 3593.9565294117624
-  },
-  {
-    "text": "As it stands today again, quickly, there's a $0 base customer fare.",
-    "start": 3594.367,
-    "end": 3599.9977692307693
-  },
-  {
-    "text": "The trip cap is 60 per month.",
-    "start": 3600.768,
-    "end": 3602.613428571429
-  },
-  {
-    "text": "Subsidy is up to $25 per trip.",
-    "start": 3602.9210000000003,
-    "end": 3604.766428571429
-  },
-  {
-    "text": "It is available within the entire district and it is available 24/7.",
-    "start": 3606.416,
-    "end": 3609.975769230771
-  },
-  {
-    "text": "Back when we came to you in November of 2024, we had proposed making changes, and this involved having a $4.50 base customer fare, which would be $2.25 for our LiVE eligible customers.",
-    "start": 3611.384,
-    "end": 3625.4455757575724
-  },
-  {
-    "text": "We proposed a trip cap of $40 per month.",
-    "start": 3626.466,
-    "end": 3628.780666666665
-  },
-  {
-    "text": "The subsidy would go to $20 per trip, and then it was proposed to mirror both the current service area and the service hours.",
-    "start": 3630.282,
-    "end": 3637.9381250000015
-  },
-  {
-    "text": "With this recommendation, there were going to be cost savings that the District would realize, and that was going to be about $5.8 million.",
-    "start": 3640.233,
-    "end": 3648.4459166666666
-  },
-  {
-    "text": "So instead of the projected yearly spend being a little bit over 15 million, we would go down to about 9.4.",
-    "start": 3650.184,
-    "end": 3657.8306666666695
-  },
-  {
-    "text": "OK, and as a result of some of the feedback and comments that we've heard, we did put together two additional revised scenarios.",
-    "start": 3661.957,
-    "end": 3669.1404782608683
-  },
-  {
-    "text": "So scenario one is what I'm going to touch on first.",
-    "start": 3669.487,
-    "end": 3672.618818181819
-  },
-  {
-    "text": "So this has to do with an increased trip cap approach.",
-    "start": 3673.152,
-    "end": 3676.447454545455
-  },
-  {
-    "text": "So what we were proposing in this scenario is increasing the trip cap to 50 per month from the original 40 that was proposed.",
-    "start": 3677.659,
-    "end": 3685.642874999995
-  },
-  {
-    "text": "We are proposing as this is, again, as we've said, a premium supplemental service, a fare of $6.50 per trip, which would be $3.25 for our LiVE customers.",
-    "start": 3685.97,
-    "end": 3697.6937857142902
-  },
-  {
-    "text": "Then the remainder of the proposal does remain the same.",
-    "start": 3699.229,
-    "end": 3701.338599999998
-  },
-  {
-    "text": "We were still proposing a subsidy per trip of $20, and we are proposing mirroring the current service area and service hours as that of our Access-a-Ride program.",
-    "start": 3701.713,
-    "end": 3713.107964285717
-  },
-  {
-    "text": "With this program, we did see actually a little bit of the yearly impact would be a cost savings of about 6.1 million, bringing our total spend to about a little over 9.1.",
-    "start": 3714.303,
-    "end": 3729.583571428572
-  },
-  {
-    "text": "With the 50 trips, that does allow for customers to still have-- given there's about 20 week days in a month that does allow for customers to still travel to work, but then does allow for some ancillary trips throughout the month.",
-    "start": 3730.013,
-    "end": 3747.122268292679
-  },
-  {
-    "text": "And then another scenario that we had put together is the tiered approach that we have discussed.",
-    "start": 3749.977,
-    "end": 3756.1586470588236
-  },
-  {
-    "text": "With this approach, we would still maintain a trip cap of up to 60 trips per month, which matches what we have currently.",
-    "start": 3757.206,
-    "end": 3764.388521739127
-  },
-  {
-    "text": "There would be a $4.50 base customer fare for up to 30 trips, $5.50 for 31 to 50, and $6.50 for 51 to 60.",
-    "start": 3765.676,
-    "end": 3776.5929090909085
-  },
-  {
-    "text": "And the remainder of the recommendation would remain the same.",
-    "start": 3777.804,
-    "end": 3780.873900000001
-  },
-  {
-    "text": "With this program, as some people have noted, due to the program structure and some of the manual aspects that exist with monitoring today, there would be a pretty big an increase in staff oversight that would result in additional staff headcount.",
-    "start": 3782.613,
-    "end": 3800.063434782604
-  },
-  {
-    "text": "Again, that had been noted, but as it stands today, the program does require quite a bit of manual intervention.",
-    "start": 3800.499695652169,
-    "end": 3806.9892666666665
-  },
-  {
-    "text": "There is also, as someone mentioned, the customers would need to be keeping a little bit closer track of their trips, and that could lead to confusion.",
-    "start": 3808.347,
-    "end": 3816.0882592592575
-  },
-  {
-    "text": "It is something a customer would have to be regularly thinking, all right, where am I at for the month?",
-    "start": 3816.867,
-    "end": 3822.5993
-  },
-  {
-    "text": "Have I hit that 30 trips?",
-    "start": 3823.362,
-    "end": 3824.5513333333342
-  },
-  {
-    "text": "So they know what to expect for their costs.",
-    "start": 3824.789200000001,
-    "end": 3826.6921333333357
-  },
-  {
-    "text": "With this program, we would see some reductions of just over $5 million.",
-    "start": 3828.749,
-    "end": 3833.2979230769215
-  },
-  {
-    "text": "So it is a little bit less than some of the other recommendations that we've put forth, and it would bring our projected yearly spend to about $10.28 million a year.",
-    "start": 3833.757,
-    "end": 3844.0971428571406
-  },
-  {
-    "text": "Oh, and actually.",
-    "start": 3848.341,
-    "end": 3848.6715
-  },
-  {
-    "text": "So proposed next steps.",
-    "start": 3849.86,
-    "end": 3851.0006428571432
-  },
-  {
-    "text": "We are here, as GM/CEO Johnson has said, to just garner everyone's feedback and get some guidance on a path forward.",
-    "start": 3851.3808571428576,
-    "end": 3860.125785714288
-  },
-  {
-    "text": "The intent is to do outreach and engagement in June based on some of that guidance and engage with the community.",
-    "start": 3861.067,
-    "end": 3867.3679523809524
-  },
-  {
-    "text": "We would be coming back for Board consideration in July with an actual recommended action to the committee, and then provided the committee advanced it at the Board meeting.",
-    "start": 3867.663,
-    "end": 3878.1378965517265
-  },
-  {
-    "text": "And we would begin implementation in August with full implementation in October.",
-    "start": 3878.572,
-    "end": 3883.691583333336
-  },
-  {
-    "text": "And with that, I will open it up.",
-    "start": 3884.197,
     "end": 3887.4904999999994
   },
   {
-    "text": "Julien Bouquet: Perfect.",
+    "text": "Julien Bouquet: Perfect. Thank you very much for your presentation, Ms. Vallejos. OK. I'm going to open it up for Directors. Second Vice Chair Whitmore.",
     "start": 3889.082,
-    "end": 3889.082
-  },
-  {
-    "text": "Thank you very much for your presentation, Ms.",
-    "start": 3889.982,
-    "end": 3891.4887500000013
-  },
-  {
-    "text": "Vallejos.",
-    "start": 3891.744,
-    "end": 3891.744
-  },
-  {
-    "text": "OK.",
-    "start": 3893.165,
-    "end": 3893.165
-  },
-  {
-    "text": "I'm going to open it up for Directors.",
-    "start": 3893.400777777778,
-    "end": 3895.0512222222233
-  },
-  {
-    "text": "Second Vice Chair Whitmore.",
-    "start": 3895.567,
     "end": 3896.25775
   },
   {
-    "text": "Troy Whitmore: Thank you for the presentation and the ease of absorbing the proposed changes.",
+    "text": "Troy Whitmore: Thank you for the presentation and the ease of absorbing the proposed changes. Erin, looking at the second proposal, the tiered approach, one of our commenters talked about the complications of keeping up with number of trips. Is that something that the new staff would be able to be a clearinghouse, if you will, to where you have one call to RTD instead of calling a taxi and a Lyft and an Uber? That seems to be the most difficult part of that. I'm just curious if you think our staff would be handling that in a way that would be handy for our customers.",
     "start": 3896.25775,
-    "end": 3902.034769230768
-  },
-  {
-    "text": "Erin, looking at the second proposal, the tiered approach, one of our commenters talked about the complications of keeping up with number of trips.",
-    "start": 3903.264,
-    "end": 3915.25945833333
-  },
-  {
-    "text": "Is that something that the new staff would be able to be a clearinghouse, if you will, to where you have one call to RTD instead of calling a taxi and a Lyft and an Uber?",
-    "start": 3916.522,
-    "end": 3928.4660722891535
-  },
-  {
-    "text": "That seems to be the most difficult part of that.",
-    "start": 3928.77636144578,
-    "end": 3931.568963855417
-  },
-  {
-    "text": "I'm just curious if you think our staff would be handling that in a way that would be handy for our customers.",
-    "start": 3931.8792530120436,
     "end": 3938.3953253011973
   },
   {
-    "text": "Erin Vallejos: It's definitely something I think we could assist with, but I do think there would still be some burden on the customer for having some of that responsibility.",
+    "text": "Erin Vallejos: It's definitely something I think we could assist with, but I do think there would still be some burden on the customer for having some of that responsibility. Again, as I mentioned, as it stands today, there is just a very manual aspect of the program. And so while we're always looking at things to improve, I do think there would still be some responsibility that would live with the customer.",
     "start": 3938.7056144578237,
-    "end": 3947.0834216867356
-  },
-  {
-    "text": "Again, as I mentioned, as it stands today, there is just a very manual aspect of the program.",
-    "start": 3948.207,
-    "end": 3953.4666111111105
-  },
-  {
-    "text": "And so while we're always looking at things to improve, I do think there would still be some responsibility that would live with the customer.",
-    "start": 3954.317,
     "end": 3962.355079999995
   },
   {
-    "text": "Julien Bouquet: Thank you.",
+    "text": "Julien Bouquet: Thank you. Director Catlin.",
     "start": 3964.934,
-    "end": 3965.2545
-  },
-  {
-    "text": "Director Catlin.",
-    "start": 3967.36,
     "end": 3967.36
   },
   {
-    "text": "Peggy Catlin: Thank you.",
+    "text": "Peggy Catlin: Thank you. And thank you for a very clear presentation. Although I have one question of clarification. You talk about mirroring the existing service area. One of the things that appealed to me about this service was that I don't think that the customers were restricted to the 3/4 mile within a fixed route. Would that change with this, any of these proposals? Or would it still be over the entire RTD service area?",
     "start": 3967.36,
-    "end": 3967.6605
-  },
-  {
-    "text": "And thank you for a very clear presentation.",
-    "start": 3967.981,
-    "end": 3970.0136250000005
-  },
-  {
-    "text": "Although I have one question of clarification.",
-    "start": 3970.384,
-    "end": 3973.5777142857132
-  },
-  {
-    "text": "You talk about mirroring the existing service area.",
-    "start": 3974.49,
-    "end": 3976.8909999999987
-  },
-  {
-    "text": "One of the things that appealed to me about this service was that I don't think that the customers were restricted to the 3/4 mile within a fixed route.",
-    "start": 3978.496,
-    "end": 3993.035633333339
-  },
-  {
-    "text": "Would that change with this, any of these proposals?",
-    "start": 3994.225,
-    "end": 3997.3682
-  },
-  {
-    "text": "Or would it still be over the entire RTD service area?",
-    "start": 3997.7552666666666,
     "end": 4001.6259333333333
   },
   {
@@ -3200,703 +520,88 @@
     "end": 4010.7200400000042
   },
   {
-    "text": "Peggy Catlin: That presents some problems for me, but we can talk about that later.",
+    "text": "Peggy Catlin: That presents some problems for me, but we can talk about that later. Thank you.",
     "start": 4014.645,
-    "end": 4020.895384615384
-  },
-  {
-    "text": "Thank you.",
-    "start": 4021.372,
     "end": 4021.562
   },
   {
-    "text": "Julien Bouquet: OK.",
-    "start": 4023.993,
-    "end": 4023.993
-  },
-  {
-    "text": "Secretary Nicholson.",
+    "text": "Julien Bouquet: OK. Secretary Nicholson.",
     "start": 4023.993,
     "end": 4024.5245
   },
   {
-    "text": "Chris Nicholson: Thank you very much.",
+    "text": "Chris Nicholson: Thank you very much. I think I first want to echo and perhaps be a little bit more direct about what Director Catlin said. We have bus routes in this system that don't qualify for the ADA service, but they're bus routes anyway. They're our commuter routes, and I would not vote personally for a change that would cut off the people who live within 3/4 of a mile of those routes. So at least for me, you guys want to get this through, you're going to need to change that because it's just a matter of basic equity. Otherwise Peggy has two places in her district that get service, and that's just not reasonable. There are a lot of older folks that live up in those areas. I think the second issue that I have with what's being proposed is that the needs of-- not call it rural, but mountainous Jefferson County, when it comes to AOD, are very different than the needs of central Denver. I can get to most places that I need to go, in terms of grocery stores, medical, et cetera, in a $15 Uber. I don't think there's anywhere that you can get to for $15 in Peggy's district, or yours. Exactly. But creating a system where the trip cap is $40 doesn't work for me. Creating a trip cap where it's $15 doesn't work for the people in her district. It strikes me that the right approach would be to have different levels of financial cap and different levels of trip cap to go along with them and let people pick. You want 60 trips at $15 per? Great. You want 50 trips at $20 per? Great. You want 40 trips at $30 per? Great. Depends on where you live, depends on the types of trips you're going to be taking. But making people all fit into one size is either going to leave her people paying $20 for every single trip that they take, or it's going to put people in my district in a reduced number of rides, because very few trips are going to cost $20 or $25. Those are my two pieces of feedback. Thank you.",
     "start": 4024.5245,
-    "end": 4028.1532500000003
-  },
-  {
-    "text": "I think I first want to echo and perhaps be a little bit more direct about what Director Catlin said.",
-    "start": 4028.805,
-    "end": 4035.5671
-  },
-  {
-    "text": "We have bus routes in this system that don't qualify for the ADA service, but they're bus routes anyway.",
-    "start": 4037.407,
-    "end": 4043.1455555555567
-  },
-  {
-    "text": "They're our commuter routes, and I would not vote personally for a change that would cut off the people who live within 3/4 of a mile of those routes.",
-    "start": 4044.508,
-    "end": 4055.679766666669
-  },
-  {
-    "text": "So at least for me, you guys want to get this through, you're going to need to change that because it's just a matter of basic equity.",
-    "start": 4056.126,
-    "end": 4062.317851851847
-  },
-  {
-    "text": "Otherwise Peggy has two places in her district that get service, and that's just not reasonable.",
-    "start": 4062.596,
-    "end": 4068.2576153846144
-  },
-  {
-    "text": "There are a lot of older folks that live up in those areas.",
-    "start": 4068.566,
-    "end": 4071.434
-  },
-  {
-    "text": "I think the second issue that I have with what's being proposed is that the needs of-- not call it rural, but mountainous Jefferson County, when it comes to AOD, are very different than the needs of central Denver.",
-    "start": 4072.675,
-    "end": 4090.692583333333
-  },
-  {
-    "text": "I can get to most places that I need to go, in terms of grocery stores, medical, et cetera, in a $15 Uber.",
-    "start": 4091.911208333333,
-    "end": 4101.254000000005
-  },
-  {
-    "text": "I don't think there's anywhere that you can get to for $15 in Peggy's district, or yours.",
-    "start": 4102.472625000007,
-    "end": 4109.378166666681
-  },
-  {
-    "text": "Exactly.",
-    "start": 4109.784375000015,
-    "end": 4109.784375000015
-  },
-  {
-    "text": "But creating a system where the trip cap is $40 doesn't work for me.",
-    "start": 4111.49,
-    "end": 4116.088533333335
-  },
-  {
-    "text": "Creating a trip cap where it's $15 doesn't work for the people in her district.",
-    "start": 4116.497,
-    "end": 4121.604500000004
-  },
-  {
-    "text": "It strikes me that the right approach would be to have different levels of financial cap and different levels of trip cap to go along with them and let people pick.",
-    "start": 4122.005,
-    "end": 4133.285967741941
-  },
-  {
-    "text": "You want 60 trips at $15 per?",
-    "start": 4133.762,
-    "end": 4136.493
-  },
-  {
-    "text": "Great.",
-    "start": 4137.505,
-    "end": 4137.505
-  },
-  {
-    "text": "You want 50 trips at $20 per?",
-    "start": 4137.826,
-    "end": 4140.024571428571
-  },
-  {
-    "text": "Great.",
-    "start": 4140.511,
-    "end": 4140.511
-  },
-  {
-    "text": "You want 40 trips at $30 per?",
-    "start": 4140.792,
-    "end": 4143.317142857143
-  },
-  {
-    "text": "Great.",
-    "start": 4144.098,
-    "end": 4144.098
-  },
-  {
-    "text": "Depends on where you live, depends on the types of trips you're going to be taking.",
-    "start": 4144.399,
-    "end": 4147.2882727272745
-  },
-  {
-    "text": "But making people all fit into one size is either going to leave her people paying $20 for every single trip that they take, or it's going to put people in my district in a reduced number of rides, because very few trips are going to cost $20 or $25.",
-    "start": 4147.545,
-    "end": 4166.445192307687
-  },
-  {
-    "text": "Those are my two pieces of feedback.",
-    "start": 4167.137374999999,
-    "end": 4168.669624999998
-  },
-  {
-    "text": "Thank you.",
-    "start": 4168.946,
     "end": 4170.178
   },
   {
-    "text": "Julien Bouquet: Thank you, Secretary.",
+    "text": "Julien Bouquet: Thank you, Secretary. Director Ruscha.",
     "start": 4171.43,
-    "end": 4171.9506666666675
-  },
-  {
-    "text": "Director Ruscha.",
-    "start": 4173.013,
     "end": 4173.3535
   },
   {
-    "text": "Joyann Ruscha: Thank you, Mr.",
+    "text": "Joyann Ruscha: Thank you, Mr. Chair. So I just wanted to offer a bit of context. And the General Manager, please interrupt me if I'm framing this wrong. But the conversation that we're having tonight is a framework of a potential path forward. And because our OSS meeting went so long, we weren't able to get to the discussion and that also, I think, impacted our ability to have some interim discussions. So I just want folks to keep an open mind to what staff is saying and definitely share that feedback because we're on a timeline. But also just recognize that-- and please, if I'm saying this wrong, interrupt me. But what is being presented is a concept framework. So we'll get Board feedback, and then of course, staff is going to be working very closely with our existing customers and advocacy organizations to make further refinements and give us some more stuff to look at. So I hope I didn't speak out of turn, but I just wanted to offer that for context. And I'm also listening and taking notes, and I know staff is. So I would just urge, if anyone has thoughts, one way or another, please share them tonight since we are also on a timeline with our existing partners and those contracts as well. Thank you.",
     "start": 4173.3535,
-    "end": 4178.672500000001
-  },
-  {
-    "text": "Chair.",
-    "start": 4178.842750000001,
-    "end": 4178.842750000001
-  },
-  {
-    "text": "So I just wanted to offer a bit of context.",
-    "start": 4180.174,
-    "end": 4184.264499999998
-  },
-  {
-    "text": "And the General Manager, please interrupt me if I'm framing this wrong.",
-    "start": 4184.739,
-    "end": 4189.236166666662
-  },
-  {
-    "text": "But the conversation that we're having tonight is a framework of a potential path forward.",
-    "start": 4190.025,
-    "end": 4195.8928666666725
-  },
-  {
-    "text": "And because our OSS meeting went so long, we weren't able to get to the discussion and that also, I think, impacted our ability to have some interim discussions.",
-    "start": 4196.993,
-    "end": 4209.939526315792
-  },
-  {
-    "text": "So I just want folks to keep an open mind to what staff is saying and definitely share that feedback because we're on a timeline.",
-    "start": 4210.253789473687,
-    "end": 4218.738894736848
-  },
-  {
-    "text": "But also just recognize that-- and please, if I'm saying this wrong, interrupt me.",
-    "start": 4219.053157894743,
-    "end": 4223.452842105271
-  },
-  {
-    "text": "But what is being presented is a concept framework.",
-    "start": 4223.452842105271,
-    "end": 4225.96694736843
-  },
-  {
-    "text": "So we'll get Board feedback, and then of course, staff is going to be working very closely with our existing customers and advocacy organizations to make further refinements and give us some more stuff to look at.",
-    "start": 4227.852526315799,
-    "end": 4240.5734000000075
-  },
-  {
-    "text": "So I hope I didn't speak out of turn, but I just wanted to offer that for context.",
-    "start": 4241.005,
-    "end": 4247.720944444447
-  },
-  {
-    "text": "And I'm also listening and taking notes, and I know staff is.",
-    "start": 4248.877,
-    "end": 4252.921117647058
-  },
-  {
-    "text": "So I would just urge, if anyone has thoughts, one way or another, please share them tonight since we are also on a timeline with our existing partners and those contracts as well.",
-    "start": 4253.2887647058815,
-    "end": 4264.709299999998
-  },
-  {
-    "text": "Thank you.",
-    "start": 4265.631,
     "end": 4265.8115
   },
   {
-    "text": "Julien Bouquet: Thank you, Director.",
+    "text": "Julien Bouquet: Thank you, Director. Director Larsen.",
     "start": 4267.114,
-    "end": 4268.577
-  },
-  {
-    "text": "Director Larsen.",
-    "start": 4268.577,
     "end": 4268.907999999999
   },
   {
-    "text": "Matt Larsen: Thank you.",
+    "text": "Matt Larsen: Thank you. I just have a question for Ms. Vallejos. So I seen one of these slides that it says in December of 2024, there were about 2,900 total active customers of Access-on-Demand. So there were 2,900 people, roughly, who used it in all of December? Is that right?",
     "start": 4272.886,
-    "end": 4273.0965
-  },
-  {
-    "text": "I just have a question for Ms.",
-    "start": 4273.447,
-    "end": 4275.457
-  },
-  {
-    "text": "Vallejos.",
-    "start": 4275.812,
-    "end": 4275.812
-  },
-  {
-    "text": "So I seen one of these slides that it says in December of 2024, there were about 2,900 total active customers of Access-on-Demand.",
-    "start": 4277.596,
-    "end": 4288.194000000004
-  },
-  {
-    "text": "So there were 2,900 people, roughly, who used it in all of December?",
-    "start": 4290.982,
-    "end": 4295.732153846151
-  },
-  {
-    "text": "Is that right?",
-    "start": 4296.929,
     "end": 4297.262333333334
   },
   {
-    "text": "Erin Vallejos: No, that would be for the year, I believe.",
+    "text": "Erin Vallejos: No, that would be for the year, I believe. Let me--",
     "start": 4298.751,
-    "end": 4301.129699999999
+    "end": 4302.822666666667
   },
   {
-    "text": "Let me-- Matt Larsen: As of.",
-    "start": 4302.736,
-    "end": 4303.076
+    "text": "Matt Larsen: As of. OK. As of. So 2,900 people used this service for the whole year. That's it? And so I guess what I'm trying to just understand is so if we were going to spend, say $10 million or $15 million on 2,900 people, what do we think the equivalent is for just our regular riders? Do we have any guess? I mean, I know people have different ridership. I'm just trying to get-- I mean, if we have a million customers a year and it's the majority of our budget, I'm just trying to get a sense of how the per person spend for a regular rider compares to the per person spend for Access-on-Demand",
+    "start": 4302.909333333334,
+    "end": 4346.514767857119
   },
   {
-    "text": "OK.",
-    "start": 4303.076,
-    "end": 4303.076
-  },
-  {
-    "text": "As of.",
-    "start": 4304.017,
-    "end": 4304.017
-  },
-  {
-    "text": "So 2,900 people used this service for the whole year.",
-    "start": 4304.017,
-    "end": 4308.324400000003
-  },
-  {
-    "text": "That's it?",
-    "start": 4309.084,
-    "end": 4309.294
-  },
-  {
-    "text": "And so I guess what I'm trying to just understand is so if we were going to spend, say $10 million or $15 million on 2,900 people, what do we think the equivalent is for just our regular riders?",
-    "start": 4311.2013636363645,
-    "end": 4328.259928571423
-  },
-  {
-    "text": "Do we have any guess?",
-    "start": 4328.959,
-    "end": 4329.7126
-  },
-  {
-    "text": "I mean, I know people have different ridership.",
-    "start": 4330.521,
-    "end": 4332.648599999998
-  },
-  {
-    "text": "I'm just trying to get-- I mean, if we have a million customers a year and it's the majority of our budget, I'm just trying to get a sense of how the per person spend for a regular rider compares to the per person spend for Access-on-Demand Erin Vallejos: And I-- go ahead, Debra.",
-    "start": 4332.925,
-    "end": 4350.901000000002
-  },
-  {
-    "text": "Oh.",
-    "start": 4353.393,
+    "text": "Erin Vallejos: And I-- go ahead, Debra. Oh.",
+    "start": 4346.771178571405,
     "end": 4353.393
   },
   {
-    "text": "Debra Johnson: So if I can, Mr.",
+    "text": "Debra Johnson: So if I can, Mr. Chair, and thank you, Director Larsen, for the question. I would not want us to conjecture and speculate. We could double back and give you those numbers. As we talk about, you use the term regular rider. You're talking about those that are using fixed route service. I just want to be clear and intentional with the language we're using going forward. So we need to assess that, because it's a different level of service. Because with fixed route bus, we're not providing curb to curb service. And so we can double back and share that information with the Board, but I think it wouldn't be fruitful for us to guesstimate because this is critically important. But as we come back and we have some guidance, we could provide that detailed information, if you will. Thank you.",
     "start": 4353.393,
-    "end": 4354.383857142857
-  },
-  {
-    "text": "Chair, and thank you, Director Larsen, for the question.",
-    "start": 4354.631571428571,
-    "end": 4356.613285714285
-  },
-  {
-    "text": "I would not want us to conjecture and speculate.",
-    "start": 4357.162,
-    "end": 4359.318444444445
-  },
-  {
-    "text": "We could double back and give you those numbers.",
-    "start": 4359.668,
-    "end": 4361.29022222222
-  },
-  {
-    "text": "As we talk about, you use the term regular rider.",
-    "start": 4362.375,
-    "end": 4364.945849999998
-  },
-  {
-    "text": "You're talking about those that are using fixed route service.",
-    "start": 4365.231499999998,
-    "end": 4367.802349999996
-  },
-  {
-    "text": "I just want to be clear and intentional with the language we're using going forward.",
-    "start": 4368.129,
-    "end": 4371.010199999996
-  },
-  {
-    "text": "So we need to assess that, because it's a different level of service.",
-    "start": 4371.196,
-    "end": 4375.424799999997
-  },
-  {
-    "text": "Because with fixed route bus, we're not providing curb to curb service.",
-    "start": 4375.777199999997,
-    "end": 4379.653599999994
-  },
-  {
-    "text": "And so we can double back and share that information with the Board, but I think it wouldn't be fruitful for us to guesstimate because this is critically important.",
-    "start": 4380.366,
-    "end": 4389.099437499996
-  },
-  {
-    "text": "But as we come back and we have some guidance, we could provide that detailed information, if you will.",
-    "start": 4389.736,
-    "end": 4394.933263157894
-  },
-  {
-    "text": "Thank you.",
-    "start": 4395.642,
     "end": 4395.8125
   },
   {
-    "text": "Julien Bouquet: Thank you.",
+    "text": "Julien Bouquet: Thank you. Any other Directors, comments? Yeah, Director Guzman.",
     "start": 4397.965,
-    "end": 4398.4955
-  },
-  {
-    "text": "Any other Directors, comments?",
-    "start": 4400.356,
-    "end": 4401.9047500000015
-  },
-  {
-    "text": "Yeah, Director Guzman.",
-    "start": 4402.441,
     "end": 4402.975666666666
   },
   {
-    "text": "Michael Guzman: I am concerned with the aligning with the ADA for the service area.",
+    "text": "Michael Guzman: I am concerned with the aligning with the ADA for the service area. District C is fairly blessed with multiple forms of transit and fixed route where this is not a particular problem, but it is an issue in the suburban areas of the region. And it is highly concerning that we would restrict it so much where people would be left off of the system that live within a quarter mile of a commuter bus, and still not be able to access this. I also think that as we proceed into the future after the demographer's presentation to the Finance and Planning Committee, a big concern will be our aging population in the region. And somebody said that this is a drop in the bucket for our budget. Maybe right now, but eventually, this is going to catch up with us, which is why we're having this conversation. And Access-on-Demand and folks that are able to, or out of need, utilize this system need to be considered as humans first and how we serve them, which is our mission. They need connection as well, and not every one of them will be able to jump from a-- jump, roll, walk, shuffle to a fixed route form of transportation to get them to their destinations. I have a question about the time on this. If it's mirroring regular service provision for the whole region, it kind of makes sense. But I would still be concerned for the reasons that emergencies don't happen on RTD's schedule. And so somebody who already has a specific need for this type of transportation usage might need to go to the doctor. And what do they do if they're unable to drive. And regular bus service is not something that they can use because the buses aren't running? At 2 o'clock in the morning, emergency room visit is not unheard of and not uncommon in anybody's life. And yet, what do we do to take care of those that are most vulnerable? So for me, I would really want to see some clarity around those two areas. I am frankly less concerned about minimal difference of cost savings. I mean, we're talking $5 million. This is not really the top priority for me on that part right now. It will eventually get there because this will likely continue to grow. But I do want to make sure that we are basing ourselves in reality to serve the taxpayers' needs. And this is a need. This is not a desire, as some of the other services we want to grow and create are. This one is an actual need. And so I want to be clear in my language on that and why I'm depositing these comments within that framework. So that would be my feedback. I'd like to see something a little bit different on those two things, the service area and the time for service. Thank you.",
     "start": 4404.185,
-    "end": 4411.184571428566
-  },
-  {
-    "text": "District C is fairly blessed with multiple forms of transit and fixed route where this is not a particular problem, but it is an issue in the suburban areas of the region.",
-    "start": 4414.23,
-    "end": 4427.175846153851
-  },
-  {
-    "text": "And it is highly concerning that we would restrict it so much where people would be left off of the system that live within a quarter mile of a commuter bus, and still not be able to access this.",
-    "start": 4427.961,
-    "end": 4441.25223076923
-  },
-  {
-    "text": "I also think that as we proceed into the future after the demographer's presentation to the Finance and Planning Committee, a big concern will be our aging population in the region.",
-    "start": 4444.113,
-    "end": 4456.051064516135
-  },
-  {
-    "text": "And somebody said that this is a drop in the bucket for our budget.",
-    "start": 4457.31,
-    "end": 4462.170111111107
-  },
-  {
-    "text": "Maybe right now, but eventually, this is going to catch up with us, which is why we're having this conversation.",
-    "start": 4463.698,
-    "end": 4470.191566666663
-  },
-  {
-    "text": "And Access-on-Demand and folks that are able to, or out of need, utilize this system need to be considered as humans first and how we serve them, which is our mission.",
-    "start": 4470.533333333329,
-    "end": 4487.681629629639
-  },
-  {
-    "text": "They need connection as well, and not every one of them will be able to jump from a-- jump, roll, walk, shuffle to a fixed route form of transportation to get them to their destinations.",
-    "start": 4488.812,
-    "end": 4503.945166666675
-  },
-  {
-    "text": "I have a question about the time on this.",
-    "start": 4505.334,
-    "end": 4510.620399999997
-  },
-  {
-    "text": "If it's mirroring regular service provision for the whole region, it kind of makes sense.",
-    "start": 4512.363,
-    "end": 4519.913809523809
-  },
-  {
-    "text": "But I would still be concerned for the reasons that emergencies don't happen on RTD's schedule.",
-    "start": 4520.284761904761,
-    "end": 4525.849047619042
-  },
-  {
-    "text": "And so somebody who already has a specific need for this type of transportation usage might need to go to the doctor.",
-    "start": 4527.221,
-    "end": 4535.842454545448
-  },
-  {
-    "text": "And what do they do if they're unable to drive.",
-    "start": 4536.774,
-    "end": 4539.206700000002
-  },
-  {
-    "text": "And regular bus service is not something that they can use because the buses aren't running?",
-    "start": 4539.98,
-    "end": 4544.039375000001
-  },
-  {
-    "text": "At 2 o'clock in the morning, emergency room visit is not unheard of and not uncommon in anybody's life.",
-    "start": 4544.891,
-    "end": 4550.245526315792
-  },
-  {
-    "text": "And yet, what do we do to take care of those that are most vulnerable?",
-    "start": 4551.085,
-    "end": 4553.685266666672
-  },
-  {
-    "text": "So for me, I would really want to see some clarity around those two areas.",
-    "start": 4555.234,
-    "end": 4559.561333333334
-  },
-  {
-    "text": "I am frankly less concerned about minimal difference of cost savings.",
-    "start": 4561.044,
-    "end": 4566.033999999998
-  },
-  {
-    "text": "I mean, we're talking $5 million.",
-    "start": 4567.474,
-    "end": 4569.210666666666
-  },
-  {
-    "text": "This is not really the top priority for me on that part right now.",
-    "start": 4570.039,
-    "end": 4576.883071428571
-  },
-  {
-    "text": "It will eventually get there because this will likely continue to grow.",
-    "start": 4577.235142857143,
-    "end": 4581.107928571429
-  },
-  {
-    "text": "But I do want to make sure that we are basing ourselves in reality to serve the taxpayers' needs.",
-    "start": 4581.5,
-    "end": 4588.502947368423
-  },
-  {
-    "text": "And this is a need.",
-    "start": 4589.714,
-    "end": 4591.476666666666
-  },
-  {
-    "text": "This is not a desire, as some of the other services we want to grow and create are.",
-    "start": 4592.378,
-    "end": 4596.351750000005
-  },
-  {
-    "text": "This one is an actual need.",
-    "start": 4596.585500000006,
-    "end": 4597.754250000007
-  },
-  {
-    "text": "And so I want to be clear in my language on that and why I'm depositing these comments within that framework.",
-    "start": 4598.749,
-    "end": 4604.3736666666655
-  },
-  {
-    "text": "So that would be my feedback.",
-    "start": 4605.106,
-    "end": 4606.109333333333
-  },
-  {
-    "text": "I'd like to see something a little bit different on those two things, the service area and the time for service.",
-    "start": 4606.351,
-    "end": 4610.631952380959
-  },
-  {
-    "text": "Thank you.",
-    "start": 4611.027,
     "end": 4611.1775
   },
   {
-    "text": "Julien Bouquet: Thank you, Director.",
+    "text": "Julien Bouquet: Thank you, Director. Director Harwick.",
     "start": 4611.91,
-    "end": 4613.275
-  },
-  {
-    "text": "Director Harwick.",
-    "start": 4613.275,
     "end": 4613.636
   },
   {
-    "text": "Ian Harwick: Well, thank you, Director Guzman.",
+    "text": "Ian Harwick: Well, thank you, Director Guzman. I'm just going to pretty much replicate everything you just said. I represent Arvada, and Arvada is actually the fastest growing aging population. However I said that, I'm not sure I said it right. And a lot of our service is not in the areas where we have those aging people. So I'd really like to see just the boundary kept the same. I'm also really, again, with Director Guzman, keeping it at a full 24/7. I have a friend in a wheelchair and I just think about her trying-- like if she didn't live where she lived, if she lived where I lived, she would have such a difficult time getting around her community. And I would just-- especially if the service is outside of that time period, it's just precluding her life. I know we don't all have the same abilities when we're riding a bus, but for a person with disability that's blind or in a wheelchair, I think that we can extend them the grace that they deserve. I also would like to see the cap stay at 60. I think that, again, I know that less than 10% of the population go above the 50 rides. But I think it's still, we're giving them access to a free and full life. And I think if we are going to go the 6.50, I think that that, to me is fine. But I also think that it would be imperative that we really put out the LiVE program and let those riders know that there is another option. I was with someone the other day. She lives about 3 miles away from where she works, and she can afford it, but just barely. And she didn't know about the LiVE program. So I think that we're missing an opportunity there specifically with these riders. And then my last one is just a request. Is it possible to get a map, sort of like a density map, of where AOD is highly being used? To go with that thinking about West Jefferson County versus central Denver, just kind see what that looks like. Obviously, we want to anonymize the data, but I think it just would be interesting for us to know where the hotspots of usage are. Thank you.",
     "start": 4613.636,
-    "end": 4616.7984000000015
-  },
-  {
-    "text": "I'm just going to pretty much replicate everything you just said.",
-    "start": 4617.275,
-    "end": 4619.385909090906
-  },
-  {
-    "text": "I represent Arvada, and Arvada is actually the fastest growing aging population.",
-    "start": 4619.617,
-    "end": 4628.207083333333
-  },
-  {
-    "text": "However I said that, I'm not sure I said it right.",
-    "start": 4629.189,
-    "end": 4631.227999999997
-  },
-  {
-    "text": "And a lot of our service is not in the areas where we have those aging people.",
-    "start": 4632.012,
-    "end": 4637.137647058827
-  },
-  {
-    "text": "So I'd really like to see just the boundary kept the same.",
-    "start": 4638.039,
-    "end": 4642.931666666667
-  },
-  {
-    "text": "I'm also really, again, with Director Guzman, keeping it at a full 24/7.",
-    "start": 4643.392,
-    "end": 4647.614285714291
-  },
-  {
-    "text": "I have a friend in a wheelchair and I just think about her trying-- like if she didn't live where she lived, if she lived where I lived, she would have such a difficult time getting around her community.",
-    "start": 4649.364187499999,
-    "end": 4663.046687499995
-  },
-  {
-    "text": "And I would just-- especially if the service is outside of that time period, it's just precluding her life.",
-    "start": 4663.388749999995,
-    "end": 4669.720266666662
-  },
-  {
-    "text": "I know we don't all have the same abilities when we're riding a bus, but for a person with disability that's blind or in a wheelchair, I think that we can extend them the grace that they deserve.",
-    "start": 4670.277799999994,
-    "end": 4681.707233333314
-  },
-  {
-    "text": "I also would like to see the cap stay at 60.",
-    "start": 4682.843,
-    "end": 4685.083000000001
-  },
-  {
-    "text": "I think that, again, I know that less than 10% of the population go above the 50 rides.",
-    "start": 4685.327,
-    "end": 4692.500923076927
-  },
-  {
-    "text": "But I think it's still, we're giving them access to a free and full life.",
-    "start": 4692.842538461543,
-    "end": 4698.308384615392
-  },
-  {
-    "text": "And I think if we are going to go the 6.50, I think that that, to me is fine.",
-    "start": 4699.712,
-    "end": 4704.291
-  },
-  {
-    "text": "But I also think that it would be imperative that we really put out the LiVE program and let those riders know that there is another option.",
-    "start": 4704.532,
-    "end": 4712.910307692302
-  },
-  {
-    "text": "I was with someone the other day.",
-    "start": 4713.245261538455,
-    "end": 4715.5899384615295
-  },
-  {
-    "text": "She lives about 3 miles away from where she works, and she can afford it, but just barely.",
-    "start": 4715.924892307683,
-    "end": 4722.289015384598
-  },
-  {
-    "text": "And she didn't know about the LiVE program.",
-    "start": 4722.623969230752,
-    "end": 4724.968646153826
-  },
-  {
-    "text": "So I think that we're missing an opportunity there specifically with these riders.",
-    "start": 4725.303599999979,
-    "end": 4730.506
-  },
-  {
-    "text": "And then my last one is just a request.",
-    "start": 4731.2604,
-    "end": 4733.343600000001
-  },
-  {
-    "text": "Is it possible to get a map, sort of like a density map, of where AOD is highly being used?",
-    "start": 4733.624,
-    "end": 4741.024489361699
-  },
-  {
-    "text": "To go with that thinking about West Jefferson County versus central Denver, just kind see what that looks like.",
-    "start": 4741.376893617018,
-    "end": 4749.8345957446745
-  },
-  {
-    "text": "Obviously, we want to anonymize the data, but I think it just would be interesting for us to know where the hotspots of usage are.",
-    "start": 4750.267,
-    "end": 4757.4803793103565
-  },
-  {
-    "text": "Thank you.",
-    "start": 4758.393,
     "end": 4758.563
   },
   {
-    "text": "Julien Bouquet: Thank you, Director Harwick.",
+    "text": "Julien Bouquet: Thank you, Director Harwick. Ms. Johnson.",
     "start": 4758.753,
-    "end": 4759.293750000001
-  },
-  {
-    "text": "Ms.",
-    "start": 4759.655,
-    "end": 4759.655
-  },
-  {
-    "text": "Johnson.",
-    "start": 4759.875,
     "end": 4759.875
   },
   {
-    "text": "Debra Johnson: Yes.",
+    "text": "Debra Johnson: Yes. Director Harwick, if I understood you correctly, because I'm taking copious notes here, you are in support, for all intents and purposes, of what I hear, modification of scenario one, keeping it at 60 trips with 6.50, and then want information relative to what the current usage is from a geographic vantage point. OK. Thank you.",
     "start": 4759.875,
-    "end": 4761.397
-  },
-  {
-    "text": "Director Harwick, if I understood you correctly, because I'm taking copious notes here, you are in support, for all intents and purposes, of what I hear, modification of scenario one, keeping it at 60 trips with 6.50, and then want information relative to what the current usage is from a geographic vantage point.",
-    "start": 4761.730490909091,
-    "end": 4779.405509090907
-  },
-  {
-    "text": "OK.",
-    "start": 4780.259,
-    "end": 4780.259
-  },
-  {
-    "text": "Thank you.",
-    "start": 4780.7,
     "end": 4780.87
   },
   {
@@ -3905,238 +610,38 @@
     "end": 4782.5715
   },
   {
-    "text": "Ian Harwick: Yeah, but I also want to keep the service areas the same as they are today.",
+    "text": "Ian Harwick: Yeah, but I also want to keep the service areas the same as they are today. Yeah.",
     "start": 4782.942,
-    "end": 4786.715437499995
-  },
-  {
-    "text": "Yeah.",
-    "start": 4787.508,
     "end": 4787.508
   },
   {
-    "text": "Julien Bouquet: Excellent.",
+    "text": "Julien Bouquet: Excellent. Director Nicholson, then Director Ruscha.",
     "start": 4789.713,
-    "end": 4789.713
-  },
-  {
-    "text": "Director Nicholson, then Director Ruscha.",
-    "start": 4791.637,
     "end": 4794.170599999999
   },
   {
-    "text": "Chris Nicholson: Yeah, just a quick follow up onto that.",
+    "text": "Chris Nicholson: Yeah, just a quick follow up onto that. When it comes to-- go to Director Ruscha. My brain-- I lost my train of thought for a second, so.",
     "start": 4794.884,
-    "end": 4798.092625000001
-  },
-  {
-    "text": "When it comes to-- go to Director Ruscha.",
-    "start": 4799.533,
-    "end": 4802.114600000002
-  },
-  {
-    "text": "My brain-- I lost my train of thought for a second, so.",
-    "start": 4802.483400000002,
     "end": 4806.540200000004
   },
   {
-    "text": "Julien Bouquet: All right.",
+    "text": "Julien Bouquet: All right. Director Ruscha.",
     "start": 4808.151,
-    "end": 4808.3515
-  },
-  {
-    "text": "Director Ruscha.",
-    "start": 4808.552,
     "end": 4808.7525
   },
   {
-    "text": "Joyann Ruscha: Thank you for the Red Rover.",
+    "text": "Joyann Ruscha: Thank you for the Red Rover. I wasn't prepared. I went back to my notes. OK. So anyway, so some of this feedback I did share with staff and I don't want to be repetitive, but I also just want to be really transparent with my colleagues because we haven't had this public conversation yet. And just high level, some of the things that I had shared was, first of all, we don't want to put one proposal out before the community and get feedback, like the one that we've had out for several months, and then come back with something else that looks like less than what we originally proposed. And so one of the pain points that I had was just the idea of going up to 6.50 for the initial fare, because that's not what we originally put out there. So one of the things that I urge is that if we put an offer on the table, so to speak, we don't take it back. That's our baseline now. And another piece of feedback I had is that where something is not-- for every change we make, which essentially results in a reduction of a service of some kind or an increase in price, we really have to justify that line by line. So, for example, if we decide that we are going to strictly align with service hours, then we have to justify it. It doesn't cost us any more money. It's not going to save us a penny if somebody uses on-Demand 15 or 20 minutes or an hour before fixed route starts. Likewise, it's not costing us, that I could see, a lot of money, if any, for us to offer service outside of our general service area. I know that was flagged in the peer review. Because this idea has been on the table for so many months, I also want to caution us about the service area idea, because if we restrict this service, that means there are people who currently are using AOD and they're going to lose it. I mean, that was just a kind of high level theme that I had in the feedback. And also, I going back to the initial affair, we also want to be really careful about what we think is inexpensive, because it's really relative. So for some folks using this service and they have a fixed income or very limited income, if we even do 4.50, which would be parity with Access-a-Ride-- and I think I could accept that. But say we go up to 6.50 or we do this tiered system, then for some folks they are not going to be able to ride or they're going to be choosing, do I get to the doctor or do I buy food for tonight. So I just wanted to put that out there. And finally-- well, actually, I'll stop there. I concurred with what a lot of other Directors said in terms of keeping the program as-is as much as we can, But I also just want to commend staff, because we are at a much different place than where we were several months ago. This was a totally different conversation. We're talking about really slashing this program, and staff did a lot of work and we spent several months. We almost voted on this a few months ago, and they listened to us as Directors and they listened to community because, as you know, we've had hundreds of public comments over several months on this. And they said, OK, we can take a timeout, we can reassess, we can get some different data. We can present a new paradigm. So again, what's before us today is a sketch of ideas. The feedback is good, but I really do want to commend staff for listening and working with us in partnership. So thank you and thank you.",
     "start": 4808.7525,
-    "end": 4814.761666666666
-  },
-  {
-    "text": "I wasn't prepared.",
-    "start": 4815.022,
-    "end": 4815.543333333334
-  },
-  {
-    "text": "I went back to my notes.",
-    "start": 4815.824,
-    "end": 4816.574833333332
-  },
-  {
-    "text": "OK.",
-    "start": 4817.206,
-    "end": 4817.206
-  },
-  {
-    "text": "So anyway, so some of this feedback I did share with staff and I don't want to be repetitive, but I also just want to be really transparent with my colleagues because we haven't had this public conversation yet.",
-    "start": 4817.7837500000005,
-    "end": 4831.884333333325
-  },
-  {
-    "text": "And just high level, some of the things that I had shared was, first of all, we don't want to put one proposal out before the community and get feedback, like the one that we've had out for several months, and then come back with something else that looks like less than what we originally proposed.",
-    "start": 4832.609,
-    "end": 4849.6362758620935
-  },
-  {
-    "text": "And so one of the pain points that I had was just the idea of going up to 6.50 for the initial fare, because that's not what we originally put out there.",
-    "start": 4850.016,
-    "end": 4856.955352941176
-  },
-  {
-    "text": "So one of the things that I urge is that if we put an offer on the table, so to speak, we don't take it back.",
-    "start": 4857.526,
-    "end": 4867.959653846144
-  },
-  {
-    "text": "That's our baseline now.",
-    "start": 4868.958,
-    "end": 4870.193000000001
-  },
-  {
-    "text": "And another piece of feedback I had is that where something is not-- for every change we make, which essentially results in a reduction of a service of some kind or an increase in price, we really have to justify that line by line.",
-    "start": 4871.2,
-    "end": 4890.354451612911
-  },
-  {
-    "text": "So, for example, if we decide that we are going to strictly align with service hours, then we have to justify it.",
-    "start": 4891.121,
-    "end": 4899.569
-  },
-  {
-    "text": "It doesn't cost us any more money.",
-    "start": 4899.569,
-    "end": 4900.838428571426
-  },
-  {
-    "text": "It's not going to save us a penny if somebody uses on-Demand 15 or 20 minutes or an hour before fixed route starts.",
-    "start": 4901.23,
-    "end": 4910.891727272725
-  },
-  {
-    "text": "Likewise, it's not costing us, that I could see, a lot of money, if any, for us to offer service outside of our general service area.",
-    "start": 4912.961,
-    "end": 4922.31209090909
-  },
-  {
-    "text": "I know that was flagged in the peer review.",
-    "start": 4923.801,
-    "end": 4926.38322222222
-  },
-  {
-    "text": "Because this idea has been on the table for so many months, I also want to caution us about the service area idea, because if we restrict this service, that means there are people who currently are using AOD and they're going to lose it.",
-    "start": 4927.854893617021,
-    "end": 4945.650553191475
-  },
-  {
-    "text": "I mean, that was just a kind of high level theme that I had in the feedback.",
-    "start": 4950.409999999998,
-    "end": 4958.43199999999
-  },
-  {
-    "text": "And also, I going back to the initial affair, we also want to be really careful about what we think is inexpensive, because it's really relative.",
-    "start": 4959.925370370371,
-    "end": 4974.8736451612895
-  },
-  {
-    "text": "So for some folks using this service and they have a fixed income or very limited income, if we even do 4.50, which would be parity with Access-a-Ride-- and I think I could accept that.",
-    "start": 4975.239774193547,
-    "end": 4990.251064516124
-  },
-  {
-    "text": "But say we go up to 6.50 or we do this tiered system, then for some folks they are not going to be able to ride or they're going to be choosing, do I get to the doctor or do I buy food for tonight.",
-    "start": 4990.617193548382,
-    "end": 5004.422875000006
-  },
-  {
-    "text": "So I just wanted to put that out there.",
-    "start": 5004.865,
-    "end": 5008.13877777778
-  },
-  {
-    "text": "And finally-- well, actually, I'll stop there.",
-    "start": 5008.969,
-    "end": 5017.359571428572
-  },
-  {
-    "text": "I concurred with what a lot of other Directors said in terms of keeping the program as-is as much as we can, But I also just want to commend staff, because we are at a much different place than where we were several months ago.",
-    "start": 5018.778,
-    "end": 5038.645999999992
-  },
-  {
-    "text": "This was a totally different conversation.",
-    "start": 5039.724,
-    "end": 5041.210666666665
-  },
-  {
-    "text": "We're talking about really slashing this program, and staff did a lot of work and we spent several months.",
-    "start": 5042.23,
-    "end": 5047.454619047623
-  },
-  {
-    "text": "We almost voted on this a few months ago, and they listened to us as Directors and they listened to community because, as you know, we've had hundreds of public comments over several months on this.",
-    "start": 5047.714857142862,
-    "end": 5058.635592592587
-  },
-  {
-    "text": "And they said, OK, we can take a timeout, we can reassess, we can get some different data.",
-    "start": 5059.605,
-    "end": 5064.381392857148
-  },
-  {
-    "text": "We can present a new paradigm.",
-    "start": 5064.662357142863,
-    "end": 5067.191035714294
-  },
-  {
-    "text": "So again, what's before us today is a sketch of ideas.",
-    "start": 5067.492,
-    "end": 5070.013999999999
-  },
-  {
-    "text": "The feedback is good, but I really do want to commend staff for listening and working with us in partnership.",
-    "start": 5070.266199999999,
-    "end": 5076.257624999999
-  },
-  {
-    "text": "So thank you and thank you.",
-    "start": 5076.592,
     "end": 5078.4619999999995
   },
   {
-    "text": "Julien Bouquet: Thank you, Director Ruscha.",
+    "text": "Julien Bouquet: Thank you, Director Ruscha. Director Nicholson.",
     "start": 5080.098,
-    "end": 5080.744500000001
-  },
-  {
-    "text": "Director Nicholson.",
-    "start": 5081.16,
     "end": 5081.521
   },
   {
-    "text": "Chris Nicholson: Thank you.",
+    "text": "Chris Nicholson: Thank you. Is there any step during enrollment of AAR and AOD where we ask people if they are enrolled in the LiVE program and ask them, hey, we're taking 14 other pieces of documentation from you? I mean, AOD or AAR is remarkably complicated to sign up for. Is there any part of that process where we try to enroll them in the LiVE program as well? And then I have a quick follow up.",
     "start": 5081.521,
-    "end": 5083.925499999999
-  },
-  {
-    "text": "Is there any step during enrollment of AAR and AOD where we ask people if they are enrolled in the LiVE program and ask them, hey, we're taking 14 other pieces of documentation from you?",
-    "start": 5085.953,
-    "end": 5100.431171428573
-  },
-  {
-    "text": "I mean, AOD or AAR is remarkably complicated to sign up for.",
-    "start": 5100.877,
-    "end": 5104.429299999999
-  },
-  {
-    "text": "Is there any part of that process where we try to enroll them in the LiVE program as well?",
-    "start": 5104.884,
-    "end": 5111.393368421059
-  },
-  {
-    "text": "And then I have a quick follow up.",
-    "start": 5111.795,
     "end": 5112.811749999997
   },
   {
@@ -4145,7713 +650,2193 @@
     "end": 5125.341700000008
   },
   {
-    "text": "Chris Nicholson: Yeah.",
+    "text": "Chris Nicholson: Yeah. So yeah, as a first thing, I would say that since we're going to be updating this to offer the LiVE discount and not make it free, it should be required as part of the process if you're going through to sign up for AOD or AAR, some point in that process, to ask someone to affirm that they are either already signed up or haven't signed up or whatever. And then give them the opportunity. Make it super easy because we only have 15,000 people signed up for LiVE right now, and we have 180 something thousand boardings every day. And I think only about half the people in AOD are currently signed up for-- or AAR are currently signed up for LiVE. So definitely something I'd like to see there. The second thing. I want to echo what Director Ruscha said about the effect on people who are low income to having these fares. But I want to take it from the other side, which is if you don't have a lot of money and you need to get around to a lot of places, then 40 trips may be, or whatever the number ends up being, not nearly enough in a way that someone who makes more money can probably have some discretionary to be like, oh, I've run out of trips. I can afford to take an extra three or five or whatever. So I'm not sure that needs to be fit into the policy here. I'm wary about trying to do too much too quickly. But I do think we need to get a report from you after, I don't know, six months, a year, that looks at how many trips are people on LiVE using. Are they maxing out? Or are we seeing the same curve from LiVE users as we do from regular users right now? And that might inform us to take action a year from now to try to offer the right service for people who need it. Some LiVE people make decent incomes, some of them are literally broke. And we need to recognize that those two groups of people have very different lived experiences.",
     "start": 5126.708,
-    "end": 5126.708
-  },
-  {
-    "text": "So yeah, as a first thing, I would say that since we're going to be updating this to offer the LiVE discount and not make it free, it should be required as part of the process if you're going through to sign up for AOD or AAR, some point in that process, to ask someone to affirm that they are either already signed up or haven't signed up or whatever.",
-    "start": 5126.988,
-    "end": 5147.16525
-  },
-  {
-    "text": "And then give them the opportunity.",
-    "start": 5147.4368125,
-    "end": 5148.794625
-  },
-  {
-    "text": "Make it super easy because we only have 15,000 people signed up for LiVE right now, and we have 180 something thousand boardings every day.",
-    "start": 5149.337750000001,
-    "end": 5156.723600000007
-  },
-  {
-    "text": "And I think only about half the people in AOD are currently signed up for-- or AAR are currently signed up for LiVE.",
-    "start": 5157.193,
-    "end": 5163.405181818189
-  },
-  {
-    "text": "So definitely something I'd like to see there.",
-    "start": 5163.761,
-    "end": 5165.846125000002
-  },
-  {
-    "text": "The second thing.",
-    "start": 5166.164,
-    "end": 5167.261764705882
-  },
-  {
-    "text": "I want to echo what Director Ruscha said about the effect on people who are low income to having these fares.",
-    "start": 5167.810647058824,
-    "end": 5177.632803278687
-  },
-  {
-    "text": "But I want to take it from the other side, which is if you don't have a lot of money and you need to get around to a lot of places, then 40 trips may be, or whatever the number ends up being, not nearly enough in a way that someone who makes more money can probably have some discretionary to be like, oh, I've run out of trips.",
-    "start": 5177.896770491801,
-    "end": 5195.237071428576
-  },
-  {
-    "text": "I can afford to take an extra three or five or whatever.",
-    "start": 5195.576,
-    "end": 5198.532250000002
-  },
-  {
-    "text": "So I'm not sure that needs to be fit into the policy here.",
-    "start": 5198.841,
-    "end": 5202.67321428571
-  },
-  {
-    "text": "I'm wary about trying to do too much too quickly.",
-    "start": 5203.028,
-    "end": 5205.299600000003
-  },
-  {
-    "text": "But I do think we need to get a report from you after, I don't know, six months, a year, that looks at how many trips are people on LiVE using.",
-    "start": 5205.892,
-    "end": 5216.068774193542
-  },
-  {
-    "text": "Are they maxing out?",
-    "start": 5216.629,
-    "end": 5217.665500000001
-  },
-  {
-    "text": "Or are we seeing the same curve from LiVE users as we do from regular users right now?",
-    "start": 5218.031,
-    "end": 5223.816571428569
-  },
-  {
-    "text": "And that might inform us to take action a year from now to try to offer the right service for people who need it.",
-    "start": 5224.178828571426,
-    "end": 5232.510742857133
-  },
-  {
-    "text": "Some LiVE people make decent incomes, some of them are literally broke.",
-    "start": 5232.913,
-    "end": 5236.796772727271
-  },
-  {
-    "text": "And we need to recognize that those two groups of people have very different lived experiences.",
-    "start": 5237.132727272725,
     "end": 5242.172045454537
   },
   {
-    "text": "Julien Bouquet: Thank you, Secretary.",
+    "text": "Julien Bouquet: Thank you, Secretary. Ms. Johnson.",
     "start": 5243.209,
-    "end": 5243.796333333333
-  },
-  {
-    "text": "Ms.",
-    "start": 5244.17,
-    "end": 5244.17
-  },
-  {
-    "text": "Johnson.",
-    "start": 5244.371,
     "end": 5244.371
   },
   {
-    "text": "Debra Johnson: Yes, thank you very much, Director Nicholson.",
+    "text": "Debra Johnson: Yes, thank you very much, Director Nicholson. Thank you, Mr. Chair. Thank you, Director Nicholson, for the comments. And what I will say in reference to your request. It appeared to be a directive, but I would just offer this up to you. That once we collectively agree upon the path forward and this Board acts, we can then assess what might be most prudent, because at this point in time, we don't know what we don't know. And relative to what you just asked, I can't commit to that without knowing what we intend to do. So I just had to say that for the record, because it seems as if Ms. Vallejos was getting direction, and I don't think that's appropriate at this juncture. Thank you.",
     "start": 5244.371,
-    "end": 5246.99742857143
-  },
-  {
-    "text": "Thank you, Mr.",
-    "start": 5247.717,
-    "end": 5248.2480000000005
-  },
-  {
-    "text": "Chair.",
-    "start": 5248.513500000001,
-    "end": 5248.513500000001
-  },
-  {
-    "text": "Thank you, Director Nicholson, for the comments.",
-    "start": 5248.799,
-    "end": 5250.635857142856
-  },
-  {
-    "text": "And what I will say in reference to your request.",
-    "start": 5251.403,
-    "end": 5253.712625
-  },
-  {
-    "text": "It appeared to be a directive, but I would just offer this up to you.",
-    "start": 5253.96925,
-    "end": 5258.26293548387
-  },
-  {
-    "text": "That once we collectively agree upon the path forward and this Board acts, we can then assess what might be most prudent, because at this point in time, we don't know what we don't know.",
-    "start": 5258.564677419354,
-    "end": 5267.81223076923
-  },
-  {
-    "text": "And relative to what you just asked, I can't commit to that without knowing what we intend to do.",
-    "start": 5268.068,
-    "end": 5273.532421052639
-  },
-  {
-    "text": "So I just had to say that for the record, because it seems as if Ms.",
-    "start": 5273.996,
-    "end": 5277.153157894736
-  },
-  {
-    "text": "Vallejos was getting direction, and I don't think that's appropriate at this juncture.",
-    "start": 5277.400789473683,
-    "end": 5280.37236842105
-  },
-  {
-    "text": "Thank you.",
-    "start": 5280.64,
     "end": 5280.9905
   },
   {
-    "text": "Julien Bouquet: Thank you.",
+    "text": "Julien Bouquet: Thank you. Director Larsen.",
     "start": 5282.862,
-    "end": 5283.0125
-  },
-  {
-    "text": "Director Larsen.",
-    "start": 5283.263,
     "end": 5283.563
   },
   {
-    "text": "Matt Larsen: Thank you.",
+    "text": "Matt Larsen: Thank you. I was just kind of doing some stuff on my calculator. So if we only have 3,000 people who use Access-on-Demand , I mean, it seems like the disabled population might be 300,000 people in Denver or something. Much, much larger. How confident are we of our projection that it will stay at around, I mean, or however much we think it will increase? I mean, what do we think the total number of active users might become? And why won't it become many multiples more than 3,000 or so?",
     "start": 5285.605,
-    "end": 5285.8155
-  },
-  {
-    "text": "I was just kind of doing some stuff on my calculator.",
-    "start": 5286.9216,
-    "end": 5292.175199999996
-  },
-  {
-    "text": "So if we only have 3,000 people who use Access-on-Demand , I mean, it seems like the disabled population might be 300,000 people in Denver or",
-    "start": 5293.185318181818,
-    "end": 5307.103249999999
-  },
-  {
-    "text": "something. Much, much",
-    "start": 5308.575749999999,
-    "end": 5308.943874999999
-  },
-  {
-    "text": "larger. How confident are we of our projection that it will stay at around, I mean, or however much we think it will",
-    "start": 5311.788999999999,
-    "end": 5317.112499999995
-  },
-  {
-    "text": "increase? I mean, what do we think the total number of active users might",
-    "start": 5317.386,
-    "end": 5322.550137931029
-  },
-  {
-    "text": "become? And why won't it become many multiples more than 3,000 or",
-    "start": 5322.947379310339,
     "end": 5328.508758620677
   },
   {
-    "text": "so? Debra Johnson: First, if I",
+    "text": "Debra Johnson: First, if I may. Just for everyone's edification, probably you have heard this over the course of several months in the public comment discussions. When we talk about Access-on-Demand, currently as it's configured, recognizing that we're using private entities, transportation network companies in particular, not all of the vehicles are outfitted to be wheelchair accessible. So that's a critical element when we're talking about the population, because there's different disabilities that individuals have. Some may have cognitive. Somebody may be using a mobility device which can't be accommodated going forward. So I just wanted to provide that context prior to Ms. Vallejos answering the question, because that has not been factored in to this conversation this evening, and I believe it's a germane point.",
     "start": 5334.522,
-    "end": 5335.623374999999
-  },
-  {
-    "text": "may. Just for everyone's edification, probably you have heard this over the course of several months in the public comment",
-    "start": 5335.990499999999,
-    "end": 5342.965874999994
-  },
-  {
-    "text": "discussions. When we talk about Access-on-Demand, currently as it's configured, recognizing that we're using private entities, transportation network companies in particular, not all of the vehicles are outfitted to be wheelchair",
-    "start": 5344.034,
-    "end": 5358.753030303036
-  },
-  {
-    "text": "accessible. So that's a critical element when we're talking about the population, because there's different disabilities that individuals",
-    "start": 5359.497,
-    "end": 5366.834388888889
-  },
-  {
-    "text": "have. Some may have",
-    "start": 5367.366,
-    "end": 5368.581705882354
-  },
-  {
-    "text": "cognitive. Somebody may be using a mobility device which can't be accommodated going",
-    "start": 5368.986941176472,
-    "end": 5373.849764705888
-  },
-  {
-    "text": "forward. So I just wanted to provide that context prior to",
-    "start": 5374.275,
-    "end": 5376.932272727274
-  },
-  {
-    "text": "Ms. Vallejos answering the question, because that has not been factored in to this conversation this evening, and I believe it's a germane",
-    "start": 5377.218,
     "end": 5383.271428571427
   },
   {
-    "text": "point. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director.",
     "start": 5385.508,
     "end": 5385.9220000000005
   },
   {
-    "text": "Director. Erin Vallejos: And I don't think I need to add",
+    "text": "Erin Vallejos: And I don't think I need to add anything. That was really exactly what I was going to say. Not everyone is able to use the Access-on-Demand service that is eligible for Access-a-Ride. There is a difference there.",
     "start": 5386.632,
-    "end": 5388.487578947368
-  },
-  {
-    "text": "anything. That was really exactly what I was going to",
-    "start": 5388.719526315789,
-    "end": 5390.807052631579
-  },
-  {
-    "text": "say. Not everyone is able to use the Access-on-Demand service that is eligible for",
-    "start": 5391.059,
-    "end": 5396.354937500005
-  },
-  {
-    "text": "Access-a-Ride. There is a difference",
-    "start": 5397.109,
     "end": 5398.1826
   },
   {
-    "text": "there. Matt Larsen: Can I just follow",
+    "text": "Matt Larsen: Can I just follow up? But I mean, surely many more people than 3,000 in the metro area would be eligible, though. I mean.",
     "start": 5399.152,
-    "end": 5399.8896
-  },
-  {
-    "text": "up? But I mean, surely many more people than 3,000 in the metro area would be eligible,",
-    "start": 5400.094,
-    "end": 5406.6361176470555
-  },
-  {
-    "text": "though. I",
-    "start": 5408.547,
     "end": 5408.547
   },
   {
-    "text": "mean. Erin Vallejos: Well, and again, we have continued to see substantial growth in the number of customers that are beginning to use the",
+    "text": "Erin Vallejos: Well, and again, we have continued to see substantial growth in the number of customers that are beginning to use the service. Again, the trips that we are seeing continue to grow even into this year. So we are seeing quite significant growth still.",
     "start": 5408.547,
-    "end": 5417.755333333329
-  },
-  {
-    "text": "service. Again, the trips that we are seeing continue to grow even into this",
-    "start": 5418.585,
-    "end": 5422.562999999995
-  },
-  {
-    "text": "year. So we are seeing quite significant growth",
-    "start": 5422.929,
     "end": 5427.869250000001
   },
   {
-    "text": "still. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you.",
     "start": 5428.595,
     "end": 5428.755
   },
   {
-    "text": "you. Matt Larsen: Thank",
+    "text": "Matt Larsen: Thank you.",
     "start": 5429.095,
     "end": 5429.2755
   },
   {
-    "text": "you. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you. Any further questions, comments? Ms. Johnson and Ms. Vallejos, thank you very much for the presentation. I hope this was helpful feedback for going forward. So thank you.",
     "start": 5429.476,
-    "end": 5429.996499999999
-  },
-  {
-    "text": "you. Any further questions,",
-    "start": 5431.758,
-    "end": 5432.853749999999
-  },
-  {
-    "text": "comments?",
-    "start": 5434.861,
-    "end": 5434.861
-  },
-  {
-    "text": "Ms. Johnson and",
-    "start": 5435.702,
-    "end": 5436.209333333333
-  },
-  {
-    "text": "Ms. Vallejos, thank you very much for the",
-    "start": 5436.483,
-    "end": 5438.2347500000005
-  },
-  {
-    "text": "presentation. I hope this was helpful feedback for going",
-    "start": 5438.525,
-    "end": 5440.571222222219
-  },
-  {
-    "text": "forward. So thank",
-    "start": 5441.247,
     "end": 5441.727666666667
   },
   {
-    "text": "you. Debra Johnson:",
+    "text": "Debra Johnson: Yes. Thank you, Mr. Chair. This was in the sense that we do have some guidance. Now we know what we need to do as we do further outreach. So thank you all very much for the opportunity. And when we come back in July with a recommended action, hopefully we can all rally around that, recognizing the public comments that we heard and the direction in which you provided. Thank you.",
     "start": 5442.573,
-    "end": 5442.573
-  },
-  {
-    "text": "Yes. Thank you,",
-    "start": 5442.7774,
-    "end": 5443.186199999999
-  },
-  {
-    "text": "Mr.",
-    "start": 5443.390599999999,
-    "end": 5443.390599999999
-  },
-  {
-    "text": "Chair. This was in the sense that we do have some",
-    "start": 5443.695,
-    "end": 5446.081666666671
-  },
-  {
-    "text": "guidance. Now we know what we need to do as we do further",
-    "start": 5446.320333333338,
-    "end": 5449.35691666667
-  },
-  {
-    "text": "outreach. So thank you all very much for the",
-    "start": 5449.624,
-    "end": 5451.725333333332
-  },
-  {
-    "text": "opportunity. And when we come back in July with a recommended action, hopefully we can all rally around that, recognizing the public comments that we heard and the direction in which you",
-    "start": 5452.028,
-    "end": 5461.568484848496
-  },
-  {
-    "text": "provided. Thank",
-    "start": 5462.204,
     "end": 5462.3945
   },
   {
-    "text": "you. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you. Director Guzman.",
     "start": 5462.845,
-    "end": 5463.0055
-  },
-  {
-    "text": "you. Director",
-    "start": 5463.666,
     "end": 5463.9465
   },
   {
-    "text": "Guzman. Michael Guzman: Will that recommended action be going through Operation Safety and",
+    "text": "Michael Guzman: Will that recommended action be going through Operation Safety and Security.",
     "start": 5463.9465,
     "end": 5467.723454545455
   },
   {
-    "text": "Security. Julien Bouquet:",
+    "text": "Julien Bouquet: Ms. Johnson.",
     "start": 5469.756,
-    "end": 5469.756
-  },
-  {
-    "text": "Ms.",
-    "start": 5469.936,
     "end": 5469.936
   },
   {
-    "text": "Johnson. Debra Johnson:",
+    "text": "Debra Johnson: Yes. Thank you very much, Mr. Chair. And thank you, Director \"Guz-min--\" Guzman, I apologize, for the question. Most definitely, we will go through the committee procedure. The only reason why this didn't happen because it's time sensitive. So thank you.",
     "start": 5469.936,
-    "end": 5470.619
-  },
-  {
-    "text": "Yes. Thank you very much,",
-    "start": 5470.998166666666,
-    "end": 5472.514833333333
-  },
-  {
-    "text": "Mr.",
-    "start": 5472.893999999999,
-    "end": 5472.893999999999
-  },
-  {
-    "text": "Chair. And thank you, Director \"Guz-min--\" Guzman, I apologize, for the",
-    "start": 5473.273166666666,
-    "end": 5477.150000000001
-  },
-  {
-    "text": "question. Most definitely, we will go through the committee",
-    "start": 5477.855,
-    "end": 5480.153666666669
-  },
-  {
-    "text": "procedure. The only reason why this didn't happen because it's time",
-    "start": 5480.461,
-    "end": 5482.848272727274
-  },
-  {
-    "text": "sensitive. So thank",
-    "start": 5483.548,
     "end": 5483.908666666667
   },
   {
-    "text": "you. Julien Bouquet: Thank you very",
+    "text": "Julien Bouquet: Thank you very much. All right. Well, thank you again, Ms. Vallejos. All right, moving on. Thank you, Directors, for the questions and conversations. We're going to be moving to our committee reports. Not to be the time police or anything. We are at 8:31 PM and we've been going at this since 3:30. If committee reports could be less than a minute, that'd be greatly appreciated. Audit Committee Chair Buzek. What would you like to share?",
     "start": 5484.931,
-    "end": 5485.42675
-  },
-  {
-    "text": "much. All",
-    "start": 5486.775,
-    "end": 5486.9455
-  },
-  {
-    "text": "right. Well, thank you again,",
-    "start": 5487.196,
-    "end": 5488.045600000001
-  },
-  {
-    "text": "Ms.",
-    "start": 5488.299,
-    "end": 5488.299
-  },
-  {
-    "text": "Vallejos. All right, moving",
-    "start": 5489.637,
-    "end": 5490.502999999999
-  },
-  {
-    "text": "on. Thank you, Directors, for the questions and",
-    "start": 5490.791666666665,
-    "end": 5492.81233333333
-  },
-  {
-    "text": "conversations. We're going to be moving to our committee",
-    "start": 5493.602,
-    "end": 5496.2038125
-  },
-  {
-    "text": "reports. Not to be the time police or",
-    "start": 5496.5755,
-    "end": 5499.1773125
-  },
-  {
-    "text": "anything. We are at 8:31 PM and we've been going at this since",
-    "start": 5499.589,
-    "end": 5502.786538461543
-  },
-  {
-    "text": "3:30. If committee reports could be less than a minute, that'd be greatly",
-    "start": 5503.613,
-    "end": 5507.051461538466
-  },
-  {
-    "text": "appreciated. Audit Committee Chair",
-    "start": 5507.938,
-    "end": 5508.8932
-  },
-  {
-    "text": "Buzek. What would you like to",
-    "start": 5509.2116000000005,
     "end": 5510.803600000001
   },
   {
-    "text": "share? Vince Buzek: Thank you,",
+    "text": "Vince Buzek: Thank you, Mr. Chair. We did not meet in April or May. Our next meeting is June 12, 2025. That concludes my report. Thank you.",
     "start": 5512.064,
-    "end": 5512.465
-  },
-  {
-    "text": "Mr.",
-    "start": 5512.6655,
-    "end": 5512.6655
-  },
-  {
-    "text": "Chair. We did not meet in April or",
-    "start": 5512.906,
-    "end": 5514.326125
-  },
-  {
-    "text": "May. Our next meeting is June 12,",
-    "start": 5514.549,
-    "end": 5516.559
-  },
-  {
-    "text": "2025. That concludes my",
-    "start": 5516.994,
-    "end": 5517.790499999999
-  },
-  {
-    "text": "report. Thank",
-    "start": 5518.437,
     "end": 5518.7875
   },
   {
-    "text": "you. Julien Bouquet: Thank you very",
+    "text": "Julien Bouquet: Thank you very much. Finance and Planning Committee report. Committee Chair Guzman.",
     "start": 5519.158,
-    "end": 5519.684499999999
-  },
-  {
-    "text": "much. Finance and Planning Committee",
-    "start": 5521.804,
-    "end": 5523.086500000001
-  },
-  {
-    "text": "report. Committee Chair",
-    "start": 5523.4071250000015,
     "end": 5524.048375000002
   },
   {
-    "text": "Guzman. Michael Guzman: Thank you,",
+    "text": "Michael Guzman: Thank you, Mr. Chair. The Finance Planning Committee met Tuesday, May 13, discussed a handful of items, received a report from our state demographer, which was really awesome. Directors are reminded to email the Board Office if you had any follow up questions or things specific to your sub district, so we can send that all at once to receive an answer to the whole Board. Received an update from Doti for the East Colfax BRT, and three items came out of committee which will be before us tonight. Just want to thank the committee for all of the hard work. And the next meeting for the Finance and Planning Committee is scheduled for Tuesday, June 10 at 10:25-- or sorry, at 5:30 PM. Thank you.",
     "start": 5524.048375000002,
-    "end": 5524.9525
-  },
-  {
-    "text": "Mr.",
-    "start": 5525.127750000001,
-    "end": 5525.127750000001
-  },
-  {
-    "text": "Chair. The Finance Planning Committee met Tuesday, May 13, discussed a handful of items, received a report from our state demographer, which was really",
-    "start": 5526.504,
-    "end": 5533.738458333332
-  },
-  {
-    "text": "awesome. Directors are reminded to email the Board Office if you had any follow up questions or things specific to your sub district, so we can send that all at once to receive an answer to the whole",
-    "start": 5534.794,
-    "end": 5542.755527777766
-  },
-  {
-    "text": "Board. Received an update from Doti for the East Colfax BRT, and three items came out of committee which will be before us",
-    "start": 5543.684,
-    "end": 5552.551913043469
-  },
-  {
-    "text": "tonight. Just want to thank the committee for all of the hard",
-    "start": 5553.526,
-    "end": 5555.308000000003
-  },
-  {
-    "text": "work. And the next meeting for the Finance and Planning Committee is scheduled for Tuesday, June 10 at 10:25-- or sorry, at 5:30",
-    "start": 5556.292,
-    "end": 5565.05
-  },
-  {
-    "text": "PM. Thank",
-    "start": 5565.05,
     "end": 5565.21
   },
   {
-    "text": "you. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director . Committee Chair Ruscha or Committee Chair Harwick, what would you like to share for OSS?",
     "start": 5566.613,
-    "end": 5566.987
-  },
-  {
-    "text": "Director . Committee Chair Ruscha or Committee Chair Harwick, what would you like to share",
-    "start": 5568.357,
     "end": 5572.677400000004
   },
   {
-    "text": "for OSS? Joyann Ruscha: I'll take",
+    "text": "Joyann Ruscha: I'll take it, sir. Thank you. So we met remotely on Wednesday, May 14. We gaveled in at 5:34 PM and wrapped up at 9:44 PM. We had extensive public comments, the most I've ever seen at any OSS meeting. That was great. Come visit us anytime. It's always nice to know that people are listening to our podcast, and by that I mean our YouTube channel. But two major items that went on the consent calendar for tonight's meeting. Is the 2025, 2028 Title VI program update. Just ensuring that we stay in compliance with federal law, Civil Rights protections, and meet the needs of our customers, as well as the Allied Universal Security Services Contract Extension. F&P authorized a budget transfer which had no financial impact. It was just moving from one department to another. And then we followed that up with a vote to extend that contract for another year, with the cost of up to just a little over 22 million. And we did have four discussion items, two of which were heard. So we had the Vision Zero update from GM CEO Johnson. As you might recall, we passed a Vision Zero resolution last year and so that planning process is underway. We had a customer communications update. Stuart Summers led an excellent presentation discussing how we handle communications, some tech updates, customer service aspects. It was real-time information and service alerts and things like that. Unfortunately, we did hit our four hour mark before we could finish our agenda items. And even though the Nuggets weren't playing, folks wanted to go and we were tired. So we moved the on-Demand item to tonight's meeting, which we just heard. And then we'll be hearing paratransit legacy customer protections proposal next month. So for those of you who have been tracking what we're doing with paratransit, I strongly encourage you to come visit us at OSS next month and weigh in so we get your feedback before we come back with something more final. Our next meeting is Wednesday, June 11 at 5:30. Same time, same place, online or on the phone. Thank you.",
     "start": 5573.962,
-    "end": 5574.4127499999995
-  },
-  {
-    "text": "it, sir.",
-    "start": 5575.484,
-    "end": 5575.654500000001
-  },
-  {
-    "text": "Thank you. So we met remotely on Wednesday,",
-    "start": 5575.865,
-    "end": 5578.3009999999995
-  },
-  {
-    "text": "May 14. We gaveled in at 5:34 PM and wrapped up at",
-    "start": 5579.49,
-    "end": 5584.270666666668
-  },
-  {
-    "text": "9:44 PM. We had extensive public comments, the most I've ever seen at any",
-    "start": 5585.319,
-    "end": 5589.785555555553
-  },
-  {
-    "text": "OSS meeting. That",
-    "start": 5591.087,
-    "end": 5591.447666666666
-  },
-  {
-    "text": "was great. Come visit",
-    "start": 5591.708,
-    "end": 5592.639499999999
-  },
-  {
-    "text": "us anytime. It's always nice to know that people are listening to our podcast, and by that I mean our",
-    "start": 5594.012,
-    "end": 5598.083699999993
-  },
-  {
-    "text": "YouTube channel. But two major items that went on the consent calendar for",
-    "start": 5598.278,
-    "end": 5603.762480000003
-  },
-  {
-    "text": "tonight's meeting. Is the 2025, 2028 Title VI",
-    "start": 5604.219520000003,
-    "end": 5606.961760000005
-  },
-  {
-    "text": "program update. Just ensuring that we stay in compliance with federal law, Civil Rights protections, and meet the needs of our customers, as well as the Allied Universal Security Services",
-    "start": 5607.418800000005,
-    "end": 5620.672960000012
-  },
-  {
-    "text": "Contract Extension. F&P authorized a budget transfer which had no",
-    "start": 5621.11,
-    "end": 5625.596499999997
-  },
-  {
-    "text": "financial impact. It was just moving from one department",
-    "start": 5626.195,
-    "end": 5627.886555555553
-  },
-  {
-    "text": "to another. And then we followed that up with a vote to extend that contract for another year, with the cost of up to just a little over",
-    "start": 5628.598,
-    "end": 5636.552392857136
-  },
-  {
-    "text": "22 million. And we did have four discussion items, two of which",
-    "start": 5637.628,
-    "end": 5640.82075
-  },
-  {
-    "text": "were heard. So we had the Vision Zero update from GM",
-    "start": 5642.133,
-    "end": 5645.882090909086
-  },
-  {
-    "text": "CEO Johnson. As you might recall, we passed a Vision Zero resolution last year and so that planning process",
-    "start": 5646.693,
-    "end": 5651.455421052627
-  },
-  {
-    "text": "is underway. We had a customer",
-    "start": 5652.541,
-    "end": 5654.427666666668
-  },
-  {
-    "text": "communications update. Stuart Summers led an excellent presentation discussing how we handle communications, some tech updates, customer",
-    "start": 5655.506,
-    "end": 5665.38364705882
-  },
-  {
-    "text": "service aspects. It was real-time information and service alerts and things",
-    "start": 5665.981,
-    "end": 5668.989888888886
-  },
-  {
-    "text": "like that. Unfortunately, we did hit our four hour mark before we could finish our",
-    "start": 5670.088,
-    "end": 5673.3832758620665
-  },
-  {
-    "text": "agenda items. And even though the Nuggets weren't playing, folks wanted to go and we",
-    "start": 5673.636758620687,
-    "end": 5677.185517241374
-  },
-  {
-    "text": "were tired. So we moved the on-Demand item to tonight's meeting, which we",
-    "start": 5678.02,
-    "end": 5683.630041666669
-  },
-  {
-    "text": "just heard. And then we'll be hearing paratransit legacy customer protections proposal",
-    "start": 5684.061583333336,
-    "end": 5688.6775
-  },
-  {
-    "text": "next month. So for those of you who have been tracking what we're doing with paratransit, I strongly encourage you to come visit us at OSS next month and weigh in so we get your feedback before we come back with something",
-    "start": 5689.599,
-    "end": 5701.066317073184
-  },
-  {
-    "text": "more final. Our next meeting is Wednesday, June 11",
-    "start": 5702.214,
-    "end": 5706.0495555555535
-  },
-  {
-    "text": "at 5:30. Same time, same place, online or on",
-    "start": 5706.528999999998,
-    "end": 5710.364555555551
-  },
-  {
-    "text": "the phone.",
-    "start": 5711.625,
     "end": 5711.7755
   },
   {
-    "text": "Thank you. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Committee Chair. Now to for Performance Committee Chair Guzman.",
     "start": 5712.406,
-    "end": 5713.4575
-  },
-  {
-    "text": "Committee Chair. Now to for Performance Committee",
-    "start": 5714.5625,
     "end": 5716.575500000001
   },
   {
-    "text": "Chair Guzman. Michael Guzman: I",
+    "text": "Michael Guzman: I got it. Thank you, Mr. Chair. Performance committee met Monday, May 12, 2025. I, the Committee Chair, presented a draft proposal that I had worked on previously with Vice Chair Gutschenritter for the 2025 General Manager/CEO performance assessment form and process that needed to be updated to seek input from the committee and other Directors to find a way forward for the rest of the year based on the current 2025 General Manager/CEO short term goals and the respective adjustments made to the scoring points based on our votes in January. I've received some feedback. I continue to invite Directors to submit their feedback. If you have not reviewed that meeting, please do so, and any questions you may have, please email me or call me. I am happy to engage in that conversation. Of course, we are doing that with participation and a lot of communication with the General Manager/CEO, Debra Johnson. The next meeting of the Performance Committee is scheduled for June 2, 2025 at 8:30 AM. I really want to encourage all of you Directors to please participate in that meeting. Two reasons. One, we are going to receive-- I hope I don't get this wrong because I don't have my work plan in front of me, but the employee survey results in the beginning of that meeting, and then we will adjourn into executive session for the second quarterly one-on-one opportunity with our General Manager/CEO. And that is part of our contracted agreement with the General Manager/CEO to receive information from her and provide feedback regarding personnel matters. Additionally, the Performance Committee is set to have a second meeting in June because of that quarterly check-in. The second meeting is planned, I believe, for June 23 at 8:30 AM, and that is in order to do a deep dive into our community and customer surveys, which align with our community value and customer excellence strategic initiatives. And I would again encourage all Directors to participate in that meeting as well, which is the overview of the current status of the agency's surveys and where we're at with regard to public. It will inform the process for setting goals and priorities for the 2026 year which we are also doing all at the same time. So prioritizing what is important for our customers, the survey reports are a great opportunity to engage with direct feedback from our constituents in all areas of the agency. And I do believe a little birdie has told me on one of the buses that these should be really positive discussions. So if you need more than that invitation, please signal tonight and I will call you and email you and hound you to be on these meetings, because I think they're really important for all of us. Thank you.",
     "start": 5716.575500000001,
-    "end": 5717.711666666666
-  },
-  {
-    "text": "got it. Thank",
-    "start": 5718.573,
-    "end": 5719.013500000001
-  },
-  {
-    "text": "you,",
-    "start": 5719.233750000001,
-    "end": 5719.233750000001
-  },
-  {
-    "text": "Mr. Chair. Performance committee met Monday, May",
-    "start": 5719.895,
-    "end": 5721.457571428573
-  },
-  {
-    "text": "12, 2025. I, the Committee Chair, presented a draft proposal that I had worked on previously with Vice Chair Gutschenritter for the 2025 General Manager/CEO performance assessment form and process that needed to be updated to seek input from the committee and other Directors to find a way forward for the rest of the year based on the current 2025 General Manager/CEO short term goals and the respective adjustments made to the scoring points based on our votes",
-    "start": 5722.423304347826,
-    "end": 5749.616864864867
-  },
-  {
-    "text": "in January. I've received",
-    "start": 5750.508,
-    "end": 5751.51525
-  },
-  {
-    "text": "some feedback. I continue to invite Directors to submit",
-    "start": 5752.031,
-    "end": 5754.934111111111
-  },
-  {
-    "text": "their feedback. If you have not reviewed that meeting, please do so, and any questions you may have, please email me or",
-    "start": 5755.337,
-    "end": 5760.341583333329
-  },
-  {
-    "text": "call me. I am happy to engage in",
-    "start": 5760.868,
-    "end": 5762.8665
-  },
-  {
-    "text": "that conversation. Of course, we are doing that with participation and a lot of communication with the General Manager/CEO,",
-    "start": 5763.894,
-    "end": 5771.908200000002
-  },
-  {
-    "text": "Debra Johnson. The next meeting of the Performance Committee is scheduled for June 2, 2025 at",
-    "start": 5772.698,
-    "end": 5777.5636250000025
-  },
-  {
-    "text": "8:30 AM. I really want to encourage all of you Directors to please participate in",
-    "start": 5778.469,
-    "end": 5783.312999999994
-  },
-  {
-    "text": "that meeting.",
-    "start": 5784.401,
-    "end": 5784.6515
-  },
-  {
-    "text": "Two reasons. One, we are going to receive-- I hope I don't get this wrong because I don't have my work plan in front of me, but the employee survey results in the beginning of that meeting, and then we will adjourn into executive session for the second quarterly one-on-one opportunity with our",
-    "start": 5785.042,
-    "end": 5800.41994736842
-  },
-  {
-    "text": "General Manager/CEO. And that is part of our contracted agreement with the General Manager/CEO to receive information from her and provide feedback regarding",
-    "start": 5801.724,
-    "end": 5815.003624999997
-  },
-  {
-    "text": "personnel matters. Additionally, the Performance Committee is set to have a second meeting in June because of that",
-    "start": 5816.962,
-    "end": 5823.827166666673
-  },
-  {
-    "text": "quarterly check-in. The second meeting is planned, I believe, for June 23 at 8:30 AM, and that is in order to do a deep dive into our community and customer surveys, which align with our community value and customer excellence",
-    "start": 5825.192,
-    "end": 5839.23822222222
-  },
-  {
-    "text": "strategic initiatives. And I would again encourage all Directors to participate in that meeting as well, which is the overview of the current status of the agency's surveys and where we're at with regard",
-    "start": 5840.17,
-    "end": 5851.182700000003
-  },
-  {
-    "text": "to public. It will inform the process for setting goals and priorities for the 2026 year which we are also doing all at the",
-    "start": 5851.949,
-    "end": 5859.392374999999
-  },
-  {
-    "text": "same time. So prioritizing what is important for our customers, the survey reports are a great opportunity to engage with direct feedback from our constituents in all areas of",
-    "start": 5859.916,
-    "end": 5873.174482758622
-  },
-  {
-    "text": "the agency. And I do believe a little birdie has told me on one of the buses that these should be really",
-    "start": 5874.1,
-    "end": 5880.3038095238135
-  },
-  {
-    "text": "positive discussions. So if you need more than that invitation, please signal tonight and I will call you and email you and hound you to be on these meetings, because I think they're really important for all",
-    "start": 5881.295,
-    "end": 5890.617054054053
-  },
-  {
-    "text": "of us.",
-    "start": 5890.916,
     "end": 5891.0665
   },
   {
-    "text": "Thank you. Julien Bouquet: Thank you, Committee",
+    "text": "Julien Bouquet: Thank you, Committee Chair Guzman. All right, moving on. We're going to do the approval of Board meeting minutes and committee reports. The Board and committee meeting minutes were included in the Board packet. Are there any corrections from the Board for the minutes to be approved this evening? Any corrections? All right. Unless there's objection to considering the minutes all at the same time, may I please have a motion to approve the minutes for the following meetings? The April 9, 2025 Operation Safety and Security Committee. The April 29, 2025 Board meeting. The May 12, 2025 Performance Committee. The May 13, 2025 Finance and Planning Committee. May 14, 2025 Operation Safety and Security Committee. And then May 22, 2025 Executive Committee.",
     "start": 5892.239,
-    "end": 5893.7142
-  },
-  {
-    "text": "Chair Guzman. All right,",
-    "start": 5894.232,
-    "end": 5894.793333333333
-  },
-  {
-    "text": "moving on. We're going to do the approval of Board meeting minutes and",
-    "start": 5895.875,
-    "end": 5898.871307692309
-  },
-  {
-    "text": "committee reports. The Board and committee meeting minutes were included in the",
-    "start": 5899.522,
-    "end": 5902.956749999999
-  },
-  {
-    "text": "Board packet. Are there any corrections from the Board for the minutes to be approved",
-    "start": 5903.991,
-    "end": 5907.862466666671
-  },
-  {
-    "text": "this evening?",
-    "start": 5911.345,
-    "end": 5911.6055
-  },
-  {
-    "text": "Any corrections?",
-    "start": 5913.489,
-    "end": 5913.8012499999995
-  },
-  {
-    "text": "All right. Unless there's objection to considering the minutes all at the same time, may I please have a motion to approve the minutes for the",
-    "start": 5913.8012499999995,
-    "end": 5920.356076923073
-  },
-  {
-    "text": "following meetings? The April 9, 2025 Operation Safety and",
-    "start": 5921.225,
-    "end": 5924.144111111114
-  },
-  {
-    "text": "Security Committee. The April 29, 2025",
-    "start": 5925.029,
-    "end": 5926.9648333333325
-  },
-  {
-    "text": "Board meeting. The May 12, 2025",
-    "start": 5927.912,
-    "end": 5929.881166666668
-  },
-  {
-    "text": "Performance Committee. The May 13, 2025 Finance and",
-    "start": 5930.515,
-    "end": 5932.471857142859
-  },
-  {
-    "text": "Planning Committee. May 14, 2025 Operation Safety and",
-    "start": 5933.699,
-    "end": 5936.274124999999
-  },
-  {
-    "text": "Security Committee. And then May 22, 2025",
-    "start": 5936.942,
     "end": 5939.4302857142875
   },
   {
-    "text": "Executive Committee. Michael Guzman:",
+    "text": "Michael Guzman: So moved. Guzman.",
     "start": 5940.246,
-    "end": 5940.505999999999
-  },
-  {
-    "text": "So",
-    "start": 5940.786,
     "end": 5940.786
   },
   {
-    "text": "moved. Guzman. Julien Bouquet:",
+    "text": "Julien Bouquet: Mover, Guzman.",
     "start": 5941.587,
     "end": 5942.057500000001
   },
   {
-    "text": "Mover, Guzman. Joyann",
+    "text": "Joyann Ruscha: Second.",
     "start": 5943.61,
     "end": 5943.91
   },
   {
-    "text": "Ruscha: Second. Chris",
+    "text": "Chris Gutschenritter: Second.",
     "start": 5943.91,
     "end": 5943.91
   },
   {
-    "text": "Gutschenritter: Second. Julien Bouquet: I'm going to give it",
+    "text": "Julien Bouquet: I'm going to give it to Gutschenritter. So I heard Director Guzman as the mover and Director Gutschenritter as the second. Is there any discussion on this motion? OK. Seeing none, I'll now call the vote. Are there any no votes on this action? It'll pass 14, 0, and 1 absent. Excellent. All right. Moving on. It will be our Chair's report. Due to the late hour, I will be quoting my principal and saying, I am giving you all the gift of time. And all I can say with my Chair's report is we will have a Board retreat on June 7 talking about our 2026 priorities for the agency. Again, Directors, hopefully you all can make that. It'll be a very healthy discussion, a very hearty discussion, I guarantee, but please make sure you have that marked down in your calendars. Thank you.",
     "start": 5944.891,
-    "end": 5946.118999999999
-  },
-  {
-    "text": "to Gutschenritter. So I heard Director Guzman as the mover and Director Gutschenritter as",
-    "start": 5949.211,
-    "end": 5953.2094375
-  },
-  {
-    "text": "the second. Is there any discussion on",
-    "start": 5953.496,
-    "end": 5954.714000000003
-  },
-  {
-    "text": "this",
-    "start": 5959.703,
-    "end": 5959.703
-  },
-  {
-    "text": "motion? OK. Seeing none, I'll now call",
-    "start": 5960.244,
-    "end": 5961.650571428573
-  },
-  {
-    "text": "the vote. Are there any no votes on",
-    "start": 5962.006,
-    "end": 5963.336875000001
-  },
-  {
-    "text": "this action? It'll pass 14, 0, and",
-    "start": 5966.771,
-    "end": 5970.117285714287
-  },
-  {
-    "text": "1",
-    "start": 5972.417,
-    "end": 5972.417
-  },
-  {
-    "text": "absent. Excellent.",
-    "start": 5973.519,
-    "end": 5973.719
-  },
-  {
-    "text": "All right.",
-    "start": 5975.975,
-    "end": 5976.272875000001
-  },
-  {
-    "text": "Moving on. It will be our",
-    "start": 5976.570750000001,
-    "end": 5978.060125000002
-  },
-  {
-    "text": "Chair's report. Due to the late hour, I will be quoting my principal and saying, I am giving you all the gift",
-    "start": 5978.778,
-    "end": 5983.919181818181
-  },
-  {
-    "text": "of time. And all I can say with my Chair's report is we will have a Board retreat on June 7 talking about our 2026 priorities for",
-    "start": 5984.724,
-    "end": 5993.053629629627
-  },
-  {
-    "text": "the agency. Again, Directors, hopefully you all can",
-    "start": 5993.974,
-    "end": 5996.1641249999975
-  },
-  {
-    "text": "make that. It'll be a very healthy discussion, a very hearty discussion, I guarantee, but please make sure you have that marked down in",
-    "start": 5996.517,
-    "end": 6003.878083333337
-  },
-  {
-    "text": "your calendars.",
-    "start": 6004.586,
     "end": 6004.786
   },
   {
-    "text": "Thank you. Chris Nicholson: Did you want to remind everybody about the survey we",
+    "text": "Chris Nicholson: Did you want to remind everybody about the survey we sent you?",
     "start": 6008.662,
     "end": 6010.864749999999
   },
   {
-    "text": "sent you? Julien Bouquet:",
+    "text": "Julien Bouquet: Of course. Thank you. And of course, Directors, you'll see in my weekly biweekly update. There was a survey that might have been passed to you, and if you've not filled out that survey, please do so. Thank you for the Directors who did fill it in. So that's OK. If we could get that in by Monday morning, that would be excellent. I'll include that in my weekly update, though. Thank you. I'll give it now over to you, GM/CEO Johnson.",
     "start": 6011.085,
-    "end": 6011.3055
-  },
-  {
-    "text": "Of course.",
-    "start": 6011.666,
-    "end": 6011.8665
-  },
-  {
-    "text": "Thank you. And of course, Directors, you'll see in my weekly",
-    "start": 6012.467,
-    "end": 6015.5854999999965
-  },
-  {
-    "text": "biweekly update. There was a survey that might have been passed to you, and if you've not filled out that survey, please",
-    "start": 6015.931999999996,
-    "end": 6022.154363636365
-  },
-  {
-    "text": "do so. Thank you for the Directors who did fill",
-    "start": 6022.862,
-    "end": 6025.7824999999975
-  },
-  {
-    "text": "it in. So",
-    "start": 6026.307,
-    "end": 6027.121666666667
-  },
-  {
-    "text": "that's OK. If we could get that in by Monday morning, that would",
-    "start": 6028.23,
-    "end": 6033.83215384615
-  },
-  {
-    "text": "be excellent. I'll include that in my weekly",
-    "start": 6034.359,
-    "end": 6035.91825
-  },
-  {
-    "text": "update, though.",
-    "start": 6036.321,
-    "end": 6036.541499999999
-  },
-  {
-    "text": "Thank you. I'll give it now over to you,",
-    "start": 6037.973,
     "end": 6040.447666666669
   },
   {
-    "text": "GM/CEO Johnson. Debra Johnson: Thank you very",
+    "text": "Debra Johnson: Thank you very much, Mr. Chair. And to recognize the lateness of the hour, I just have a couple elements that I'll share with you that are in alignment with our activities and strategic endeavors since our last Board meeting on Tuesday, April 29. One notable aspect is the legislative conference held by the American Public Transportation Association from May 18th to the 20th in Washington, DC. Just for everyone's edification, this annual conference is an opportunity for Public Transportation industry professionals across the nation to visit Washington, DC and connect with policymakers, implementers, and their staffs. The conference helps educate and inform APTA members on important federal legislation and policy initiatives, and affords an unparalleled opportunity to shape the industry's positions in federal advocacy agenda. I, along with Directors O'Keefe, Chandler, and Gutschenritter, and Government Relations Officer Michael Davies, attended conference sessions and meetings with members of Colorado's congressional delegation and their staffs. While chairing an APTA committee meeting on Sunday, May 8, I personally engaged with Tariq Bokhari, who is the acting administrator of the Federal Transit Administration, who shared his views and inputs as it relates to public transit, as well as the importance of federal and local partnerships. Just yesterday, Tuesday, May 27, I, along with members of my team, met with individuals representing the alliance to transform transportation. As you may be aware, it's a coalition of groups on transit related matters in Colorado. Alliance representatives in attendance included executive Director of the Colorado Public Interest Research Group, Danny Katz, or CPIRG, as we refer to it. Jill Cantor, Executive Director of the Denver Streets Partnership. Portia Prescott, Present of the Rocky Mountain NAACP branch of the State Conference representing Colorado, Montana, and Wyoming. Dennis Hawkins, representing the Amalgamated Transit Union 1001. Matt Fromer, representing transportation and land use. Well, he is the Transportation and Land Use Policy Manager from the Southwest Energy Efficiency Project. The meeting really was focused on alliance's vision for transit in the Denver region. As you know, they have been very vocal in which they're seeking to increase funding for transit in the Denver region by $420 million per year to bolster the frequency and availability of transit services in the metro area. From RTD's perspective, questions were posed relative to how that $420 million figure was derived, and they explained how that came about with the work they had done with the third party entity. Very bare bones relative to providing some information. And then we talked about the agency's focus, which all of you are very well aware that we are laser focused on asset renewal, state of good repair, and rightsizing transit service in alignment with RTD's branded comprehensive operational analysis being the System Optimization Plan. Related to personal security. As was recently reported, RTD experienced a 60% reduction in security related calls for service, as well as a three year decrease in reports of criminal activities between 2022 and 2025 at Denver Union Station. The decrease is representative of concerted efforts to restore and maintain a welcoming transit environment within the critical multi-modal transit hub and following a collaborative and multifaceted strategy aimed at enhancing personal safety and security through crime prevention through environmental design methodologies. This effort would have not have been a success without the commitment of numerous agency employees, as well as support from the City and County of Denver, its police department, the Downtown Denver Partnership, Sage Hospitality, the Lower Denver Neighborhood Association, as well as several local businesses in downtown Denver residents. Fare enforcement has also increased in recent months, which is the result of RTD's growing ranks of sworn police officers having been trained to perform this function alongside the contracted team that we have in security with Allied Universal personnel who had primarily been responsible for this responsibility. I look forward to sharing additional details regarding the impacts of these efforts during the June Performance Committee, which you heard committee Chair Guzman reference when I, along with staff, will present data related to annual customer, community, and employee surveys that have recently concluded. On a related note, the agency has proactively increased its transit police officer presence at Denver Union Station and across the agency's downtown Denver sector to support the personal safety and security of customers and visitors attending major events and activity. Notably, while we're no longer in the hockey playoffs and NBA, but people had a welcoming experience in and around our facilities, and RTD PD had increased patrols at Denver Union Station and bus stops and rail stations before the high profile events, which included the playoff games I just referenced. And this coincides with increasing Denver Police patrols throughout the Downtown area. And RTD and DPD are working closely to collaborate to support enhanced safety for the traveling public. And moreover, data and metrics related to personal safety and Security are now conveniently located on the recently created security related metrics page, and we've actually showcased that on other social media channels as well. As it relates to our customer excellence in relation to the strategic priorities of customer excellence and employee ownership, I shared yesterday with the Board the last of the 31 light rail speed restrictions put into place last year on the D, H, and E and R lines was lifted as of yesterday morning. I want to give a special shout out to our Maintenance of Way teams that have done yeoman's work. The final speed restriction, which was approximately 400 feet in the southbound segment north of Southmoor Station, was removed after crews completed those repairs. Keeping in mind those rigorous restrictions were put into place due to the fact that we enhanced our inspections of track back in May 2024 as an enhanced focus on maintaining the agency's assets in a state of good repair. At the time, crews found several minor issues and track imperfections. So, as I said before, I thank and congratulate all the agency employees who work tire-- I'm tired-- tirelessly over the course of these 11 months. And like I said, a special shout out to MOW. I would be remiss if I didn't state that while this is a cause to celebrate, I shared previously, as we look at our infrastructure and it continues to age, this will be par for the course. But since we're ahead of where we were before, we will see less of an impact, I'm certain. And last, but certainly not least, I'm pleased to welcome RTD's new Chief Financial Officer, Kelly Mackey, who's in the audience. She's giving a wave. Who began her tenure on May 12. And this is her first in-person Board meeting. While we introduced her at the Finance and Planning Committee, you guys are real people, not figments of our imagination, so I wanted to ensure I did that here. So with that, I will yield the floor so we can move on to the rest of the matters that we have before us. So thank you very much, Mr. Chair.",
     "start": 6040.447666666669,
-    "end": 6043.584217391303
-  },
-  {
-    "text": "much,",
-    "start": 6043.885521739129,
-    "end": 6043.885521739129
-  },
-  {
-    "text": "Mr. Chair. And to recognize the lateness of the hour, I just have a couple elements that I'll share with you that are in alignment with our activities and strategic endeavors since our last Board meeting on Tuesday,",
-    "start": 6044.186826086955,
-    "end": 6055.937695652164
-  },
-  {
-    "text": "April 29. One notable aspect is the legislative conference held by the American Public Transportation Association from May 18th to the 20th in",
-    "start": 6058.142,
-    "end": 6068.066848484848
-  },
-  {
-    "text": "Washington, DC. Just for everyone's edification, this annual conference is an opportunity for Public Transportation industry professionals across the nation to visit Washington, DC and connect with policymakers, implementers, and",
-    "start": 6068.449272727273,
-    "end": 6079.539575757579
-  },
-  {
-    "text": "their staffs. The conference helps educate and inform APTA members on important federal legislation and policy initiatives, and affords an unparalleled opportunity to shape the industry's positions in federal",
-    "start": 6080.583,
-    "end": 6090.5249310344925
-  },
-  {
-    "text": "advocacy agenda. I, along with Directors O'Keefe, Chandler, and Gutschenritter, and Government Relations Officer Michael Davies, attended conference sessions and meetings with members of Colorado's congressional delegation and",
-    "start": 6091.349,
-    "end": 6100.879390243911
-  },
-  {
-    "text": "their staffs. While chairing an APTA committee meeting on Sunday, May 8, I personally engaged with Tariq Bokhari, who is the acting administrator of the Federal Transit Administration, who shared his views and inputs as it relates to public transit, as well as the importance of federal and",
-    "start": 6101.208024390253,
-    "end": 6117.554526315797
-  },
-  {
-    "text": "local partnerships. Just yesterday, Tuesday, May 27, I, along with members of my team, met with individuals representing the alliance to",
-    "start": 6118.332,
-    "end": 6125.271999999995
-  },
-  {
-    "text": "transform transportation. As you may be aware, it's a coalition of groups on transit related matters",
-    "start": 6126.38,
-    "end": 6131.428437499995
-  },
-  {
-    "text": "in Colorado. Alliance representatives in attendance included executive Director of the Colorado Public Interest Research Group, Danny Katz, or CPIRG, as we refer",
-    "start": 6132.406,
-    "end": 6140.807250000001
-  },
-  {
-    "text": "to it. Jill Cantor, Executive Director of the Denver",
-    "start": 6141.189125000001,
-    "end": 6144.244125000001
-  },
-  {
-    "text": "Streets Partnership. Portia Prescott, Present of the Rocky Mountain NAACP branch of the State Conference representing Colorado, Montana,",
-    "start": 6144.626000000001,
-    "end": 6151.747095238096
-  },
-  {
-    "text": "and Wyoming. Dennis Hawkins, representing the Amalgamated Transit",
-    "start": 6152.116904761906,
-    "end": 6154.705571428573
-  },
-  {
-    "text": "Union 1001. Matt Fromer, representing transportation and",
-    "start": 6156.233,
-    "end": 6158.521869565218
-  },
-  {
-    "text": "land use. Well, he is the Transportation and Land Use Policy Manager from the Southwest Energy",
-    "start": 6158.903347826088,
-    "end": 6164.625521739134
-  },
-  {
-    "text": "Efficiency Project. The meeting really was focused on alliance's vision for transit in the",
-    "start": 6165.027,
-    "end": 6169.119214285715
-  },
-  {
-    "text": "Denver region. As you know, they have been very vocal in which they're seeking to increase funding for transit in the Denver region by $420 million per year to bolster the frequency and availability of transit services in the",
-    "start": 6170.235,
-    "end": 6183.694
-  },
-  {
-    "text": "metro area. From RTD's perspective, questions were posed relative to how that $420 million figure was derived, and they explained how that came about with the work they had done with the third",
-    "start": 6186.159,
-    "end": 6200.555269230774
-  },
-  {
-    "text": "party entity. Very bare bones relative to providing",
-    "start": 6200.993461538466,
-    "end": 6204.0608076923145
-  },
-  {
-    "text": "some information. And then we talked about the agency's focus, which all of you are very well aware that we are laser focused on asset renewal, state of good repair, and rightsizing transit service in alignment with RTD's branded comprehensive operational analysis being the System",
-    "start": 6204.884,
-    "end": 6220.462933333338
-  },
-  {
-    "text": "Optimization Plan. Related to",
-    "start": 6221.675,
-    "end": 6222.80518918919
-  },
-  {
-    "text": "personal security. As was recently reported, RTD experienced a 60% reduction in security related calls for service, as well as a three year decrease in reports of criminal activities between 2022 and 2025 at Denver",
-    "start": 6223.18191891892,
-    "end": 6235.237270270279
-  },
-  {
-    "text": "Union Station. The decrease is representative of concerted efforts to restore and maintain a welcoming transit environment within the critical multi-modal transit hub and following a collaborative and multifaceted strategy aimed at enhancing personal safety and security through crime prevention through environmental",
-    "start": 6235.674,
-    "end": 6255.150181818186
-  },
-  {
-    "text": "design methodologies. This effort would have not have been a success without the commitment of numerous agency employees, as well as support from the City and County of Denver, its police department, the Downtown Denver Partnership, Sage Hospitality, the Lower Denver Neighborhood Association, as well as several local businesses in downtown",
-    "start": 6255.968,
-    "end": 6271.796249999991
-  },
-  {
-    "text": "Denver residents. Fare enforcement has also increased in recent months, which is the result of RTD's growing ranks of sworn police officers having been trained to perform this function alongside the contracted team that we have in security with Allied Universal personnel who had primarily been responsible for",
-    "start": 6272.705,
-    "end": 6293.401214285706
-  },
-  {
-    "text": "this responsibility. I look forward to sharing additional details regarding the impacts of these efforts during the June Performance Committee, which you heard committee Chair Guzman reference when I, along with staff, will present data related to annual customer, community, and employee surveys that have",
-    "start": 6294.465,
-    "end": 6308.905500000008
-  },
-  {
-    "text": "recently concluded. On a related note, the agency has proactively increased its transit police officer presence at Denver Union Station and across the agency's downtown Denver sector to support the personal safety and security of customers and visitors attending major events",
-    "start": 6309.29,
-    "end": 6324.142142857126
-  },
-  {
-    "text": "and activity. Notably, while we're no longer in the hockey playoffs and NBA, but people had a welcoming experience in and around our facilities, and RTD PD had increased patrols at Denver Union Station and bus stops and rail stations before the high profile events, which included the playoff games I",
-    "start": 6324.513446428554,
-    "end": 6346.034900000006
-  },
-  {
-    "text": "just referenced. And this coincides with increasing Denver Police patrols throughout the",
-    "start": 6346.771,
-    "end": 6351.010583333336
-  },
-  {
-    "text": "Downtown area. And RTD and DPD are working closely to collaborate to support enhanced safety for the",
-    "start": 6352.037,
-    "end": 6358.500999999993
-  },
-  {
-    "text": "traveling public. And moreover, data and metrics related to personal safety and Security are now conveniently located on the recently created security related metrics page, and we've actually showcased that on other social media channels",
-    "start": 6361.045,
-    "end": 6373.35785714287
-  },
-  {
-    "text": "as well. As it relates to our customer excellence in relation to the strategic priorities of customer excellence and employee ownership, I shared yesterday with the Board the last of the 31 light rail speed restrictions put into place last year on the D, H, and E and R lines was lifted as of",
-    "start": 6374.921,
-    "end": 6390.499444444447
-  },
-  {
-    "text": "yesterday morning. I want to give a special shout out to our Maintenance of Way teams that have done",
-    "start": 6391.843,
-    "end": 6395.748999999993
-  },
-  {
-    "text": "yeoman's work. The final speed restriction, which was approximately 400 feet in the southbound segment north of Southmoor Station, was removed after crews completed",
-    "start": 6396.407,
-    "end": 6405.693869565225
-  },
-  {
-    "text": "those repairs. Keeping in mind those rigorous restrictions were put into place due to the fact that we enhanced our inspections of track back in May 2024 as an enhanced focus on maintaining the agency's assets in a state of",
-    "start": 6408.798,
-    "end": 6423.462368421049
-  },
-  {
-    "text": "good repair. At the time, crews found several minor issues and",
-    "start": 6424.251,
-    "end": 6427.743000000002
-  },
-  {
-    "text": "track imperfections. So, as I said before, I thank and congratulate all the agency employees who work tire-- I'm tired-- tirelessly over the course of these",
-    "start": 6428.475,
-    "end": 6440.308130434776
-  },
-  {
-    "text": "11 months. And like I said, a special shout out",
-    "start": 6441.147,
-    "end": 6444.4797000000035
-  },
-  {
-    "text": "to MOW. I would be remiss if I didn't state that while this is a cause to celebrate, I shared previously, as we look at our infrastructure and it continues to age, this will be par for",
-    "start": 6446.534,
-    "end": 6456.027527272734
-  },
-  {
-    "text": "the course. But since we're ahead of where we were before, we will see less of an impact,",
-    "start": 6456.291236363643,
-    "end": 6460.774290909101
-  },
-  {
-    "text": "I'm certain. And last, but certainly not least, I'm pleased to welcome RTD's new Chief Financial Officer, Kelly Mackey, who's in",
-    "start": 6461.9,
-    "end": 6468.44476190477
-  },
-  {
-    "text": "the audience. She's giving",
-    "start": 6468.912,
-    "end": 6469.482749999999
-  },
-  {
-    "text": "a wave. Who began her tenure on",
-    "start": 6469.99,
-    "end": 6471.586857142856
-  },
-  {
-    "text": "May 12. And this is her first in-person",
-    "start": 6472.173,
-    "end": 6474.4441499999975
-  },
-  {
-    "text": "Board meeting. While we introduced her at the Finance and Planning Committee, you guys are real people, not figments of our imagination, so I wanted to ensure I did",
-    "start": 6474.696499999997,
-    "end": 6482.075666666666
-  },
-  {
-    "text": "that here. So with that, I will yield the floor so we can move on to the rest of the matters that we have",
-    "start": 6482.327,
-    "end": 6487.915
-  },
-  {
-    "text": "before us. So thank you very",
-    "start": 6487.915,
-    "end": 6488.987857142858
-  },
-  {
-    "text": "much,",
-    "start": 6489.20242857143,
     "end": 6489.20242857143
   },
   {
-    "text": "Mr. Chair. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, GM/CEO Johnson. Any comments or questions for GM/CEO Johnson?",
     "start": 6492.16,
-    "end": 6493.482249999999
-  },
-  {
-    "text": "GM/CEO Johnson. Any comments or questions for",
-    "start": 6494.824,
     "end": 6497.261714285712
   },
   {
-    "text": "GM/CEO Johnson? Chris Nicholson:",
+    "text": "Chris Nicholson: Just [INAUDIBLE].",
     "start": 6500.855,
     "end": 6500.855
   },
   {
-    "text": "Just [INAUDIBLE]. Julien",
+    "text": "Julien Bouquet: Yeah. Very exciting. And Kelly, welcome to the team. Thank you. All right. Moving on. We're going to move on to unanimous consent. There are three items on the unanimous consent agenda listed under Section 16, actions A through C. Those items are the security operations budget transfer, the 2025-2028 Title VI program update, and the Allied Universal security services contract extension for one year. I do understand that Director Benker would like to offer some amendments to item B, the 2025-2028 Title VI program update. And such, I will move that our a recommended actions. Excuse me. If anyone else has a change to discussion on or questions about any of the remaining unanimous consent items, please feel free to advise the Chair at this time and I will, of course, be happy to pull the item from unanimous consent for consideration under recommended action. Director Nicholson.",
     "start": 6500.855,
-    "end": 6500.855
-  },
-  {
-    "text": "Bouquet: Yeah.",
-    "start": 6506.261,
-    "end": 6506.5815
-  },
-  {
-    "text": "Very exciting. And Kelly, welcome to",
-    "start": 6507.242,
-    "end": 6508.543666666668
-  },
-  {
-    "text": "the team.",
-    "start": 6509.324,
-    "end": 6509.4945
-  },
-  {
-    "text": "Thank you.",
-    "start": 6512.488,
-    "end": 6512.688
-  },
-  {
-    "text": "All right.",
-    "start": 6513.409,
-    "end": 6513.7695
-  },
-  {
-    "text": "Moving on. We're going to move on to",
-    "start": 6514.758599999999,
-    "end": 6516.888699999998
-  },
-  {
-    "text": "unanimous consent. There are three items on the unanimous consent agenda listed under Section 16, actions A",
-    "start": 6518.010576923077,
-    "end": 6524.355807692312
-  },
-  {
-    "text": "through C. Those items are the security operations budget transfer, the 2025-2028 Title VI program update, and the Allied Universal security services contract extension for",
-    "start": 6524.752384615389,
-    "end": 6535.100058823533
-  },
-  {
-    "text": "one year. I do understand that Director Benker would like to offer some amendments to item B, the 2025-2028 Title VI",
-    "start": 6535.556,
-    "end": 6544.102060606058
-  },
-  {
-    "text": "program update. And such, I will move that our a",
-    "start": 6544.529363636361,
-    "end": 6548.375090909088
-  },
-  {
-    "text": "recommended actions.",
-    "start": 6548.802393939391,
-    "end": 6549.229696969694
-  },
-  {
-    "text": "Excuse me. If anyone else has a change to discussion on or questions about any of the remaining unanimous consent items, please feel free to advise the Chair at this time and I will, of course, be happy to pull the item from unanimous consent for consideration under",
-    "start": 6549.677,
-    "end": 6564.184099999989
-  },
-  {
-    "text": "recommended action.",
-    "start": 6565.597,
     "end": 6565.9675
   },
   {
-    "text": "Director Nicholson. Chris Nicholson: The Allied Universal",
+    "text": "Chris Nicholson: The Allied Universal security contract. Please pull that.",
     "start": 6565.9675,
-    "end": 6569.963000000002
-  },
-  {
-    "text": "security contract. Please",
-    "start": 6570.313500000002,
     "end": 6571.014500000003
   },
   {
-    "text": "pull that. Julien",
+    "text": "Julien Bouquet: OK. So item B will be removed and placed into recommended action Excuse me. Former item C, as I look in real time here, the Allied Universal security. So are we OK with security operations budget transfer?",
     "start": 6571.705,
-    "end": 6572.526
-  },
-  {
-    "text": "Bouquet: OK. So item B will be removed and placed into recommended action",
-    "start": 6572.526,
-    "end": 6579.6954
-  },
-  {
-    "text": "Excuse me. Former item C, as I look in real time here, the Allied",
-    "start": 6580.0758,
-    "end": 6585.626454545454
-  },
-  {
-    "text": "Universal security. So are we OK with security operations",
-    "start": 6587.289,
     "end": 6589.199124999997
   },
   {
-    "text": "budget transfer? Troy Whitmore: I would move to approve the remainder of the unanimous",
+    "text": "Troy Whitmore: I would move to approve the remainder of the unanimous consent agenda.",
     "start": 6593.919,
     "end": 6597.9945
   },
   {
-    "text": "consent agenda. Joyann",
+    "text": "Joyann Ruscha: Second.",
     "start": 6598.726,
     "end": 6598.726
   },
   {
-    "text": "Ruscha: Second. Julien",
+    "text": "Julien Bouquet: OK. I have Whitmore and then Ruscha as a second. Are there-- OK. So this is item A for the Board of Directors to approve a budget transfer of $3,845,437.10 between operating expenses lines for transit security services. Is there any no votes on that? OK. Seeing none, that item will pass 14-0-1. All right. Now we're moving on to our recommended action items. And we're going to have first on our list the Allied Universal security services contract extension for one year. Is there a motion?",
     "start": 6599.667,
-    "end": 6599.983
-  },
-  {
-    "text": "Bouquet: OK. I have Whitmore and then Ruscha as",
-    "start": 6599.983,
-    "end": 6602.194999999999
-  },
-  {
-    "text": "a second. Are",
-    "start": 6605.936,
-    "end": 6606.907499999999
-  },
-  {
-    "text": "there-- OK. So this is item A for the Board of Directors to approve a budget transfer of $3,845,437.10 between operating expenses lines for transit",
-    "start": 6606.907499999999,
-    "end": 6623.3750714285725
-  },
-  {
-    "text": "security services. Is there any no votes",
-    "start": 6626.481,
-    "end": 6628.661571428573
-  },
-  {
-    "text": "on",
-    "start": 6631.59,
-    "end": 6631.59
-  },
-  {
-    "text": "that? OK. Seeing none, that item will",
-    "start": 6633.239,
-    "end": 6635.436714285712
-  },
-  {
-    "text": "pass 14-0-1.",
-    "start": 6636.564,
-    "end": 6637.099272727273
-  },
-  {
-    "text": "All right. Now we're moving on to our recommended",
-    "start": 6637.634545454546,
-    "end": 6641.91672727273
-  },
-  {
-    "text": "action items. And we're going to have first on our list the Allied Universal security services contract extension for",
-    "start": 6643.214,
-    "end": 6648.964722222224
-  },
-  {
-    "text": "one year. Is there",
-    "start": 6650.845,
     "end": 6651.8065
   },
   {
-    "text": "a motion? Chris Nicholson:",
+    "text": "Chris Nicholson: So moved.",
     "start": 6653.148,
     "end": 6653.5485
   },
   {
-    "text": "So moved. Julien Bouquet:",
+    "text": "Julien Bouquet: OK, Nicholson. And a second. And Ruscha. All right. Any discussion? Director Nicholson?",
     "start": 6653.969,
-    "end": 6654.2495
-  },
-  {
-    "text": "OK, Nicholson. And",
-    "start": 6656.112,
-    "end": 6656.352666666667
-  },
-  {
-    "text": "a second.",
-    "start": 6657.515,
-    "end": 6657.735000000001
-  },
-  {
-    "text": "And Ruscha.",
-    "start": 6659.658,
-    "end": 6659.94825
-  },
-  {
-    "text": "All right.",
-    "start": 6660.2385,
-    "end": 6660.52875
-  },
-  {
-    "text": "Any discussion?",
-    "start": 6662.001,
     "end": 6662.3115
   },
   {
-    "text": "Director Nicholson? Chris",
+    "text": "Chris Nicholson: Yeah. So I just have a quick question about this one that came from a constituent. How many people do we have working on our security side from allied? And how many do we have from RTD PD right now? Thank you.",
     "start": 6662.3115,
-    "end": 6663.192
-  },
-  {
-    "text": "Nicholson: Yeah. So I just have a quick question about this one that came from",
-    "start": 6663.458625,
-    "end": 6667.191375000003
-  },
-  {
-    "text": "a constituent. How many people do we have working on our security side",
-    "start": 6668.399,
-    "end": 6675.055307692312
-  },
-  {
-    "text": "from allied? And how many do we have from RTD PD",
-    "start": 6676.09,
-    "end": 6680.272300000004
-  },
-  {
-    "text": "right now?",
-    "start": 6681.558,
     "end": 6681.6985
   },
   {
-    "text": "Thank you. Julien",
+    "text": "Julien Bouquet: Ms. Johnson.",
     "start": 6683.1,
-    "end": 6683.1
-  },
-  {
-    "text": "Bouquet:",
-    "start": 6683.261,
     "end": 6683.261
   },
   {
-    "text": "Ms. Johnson. Debra Johnson: Yes, I will yield the floor to Chief Martingano, who can address",
+    "text": "Debra Johnson: Yes, I will yield the floor to Chief Martingano, who can address that question. Thank you.",
     "start": 6683.261,
-    "end": 6687.388071428576
-  },
-  {
-    "text": "that question.",
-    "start": 6687.687,
     "end": 6687.857
   },
   {
-    "text": "Thank you. Julien Bouquet:",
+    "text": "Julien Bouquet: Chief Martingano.",
     "start": 6690.591,
     "end": 6690.941500000001
   },
   {
-    "text": "Chief Martingano. Steve Martingano: I am trying to",
+    "text": "Steve Martingano: I am trying to figure out. Oh, there we go. Turned green. Chair, for me?",
     "start": 6690.941500000001,
-    "end": 6693.730642857144
-  },
-  {
-    "text": "figure out. Oh, there",
-    "start": 6693.999571428572,
-    "end": 6694.53742857143
-  },
-  {
-    "text": "we go.",
-    "start": 6694.806357142858,
-    "end": 6695.075285714287
-  },
-  {
-    "text": "Turned green. Chair,",
-    "start": 6695.344214285716,
     "end": 6695.882071428573
   },
   {
-    "text": "for me? Julien",
+    "text": "Julien Bouquet: Yes.",
     "start": 6696.171,
     "end": 6696.171
   },
   {
-    "text": "Bouquet: Yes. Steve Martingano: Yeah, so technically, in regards to how many Allied personnel, it's an",
+    "text": "Steve Martingano: Yeah, so technically, in regards to how many Allied personnel, it's an hourly contract. So you'd have to take the amount of the hours and obviously divide it by 40. It roughly equates to the recommended action for next year. I think it's about 9,100 hours. So it roughly equates about 180 security officers. Right now, we currently have 87 on our staff in regards to post-certified police officers. We have a couple in training and one in the academy. We should be probably about 90 by the end of next month.",
     "start": 6696.551,
-    "end": 6701.724250000003
-  },
-  {
-    "text": "hourly contract. So you'd have to take the amount of the hours and obviously divide it",
-    "start": 6702.378,
-    "end": 6705.163066666663
-  },
-  {
-    "text": "by 40. It roughly equates to the recommended action for",
-    "start": 6705.402,
-    "end": 6709.2585
-  },
-  {
-    "text": "next year. I think it's about",
-    "start": 6709.707,
-    "end": 6711.325333333336
-  },
-  {
-    "text": "9,100 hours. So it roughly equates about 180",
-    "start": 6711.689,
-    "end": 6714.4400000000005
-  },
-  {
-    "text": "security officers. Right now, we currently have 87 on our staff in regards to post-certified",
-    "start": 6714.813,
-    "end": 6720.200812500003
-  },
-  {
-    "text": "police officers. We have a couple in training and one in",
-    "start": 6720.9,
-    "end": 6723.964347826084
-  },
-  {
-    "text": "the academy. We should be probably about 90 by the end of",
-    "start": 6724.270782608693,
     "end": 6727.6415652173855
   },
   {
-    "text": "next month. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Secretary.",
     "start": 6728.308,
-    "end": 6728.4685
-  },
-  {
-    "text": "Thank",
-    "start": 6731.592,
     "end": 6731.592
   },
   {
-    "text": "you. Secretary. Chris Nicholson: This is for",
+    "text": "Chris Nicholson: This is for GM/CEO Johnson. Are there any plans in place or-- and please feel free to not answer this if you can't. But I know there's been a drawdown over the last few years in our reliance on Allied Security. Is there anything in this contract or in your planning around this contract or anything that can give us guidance on whether we expect that to continue after authorizing this, or are we expecting to stay at 90 something hundred or 180 people over the next few years?",
     "start": 6731.592,
-    "end": 6732.745600000001
-  },
-  {
-    "text": "GM/CEO Johnson. Are there any plans in place or-- and please feel free to not answer this if",
-    "start": 6734.560750000001,
-    "end": 6742.382374999996
-  },
-  {
-    "text": "you can't. But I know there's been a drawdown over the last few years in our reliance on",
-    "start": 6743.81,
-    "end": 6749.577722222228
-  },
-  {
-    "text": "Allied Security. Is there anything in this contract or in your planning around this contract or anything that can give us guidance on whether we expect that to continue after authorizing this, or are we expecting to stay at 90 something hundred or 180 people over the next",
-    "start": 6749.958,
     "end": 6771.257142857148
   },
   {
-    "text": "few years? Julien",
+    "text": "Julien Bouquet: Ms. Johnson.",
     "start": 6773.134,
     "end": 6773.134
   },
   {
-    "text": "Bouquet:",
+    "text": "Debra Johnson: Yes. Thank you very much for the question. As Chief indicated, this is a contract extension and there's hours that are specified, hence in reference to the dollar amount that we have here. I would have to come back to the Board as it relates to any type of authorization as we're doing now currently with this contract extension, if that were to be modified. So on this point in time, it would stay the same. Unless there's some extenuating circumstances whereby we go out for a solicitation and we're not able to ensure that we're meeting the timeline before, since that's why we're here now with the contract extension. Quite naturally, in doing so, we have to ensure that we have the appropriate staffing levels. So I'm talking around and around in circles right now, but the answer would be no at this point in time.",
     "start": 6773.134,
-    "end": 6773.134
-  },
-  {
-    "text": "Ms. Johnson. Debra",
-    "start": 6773.134,
-    "end": 6773.134
-  },
-  {
-    "text": "Johnson: Yes. Thank you very much for",
-    "start": 6773.355,
-    "end": 6774.471857142857
-  },
-  {
-    "text": "the question. As Chief indicated, this is a contract extension and there's hours that are specified, hence in reference to the dollar amount that we",
-    "start": 6774.778,
-    "end": 6781.583999999997
-  },
-  {
-    "text": "have here. I would have to come back to the Board as it relates to any type of authorization as we're doing now currently with this contract extension, if that were to",
-    "start": 6781.849599999997,
-    "end": 6790.228565217384
-  },
-  {
-    "text": "be modified. So on this point in time, it would stay",
-    "start": 6790.721,
-    "end": 6794.1808
-  },
-  {
-    "text": "the same. Unless there's some extenuating circumstances whereby we go out for a solicitation and we're not able to ensure that we're meeting the timeline before, since that's why we're here now with the",
-    "start": 6794.52678,
-    "end": 6805.944120000002
-  },
-  {
-    "text": "contract extension. Quite naturally, in doing so, we have to ensure that we have the appropriate",
-    "start": 6806.290100000002,
-    "end": 6811.523636363637
-  },
-  {
-    "text": "staffing levels. So I'm talking around and around in circles right now, but the answer would be no at this point",
-    "start": 6812.499909090909,
     "end": 6817.178090909089
   },
   {
-    "text": "in time. Julien",
+    "text": "Julien Bouquet: Secretary. Perfect. Second Vice Chair Whitmore.",
     "start": 6819.014,
-    "end": 6819.014
-  },
-  {
-    "text": "Bouquet:",
-    "start": 6821.477,
-    "end": 6821.477
-  },
-  {
-    "text": "Secretary. Perfect. Second Vice",
-    "start": 6822.838571428571,
     "end": 6823.499428571428
   },
   {
-    "text": "Chair Whitmore. Troy Whitmore: So, Chief, jog my memory on our goal for the end of the year for",
+    "text": "Troy Whitmore: So, Chief, jog my memory on our goal for the end of the year for sworn officers. It's not 90, right? It's continuing to grow.",
     "start": 6823.719714285714,
-    "end": 6831.0348947368375
-  },
-  {
-    "text": "sworn officers. It's not",
-    "start": 6831.449,
-    "end": 6832.3054999999995
-  },
-  {
-    "text": "90, right? It's continuing",
-    "start": 6832.671,
     "end": 6833.7825
   },
   {
-    "text": "to grow. Julien Bouquet:",
+    "text": "Julien Bouquet: Chief Martingano.",
     "start": 6834.713,
     "end": 6835.452
   },
   {
-    "text": "Chief Martingano. Steve",
+    "text": "Steve Martingano: Yeah. So we are budgeted for 150. We're still in the process of growing to those numbers. So obviously with applications, background checks, everything else, we're heading positively toward that. We're putting eight more in the academy here in June. We continue to get lateral transfers. I'm sorry, lateral applications from other agencies, officers with experience. So we're hoping to hit 150 goal by the end of the year.",
     "start": 6835.452,
-    "end": 6835.452
-  },
-  {
-    "text": "Martingano: Yeah. So we are budgeted",
-    "start": 6835.732285714286,
-    "end": 6837.133714285716
-  },
-  {
-    "text": "for 150. We're still in the process of growing to",
-    "start": 6837.874,
-    "end": 6840.275818181815
-  },
-  {
-    "text": "those numbers. So obviously with applications, background checks, everything else, we're heading positively",
-    "start": 6842.587470588234,
-    "end": 6848.266176470583
-  },
-  {
-    "text": "toward that. We're putting eight more in the academy here",
-    "start": 6848.743,
-    "end": 6850.526799999999
-  },
-  {
-    "text": "in June. We continue to get",
-    "start": 6850.765,
-    "end": 6852.8924285714265
-  },
-  {
-    "text": "lateral transfers. I'm sorry, lateral applications from other agencies, officers",
-    "start": 6853.747,
-    "end": 6856.943615384615
-  },
-  {
-    "text": "with experience. So we're hoping to hit 150 goal by the end of",
-    "start": 6857.671,
     "end": 6860.349769230774
   },
   {
-    "text": "the year. Troy Whitmore:",
+    "text": "Troy Whitmore: All right. Thank you very much. I did have the right memory up here. Thank you, Mr. Chair.",
     "start": 6860.593,
-    "end": 6860.8335
-  },
-  {
-    "text": "All right. Thank you",
-    "start": 6861.094,
-    "end": 6861.634000000001
-  },
-  {
-    "text": "very much. I did have the right memory",
-    "start": 6861.834,
-    "end": 6863.988249999999
-  },
-  {
-    "text": "up here. Thank",
-    "start": 6864.336,
-    "end": 6864.7964999999995
-  },
-  {
-    "text": "you,",
-    "start": 6865.026749999999,
     "end": 6865.026749999999
   },
   {
-    "text": "Mr. Chair. Julien",
+    "text": "Julien Bouquet: Absolutely. Any other-- well, any further questions or discussions on this? Yeah, Director Ruscha?",
     "start": 6865.338,
-    "end": 6865.338
-  },
-  {
-    "text": "Bouquet: Absolutely. Any other-- well, any further questions or discussions",
-    "start": 6867.821,
-    "end": 6869.905249999998
-  },
-  {
-    "text": "on this? Yeah,",
-    "start": 6871.144,
     "end": 6871.517333333333
   },
   {
-    "text": "Director Ruscha? Joyann Ruscha: Thank",
+    "text": "Joyann Ruscha: Thank you, sir. So I just wanted to note, in the past, upon request, the agency has provided a breakdown of how many-- just our security personnel from RTD to contracted and even break down in terms of with our contracted Allied force, like the ones that are authorized to have firearms versus not and our mental health staff and stuff. So that's something that I think the agency-- I'm sure the agency would be happy to provide that breakdown chart. I think it's been a little over a year since we've had one, so I just wanted to offer that to those who are interested and just to piggyback on Secretary Nicholson's comments. Thank you.",
     "start": 6873.546,
-    "end": 6873.773333333333
-  },
-  {
-    "text": "you, sir. So I just wanted to note, in the past, upon request, the agency has provided a breakdown of how many-- just our security personnel from RTD to contracted and even break down in terms of with our contracted Allied force, like the ones that are authorized to have firearms versus not and our mental health staff",
-    "start": 6873.967,
-    "end": 6901.546947368422
-  },
-  {
-    "text": "and stuff. So that's something that I think the agency-- I'm sure the agency would be happy to provide that",
-    "start": 6901.862,
-    "end": 6907.844136363629
-  },
-  {
-    "text": "breakdown chart. I think it's been a little over a year since we've had one, so I just wanted to offer that to those who are interested and just to piggyback on Secretary",
-    "start": 6908.209,
-    "end": 6919.874400000001
-  },
-  {
-    "text": "Nicholson's comments.",
-    "start": 6920.282,
     "end": 6920.7325
   },
   {
-    "text": "Thank you. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Director. Any further comments or questions? OK. Seeing none. So I did have-- thank you, Chief. I did have Nicholson as the mover and Ruscha as the second. Are there any no votes on this item? OK. Seeing none, the item will pass 14-0-1 absent. We are hitting our two hour mark, so we are going to take a break for our CART employee. Let's shoot to be back here 9 o'clock. Would that be enough time? Nope? OK. OK. Let's do 9:05, then.",
     "start": 6921.203,
-    "end": 6921.6303333333335
-  },
-  {
-    "text": "you, Director. Any further comments",
-    "start": 6924.287,
-    "end": 6925.3117999999995
-  },
-  {
-    "text": "or",
-    "start": 6927.168,
-    "end": 6927.168
-  },
-  {
-    "text": "questions? OK.",
-    "start": 6927.4349999999995,
-    "end": 6927.701999999999
-  },
-  {
-    "text": "Seeing none. So I did have-- thank",
-    "start": 6928.089,
-    "end": 6929.7372857142855
-  },
-  {
-    "text": "you, Chief. I did have Nicholson as the mover and Ruscha as",
-    "start": 6930.813,
-    "end": 6933.658333333333
-  },
-  {
-    "text": "the second. Are there any no votes on",
-    "start": 6934.418,
-    "end": 6936.188125000001
-  },
-  {
-    "text": "this",
-    "start": 6940.667,
-    "end": 6940.667
-  },
-  {
-    "text": "item? OK. Seeing none, the item will pass",
-    "start": 6941.100888888889,
-    "end": 6944.13811111111
-  },
-  {
-    "text": "14-0-1 absent. We are hitting our two hour mark, so we are going to take a break for our",
-    "start": 6945.433,
-    "end": 6949.462000000001
-  },
-  {
-    "text": "CART employee. Let's shoot to be back here",
-    "start": 6950.8,
-    "end": 6953.755555555556
-  },
-  {
-    "text": "9 o'clock. Would that be",
-    "start": 6954.145,
-    "end": 6954.7058
-  },
-  {
-    "text": "enough",
-    "start": 6956.26,
-    "end": 6956.26
-  },
-  {
-    "text": "time?",
-    "start": 6956.62,
-    "end": 6956.62
-  },
-  {
-    "text": "Nope?",
-    "start": 6957.221,
-    "end": 6957.221
-  },
-  {
-    "text": "OK. OK. Let's do",
-    "start": 6957.441,
     "end": 6958.19175
   },
   {
-    "text": "9:05, then. Chris Nicholson:",
+    "text": "Chris Nicholson: Thank you.",
     "start": 6959.002,
     "end": 6959.2725
   },
   {
-    "text": "Thank you. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. We'll be back at 9:05. All right. Thank you, everyone, for your patience. We are now moving on to our next recommended action for tonight. And that is going to be the recommended action of the 2025-2028 Title VI program update to comply with federal laws, regulations, and guidelines related Title VI of the Civil Rights Act of 1964. Do we have a motion?",
     "start": 6959.563,
-    "end": 6960.0335
+    "end": 7236.960000000001
   },
   {
-    "text": "Thank you. We'll be back",
-    "start": 6960.524,
-    "end": 6979.2747500000005
+    "text": "Peggy Catlin: So moved.",
+    "start": 7237.295000000001,
+    "end": 7238.300000000001
   },
   {
-    "text": "at 9:05.",
-    "start": 6985.792,
-    "end": 6994.943333333334
+    "text": "Julien Bouquet: I have Caitlin as the mover.",
+    "start": 7238.635000000001,
+    "end": 7240.980000000001
   },
   {
-    "text": "All right. Thank you, everyone, for",
-    "start": 7004.094666666667,
-    "end": 7127.233999999999
+    "text": "Michael Guzman: Second, Guzman.",
+    "start": 7241.315000000001,
+    "end": 7242.3200000000015
   },
   {
-    "text": "your patience. We are now moving on to our next recommended action",
-    "start": 7204.588299999999,
-    "end": 7231.6
+    "text": "Julien Bouquet: Guzman as the second. I do understand that Director Benker has two amendments she would like to offer on this item. Director Benker, we'll take your amendments one at a time. What is your first amendment, Director Benker?",
+    "start": 7242.655000000002,
+    "end": 7288.0405
   },
   {
-    "text": "for tonight. And that is going to be the recommended action of the 2025-2028 Title VI program update to comply with federal laws, regulations, and guidelines related Title VI of the Civil Rights Act",
-    "start": 7231.935,
-    "end": 7242.990000000002
-  },
-  {
-    "text": "of 1964. Do we have",
-    "start": 7243.325000000002,
-    "end": 7244.665000000002
-  },
-  {
-    "text": "a motion? Peggy Catlin:",
-    "start": 7245.000000000002,
-    "end": 7246.005000000002
-  },
-  {
-    "text": "So moved. Julien Bouquet: I have Caitlin as",
-    "start": 7246.340000000002,
-    "end": 7682.699000000005
-  },
-  {
-    "text": "the mover. Michael Guzman:",
-    "start": 7683.058800000005,
-    "end": 7684.138200000006
-  },
-  {
-    "text": "Second, Guzman. Julien Bouquet: Guzman as",
-    "start": 7685.779,
-    "end": 7692.956499999998
-  },
-  {
-    "text": "the second. I do understand that Director Benker has two amendments she would like to offer on",
-    "start": 7694.795,
-    "end": 7698.963470588236
-  },
-  {
-    "text": "this item. Director Benker, we'll take your amendments one at",
-    "start": 7699.584,
-    "end": 7701.892500000004
-  },
-  {
-    "text": "a time. What is your first amendment,",
-    "start": 7703.672,
-    "end": 7705.338285714283
-  },
-  {
-    "text": "Director Benker? Karen Benker: Thank you",
-    "start": 7706.177,
-    "end": 7706.7935
-  },
-  {
-    "text": "very much. And I'm glad everybody is now second wind and we're ready to go on to our, I don't know, six or seventh hour",
-    "start": 7707.72,
-    "end": 7717.018555555557
-  },
-  {
-    "text": "of meeting. Actually, I will tell you, I",
-    "start": 7718.22,
-    "end": 7721.165250000002
-  },
-  {
-    "text": "have three. We'll see how",
-    "start": 7721.626,
-    "end": 7722.635600000001
-  },
-  {
-    "text": "things go.",
-    "start": 7722.908,
-    "end": 7723.4490000000005
-  },
-  {
-    "text": "They're short. The first one-- well, let me give you a little bit",
-    "start": 7724.992,
-    "end": 7727.321846153851
-  },
-  {
-    "text": "of background. So the background is I met with my four cities back in February",
-    "start": 7728.478,
-    "end": 7733.189466666664
-  },
-  {
-    "text": "and March. And of course, you meet with them and you say hi and you say, OK, what are",
-    "start": 7733.506,
-    "end": 7737.812736842111
-  },
-  {
-    "text": "your needs? What are",
-    "start": 7738.112,
-    "end": 7738.7435000000005
-  },
-  {
-    "text": "your wants? I met with all of them, and they all gave me a list of basically trying to restore service that was removed during",
-    "start": 7739.995,
-    "end": 7748.108920000011
-  },
-  {
-    "text": "the pandemic. And so of course, as is my job as Director, I'm trying to work with our staff to try to get that",
-    "start": 7749.828,
-    "end": 7759.943217391304
-  },
-  {
-    "text": "service restored. And so one of my questions or issues is I am guessing that when the RTD Board had to make the hard decisions of how to cut service almost in half because of this highly unusual pandemic, perhaps some of these cuts were not done equally across all",
-    "start": 7761.224,
+    "text": "Karen Benker: Thank you very much. And I'm glad everybody is now second wind and we're ready to go on to our, I don't know, six or seventh hour of meeting. Actually, I will tell you, I have three. We'll see how things go. They're short. The first one-- well, let me give you a little bit of background. So the background is I met with my four cities back in February and March. And of course, you meet with them and you say hi and you say, OK, what are your needs? What are your wants? I met with all of them, and they all gave me a list of basically trying to restore service that was removed during the pandemic. And so of course, as is my job as Director, I'm trying to work with our staff to try to get that service restored. And so one of my questions or issues is I am guessing that when the RTD Board had to make the hard decisions of how to cut service almost in half because of this highly unusual pandemic, perhaps some of these cuts were not done equally across all 15 districts.",
+    "start": 7298.722,
     "end": 7786.715779999983
   },
   {
-    "text": "15 districts. Julien Bouquet: Director Benker, I'm sorry",
+    "text": "Julien Bouquet: Director Benker, I'm sorry to interrupt. Just so that we keep an order, could we get a second on-- could you read the motion and then we get a second?",
     "start": 7787.438,
-    "end": 7788.802473684212
-  },
-  {
-    "text": "to interrupt. Just so that we keep an order, could we get a second on-- could you read the motion and then we get",
-    "start": 7789.075368421054,
     "end": 7794.532181818185
   },
   {
-    "text": "a second? Karen Benker: The motion is change the threshold for disproportionate burden and disparate impact from 10% to 20% as it relates to major service changes and consistent with the FTA",
+    "text": "Karen Benker: The motion is change the threshold for disproportionate burden and disparate impact from 10% to 20% as it relates to major service changes and consistent with the FTA circular 4702.1b. And I believe the version that will be voted on is actually the version that Mr. Kroll put up for us.",
     "start": 7794.705,
-    "end": 7807.783064516121
-  },
-  {
-    "text": "circular 4702.1b. And I believe the version that will be voted on is actually the version",
-    "start": 7809.841,
-    "end": 7816.852
-  },
-  {
-    "text": "that Mr. Kroll put up",
-    "start": 7817.155666666667,
     "end": 7818.370333333333
   },
   {
-    "text": "for us. Julien Bouquet: So that's the language",
+    "text": "Julien Bouquet: So that's the language right there. The first motion is to move to amend the 2025-2028 Title VI program update, such that the threshold for triggering either disperportionate burden-- or disparities in-- disparate impact finding-- late night-- finding arising from a major service change from 10% to 20%. Do I have a second?",
     "start": 7819.755,
-    "end": 7821.676714285716
-  },
-  {
-    "text": "right there. The first motion is to move to amend the 2025-2028 Title VI program update, such that the threshold for triggering either disperportionate burden-- or disparities in-- disparate impact finding-- late night-- finding arising from a major service change from 10%",
-    "start": 7822.017,
-    "end": 7837.569318181815
-  },
-  {
-    "text": "to 20%. Do I have",
-    "start": 7839.613,
     "end": 7840.894
   },
   {
-    "text": "a second? Brett Paglieri:",
+    "text": "Brett Paglieri: Second, Paglieri.",
     "start": 7842.115,
     "end": 7842.115
   },
   {
-    "text": "Second, Paglieri. Julien Bouquet: Paglieri is",
+    "text": "Julien Bouquet: Paglieri is the second. Thank you.",
     "start": 7842.115,
-    "end": 7843.090749999999
-  },
-  {
-    "text": "the second.",
-    "start": 7844.397,
     "end": 7844.496999999999
   },
   {
-    "text": "Thank you. Karen Benker: So just to continue a little bit more background, and then we can start, I guess the",
+    "text": "Karen Benker: So just to continue a little bit more background, and then we can start, I guess the debate here. I'm just trying to get service restored that was eliminated during the pandemic. And there have been a couple of times now when I have requested and the answer that I have gotten several times is, well, it's going to depend on how the equity analysis calculations come out. And so I'm just trying to find ways where we can perhaps start to restore some of the service that had been eliminated during the pandemic and perhaps do it a little bit quicker and also try to make it not quite so difficult. So then what happened, of course, is everyone received about a week, 10 days ago, a letter from the City and County of Broomfield. And their transportation staff went through our items quite closely, and they sent us all a letter with recommended changes. So I've gone through with their changes, and that's where I've come up with the three amendments that I'd like to at least talk to the Board, see what your thoughts are. Hopefully it'll pass, but we'll see what happens. But it's just basically what City and County of Broomfield had found when they did their research is that the RTD is using some very conservative calculations compared to some of the other large transit agencies. And so I did send you also a copy of the City and County of Broomfield's letter, just to refresh your memory. And so I would like to put forth that the first amendment would be changing the threshold from 10% to 20%.",
     "start": 7845.488,
-    "end": 7851.643999999994
-  },
-  {
-    "text": "debate here. I'm just trying to get service restored that was eliminated during",
-    "start": 7852.648,
-    "end": 7859.905230769232
-  },
-  {
-    "text": "the pandemic. And there have been a couple of times now when I have requested and the answer that I have gotten several times is, well, it's going to depend on how the equity analysis calculations",
-    "start": 7860.49,
-    "end": 7872.850833333337
-  },
-  {
-    "text": "come out. And so I'm just trying to find ways where we can perhaps start to restore some of the service that had been eliminated during the pandemic and perhaps do it a little bit quicker and also try to make it not quite",
-    "start": 7873.865,
-    "end": 7895.210900000001
-  },
-  {
-    "text": "so difficult. So then what happened, of course, is everyone received about a week, 10 days ago, a letter from the City and County",
-    "start": 7896.071,
-    "end": 7903.104208333333
-  },
-  {
-    "text": "of Broomfield. And their transportation staff went through our items quite closely, and they sent us all a letter with",
-    "start": 7904.212,
-    "end": 7914.825142857143
-  },
-  {
-    "text": "recommended changes. So I've gone through with their changes, and that's where I've come up with the three amendments that I'd like to at least talk to the Board, see what your",
-    "start": 7916.054,
-    "end": 7925.562281250002
-  },
-  {
-    "text": "thoughts are. Hopefully it'll pass, but we'll see",
-    "start": 7926.79,
-    "end": 7928.7885
-  },
-  {
-    "text": "what happens. But it's just basically what City and County of Broomfield had found when they did their research is that the RTD is using some very conservative calculations compared to some of the other large",
-    "start": 7929.514,
-    "end": 7944.170999999995
-  },
-  {
-    "text": "transit agencies. And so I did send you also a copy of the City and County of Broomfield's letter, just to refresh",
-    "start": 7945.374,
-    "end": 7950.592499999993
-  },
-  {
-    "text": "your memory. And so I would like to put forth that the first amendment would be changing the threshold from 10%",
-    "start": 7951.842,
     "end": 7958.305809523811
   },
   {
-    "text": "to 20%. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Treasurer Benker. So again, the discussion right now is on the motion, this first motion, the first amendment. Director Catlin.",
     "start": 7959.03,
-    "end": 7960.126499999999
-  },
-  {
-    "text": "Treasurer Benker. So again, the discussion right now is on the motion, this first motion, the",
-    "start": 7960.652,
-    "end": 7966.089666666666
-  },
-  {
-    "text": "first amendment.",
-    "start": 7966.818,
     "end": 7967.2285
   },
   {
-    "text": "Director Catlin. Peggy Catlin: Thank",
+    "text": "Peggy Catlin: Thank you, Mr. Chair. I'd like to ask GM/CEO Johnson. I heard from someone-- I don't remember now because it's getting late. But someone said that some of those assumptions made by City and County of Broomfield were incorrect.",
     "start": 7967.2285,
-    "end": 7971.696
-  },
-  {
-    "text": "you,",
-    "start": 7971.9215,
-    "end": 7971.9215
-  },
-  {
-    "text": "Mr. Chair. I'd like to ask",
-    "start": 7972.768,
-    "end": 7975.206571428571
-  },
-  {
-    "text": "GM/CEO Johnson. I heard from someone-- I don't remember now because it's",
-    "start": 7976.374,
-    "end": 7980.757892857141
-  },
-  {
-    "text": "getting late. But someone said that some of those assumptions made by City and County of Broomfield",
-    "start": 7981.156428571427,
     "end": 7987.13446428571
   },
   {
-    "text": "were incorrect. Julien",
+    "text": "Julien Bouquet: Ms. Johnson. Yes thank you very much relative to the comments that were made-- and thank you very much, Director Catlin-- as it relates to the transit agencies that were mentioned, being MARTA, the Metropolitan Atlanta Rapid Transit Authority, Los Angeles County Metropolitan Transit Authority, King County Metro, which is in greater Seattle, and the Chicago Transit Authority. That information, especially coming from LA Metro as the former Chief Operations Officer there, this is not correct relative to where we sit. And more specifically, I do know our Director of Civil Rights, when we were going through this, quite naturally in the role that he is in, he and his team did a desk audit and worked with colleagues at different transit agencies. So that's the communiqu\u00e9 that I did disseminate yesterday upon receiving this information. So, Mr. Green, if you want to just expound succinctly and briefly.",
     "start": 7989.036,
-    "end": 7989.036
-  },
-  {
-    "text": "Bouquet:",
-    "start": 7989.496,
-    "end": 7989.496
-  },
-  {
-    "text": "Ms. Johnson. Yes thank you very much relative to the comments that were made-- and thank you very much, Director Catlin-- as it relates to the transit agencies that were mentioned, being MARTA, the Metropolitan Atlanta Rapid Transit Authority, Los Angeles County Metropolitan Transit Authority, King County Metro, which is in greater Seattle, and the Chicago",
-    "start": 7990.141,
-    "end": 8010.1141153846165
-  },
-  {
-    "text": "Transit Authority. That information, especially coming from LA Metro as the former Chief Operations Officer there, this is not correct relative to where",
-    "start": 8012.232,
-    "end": 8020.818166666667
-  },
-  {
-    "text": "we sit. And more specifically, I do know our Director of Civil Rights, when we were going through this, quite naturally in the role that he is in, he and his team did a desk audit and worked with colleagues at different",
-    "start": 8021.1594583333335,
-    "end": 8035.152416666665
-  },
-  {
-    "text": "transit agencies. So that's the communiqu\u00e9 that I did disseminate yesterday upon receiving",
-    "start": 8035.493708333332,
-    "end": 8039.589208333331
-  },
-  {
-    "text": "this information.",
-    "start": 8039.930499999998,
-    "end": 8040.271791666664
-  },
-  {
-    "text": "So, Mr. Green, if you want to just expound succinctly",
-    "start": 8040.613083333331,
     "end": 8043.6847083333305
   },
   {
-    "text": "and briefly. Carl",
+    "text": "Carl Green: Yes. Thank you so much, General Manager and CEO Johnson. To expand upon the response, I just also want to ground us and first state that it is our collective responsibility to make federally compliant and equitable decisions, especially as it relates to service changes. And in doing that audit, we looked at 22-- rather, 23 different organizations, which includes the four, MARTA, LA Metro, King County, and the Chicago Transit Authority. And I would say the way to look at the disparate impact or disproportionate burden, the framing of it is how sensitive or less sensitive versus more sensitive, right? And ours is stacked in the middle. So I want to give you some numbers here. So for the four that I just mentioned, MARTA has 10%, LA Metro has 5%, King County has 10%, CTA or Chicago Transit Authority has 15%. And then when we rack and stack, look at those 22 different organizations, 6 out of that 23 have 5% or less. Two have 8%. Six, which includes us, or seven including us, is at 10%. Three at 15%. And then three at 20%. And in my over eight years of doing this work, I'll just say that when you are setting your policy, you don't want to do a disservice to the spirit and the letter of what we're ultimately trying to achieve specifically with Title VI. Title VI is not a stopping mechanism of bringing back or restoring service. There are a lot of different variables, as I mentioned before, with respect to our service development guidelines, our operators resources, so on and so forth. This is just a mechanism for the agencies such as RTD and the Board of Directors so we don't get too far over our skis without discounting populations that are more likely to be transit reliant. So again, it's not a stopping mechanism, but this is just more so to make sure that we are taking into consideration all of our customers.",
     "start": 8044.495,
-    "end": 8044.495
-  },
-  {
-    "text": "Green: Yes. Thank you so much, General Manager and",
-    "start": 8044.867466666667,
-    "end": 8047.8472
-  },
-  {
-    "text": "CEO Johnson. To expand upon the response, I just also want to ground us and first state that it is our collective responsibility to make federally compliant and equitable decisions, especially as it relates to",
-    "start": 8048.219666666667,
-    "end": 8059.278266666654
-  },
-  {
-    "text": "service changes. And in doing that audit, we looked at 22-- rather, 23 different organizations, which includes the four, MARTA, LA Metro, King County, and the Chicago",
-    "start": 8060.215,
-    "end": 8071.1114
-  },
-  {
-    "text": "Transit Authority. And I would say the way to look at the disparate impact or disproportionate burden, the framing of it is how sensitive or less sensitive versus more",
-    "start": 8071.57,
-    "end": 8082.881034482747
-  },
-  {
-    "text": "sensitive, right? And ours is stacked in",
-    "start": 8083.486,
-    "end": 8085.1334285714265
-  },
-  {
-    "text": "the middle. So I want to give you some",
-    "start": 8085.468,
-    "end": 8087.177333333332
-  },
-  {
-    "text": "numbers here. So for the four that I just mentioned, MARTA has 10%, LA Metro has 5%, King County has 10%, CTA or Chicago Transit Authority",
-    "start": 8088.132,
-    "end": 8100.004857142856
-  },
-  {
-    "text": "has 15%. And then when we rack and stack, look at those 22 different organizations, 6 out of that 23 have 5%",
-    "start": 8101.472,
-    "end": 8110.072454545463
-  },
-  {
-    "text": "or less. Two",
-    "start": 8111.143,
-    "end": 8111.690333333334
-  },
-  {
-    "text": "have 8%. Six, which includes us, or seven including us, is",
-    "start": 8113.045,
-    "end": 8117.631363636363
-  },
-  {
-    "text": "at 10%. Three",
-    "start": 8118.458,
-    "end": 8119.174
-  },
-  {
-    "text": "at 15%. And then three",
-    "start": 8119.532,
-    "end": 8120.964000000001
-  },
-  {
-    "text": "at 20%. And in my over eight years of doing this work, I'll just say that when you are setting your policy, you don't want to do a disservice to the spirit and the letter of what we're ultimately trying to achieve specifically with",
-    "start": 8121.983,
-    "end": 8140.351680851067
-  },
-  {
-    "text": "Title VI. Title VI is not a stopping mechanism of bringing back or",
-    "start": 8141.312,
-    "end": 8146.543999999996
-  },
-  {
-    "text": "restoring service. There are a lot of different variables, as I mentioned before, with respect to our service development guidelines, our operators resources, so on and",
-    "start": 8147.669,
-    "end": 8154.7151538461585
-  },
-  {
-    "text": "so forth. This is just a mechanism for the agencies such as RTD and the Board of Directors so we don't get too far over our skis without discounting populations that are more likely to be",
-    "start": 8155.497,
-    "end": 8166.650333333346
-  },
-  {
-    "text": "transit reliant. So again, it's not a stopping mechanism, but this is just more so to make sure that we are taking into consideration all of",
-    "start": 8166.989,
     "end": 8174.863038461545
   },
   {
-    "text": "our customers. Julien Bouquet: I have Director",
+    "text": "Julien Bouquet: I have Director Ruscha next.",
     "start": 8177.2,
     "end": 8179.073599999999
   },
   {
-    "text": "Ruscha next. Joyann",
-    "start": 8184.407,
-    "end": 8184.407
-  },
-  {
-    "text": "Ruscha: OK. I did have a question, but also Treasurer Benker had her hand up, and it was her motion, so I'm happy to wait if that was",
+    "text": "Joyann Ruscha: OK. I did have a question, but also Treasurer Benker had her hand up, and it was her motion, so I'm happy to wait if that was in response.",
     "start": 8184.407,
     "end": 8191.224799999996
   },
   {
-    "text": "in response. Julien Bouquet:",
+    "text": "Julien Bouquet: Treasurer Benker?",
     "start": 8192.234,
     "end": 8192.514
   },
   {
-    "text": "Treasurer Benker? Karen Benker: I feel that we are in an extremely unique situation because of",
+    "text": "Karen Benker: I feel that we are in an extremely unique situation because of the pandemic. So how can we restore, let's say 40% of the service that had been cut several years ago? How can we get back to 2019 when my district, other districts had that service? And so now we're being told that we can't get that service back because of this conservative calculation that we're doing, but we used to have it. And so how do we get from where we are now to bringing service back to pre-pandemic levels?",
     "start": 8195.277,
-    "end": 8199.737857142847
-  },
-  {
-    "text": "the pandemic. So how can we restore, let's say 40% of the service that had been cut several",
-    "start": 8201.062,
-    "end": 8209.855999999998
-  },
-  {
-    "text": "years ago? How can we get back to 2019 when my district, other districts had",
-    "start": 8210.693,
-    "end": 8217.98513333332
-  },
-  {
-    "text": "that service? And so now we're being told that we can't get that service back because of this conservative calculation that we're doing, but we used to",
-    "start": 8219.368,
-    "end": 8231.190142857127
-  },
-  {
-    "text": "have it. And so how do we get from where we are now to bringing service back to",
-    "start": 8232.786,
     "end": 8239.518944444435
   },
   {
-    "text": "pre-pandemic levels? Julien",
+    "text": "Julien Bouquet: Ms. Johnson.",
     "start": 8241.237,
-    "end": 8241.237
-  },
-  {
-    "text": "Bouquet:",
-    "start": 8241.437,
     "end": 8241.437
   },
   {
-    "text": "Ms. Johnson. Debra Johnson: Yes, thank you",
+    "text": "Debra Johnson: Yes, thank you very much. Director Benker, that question is better suited for me. Relative to the service delivery framework that we have, while Title VI plays a role relative to major service changes as we talk about how we deploy services based upon a myriad of different factors relative to our revenue service hours. But more specifically, at how we use our comprehensive operational analysis specifically as we talk about the SOP. When I came into this organization, it was decided that we were going to look at 85% of what service levels were-- 85% of what service levels were in 2019. We were in a different time relative to the commuting patterns, relative to how people were working going forward. What I will share is that we are being very diligent and judicious in how we're applying service, because we do want to ensure there is equity. I'm going to speak a little bit out of school here because I shared this with you yesterday, but I'll say it in this context as well. As we talk about Longmont and we talk about service, we are looking at that for the fall service change. That is up to the Board, quite naturally. But I did want to put that forward because with the restoration of service, keeping in mind that all transit agencies across the US were in these precarious positions and the Federal Transit Administration more or less provided waivers, waivers from the sense of how we were decreasing service due to the fact that we didn't have enough people power. Also, we currently are still working under a waiver as it relates to our spare ratio. What I mean by that is when you deploy service in the mornings and in the afternoons with the peak, you have a certain pullout rate and you're only supposed to have a 20% spare ratio. We've deviated from that and have a waiver, and we're rightsizing the fleet as we move forward. So while you're bringing up these points, as you indicated, we are in uncharted territory, or were, and we're coming back from that. We are looking at where there are needs relative to the entire area, from an origin and destination vantage point, just by virtue of how our service area is going forward. So I'm not providing this to say I don't understand what you're trying to do, and as I share it with you, I do clearly, and we want to work within the framework that we have. But a wholesale of restoration of what was happening in 2019, that wouldn't be fiscally responsible. And I say it from the vantage point of we had a lot of service that was out on the street, maybe that yielded one passenger boarding per hour, but that was out on the street. Does that really yield the return on investment going forward? Hence that's why there were modifications relative to reallocation of services going forward.",
     "start": 8241.437,
-    "end": 8243.044857142855
-  },
-  {
-    "text": "very much. Director Benker, that question is better suited",
-    "start": 8243.276571428569,
-    "end": 8245.136000000004
-  },
-  {
-    "text": "for me. Relative to the service delivery framework that we have, while Title VI plays a role relative to major service changes as we talk about how we deploy services based upon a myriad of different factors relative to our revenue",
-    "start": 8246.164,
-    "end": 8261.673490196088
-  },
-  {
-    "text": "service hours. But more specifically, at how we use our comprehensive operational analysis specifically as we talk about",
-    "start": 8262.040411764716,
-    "end": 8268.278078431387
-  },
-  {
-    "text": "the SOP. When I came into this organization, it was decided that we were going to look at 85% of what service levels were-- 85% of what service levels were",
-    "start": 8269.306,
-    "end": 8278.328000000005
-  },
-  {
-    "text": "in 2019. We were in a different time relative to the commuting patterns, relative to how people were working",
-    "start": 8279.397,
-    "end": 8288.070157894723
-  },
-  {
-    "text": "going forward. What I will share is that we are being very diligent and judicious in how we're applying service, because we do want to ensure there",
-    "start": 8289.634,
-    "end": 8299.310461538456
-  },
-  {
-    "text": "is equity. I'm going to speak a little bit out of school here because I shared this with you yesterday, but I'll say it in this context",
-    "start": 8299.671,
-    "end": 8305.9581851852
-  },
-  {
-    "text": "as well. As we talk about Longmont and we talk about service, we are looking at that for the fall",
-    "start": 8306.641,
-    "end": 8316.783199999985
-  },
-  {
-    "text": "service change. That is up to the Board,",
-    "start": 8317.499,
-    "end": 8319.746875000003
-  },
-  {
-    "text": "quite naturally. But I did want to put that forward because with the restoration of service, keeping in mind that all transit agencies across the US were in these precarious positions and the Federal Transit Administration more or less provided waivers, waivers from the sense of how we were decreasing service due to the fact that we didn't have enough",
-    "start": 8320.068000000003,
-    "end": 8340.305000000013
-  },
-  {
-    "text": "people power. Also, we currently are still working under a waiver as it relates to our",
-    "start": 8340.972,
-    "end": 8346.023250000006
-  },
-  {
-    "text": "spare ratio. What I mean by that is when you deploy service in the mornings and in the afternoons with the peak, you have a certain pullout rate and you're only supposed to have a 20%",
-    "start": 8346.38,
-    "end": 8356.168114285721
-  },
-  {
-    "text": "spare ratio. We've deviated from that and have a waiver, and we're rightsizing the fleet as we",
-    "start": 8356.776,
-    "end": 8363.700666666655
-  },
-  {
-    "text": "move forward. So while you're bringing up these points, as you indicated, we are in uncharted territory, or were, and we're coming back",
-    "start": 8364.148,
-    "end": 8371.492812499993
-  },
-  {
-    "text": "from that. We are looking at where there are needs relative to the entire area, from an origin and destination vantage point, just by virtue of how our service area is",
-    "start": 8372.783,
-    "end": 8384.64267741936
-  },
-  {
-    "text": "going forward. So I'm not providing this to say I don't understand what you're trying to do, and as I share it with you, I do clearly, and we want to work within the framework that",
-    "start": 8385.519,
-    "end": 8396.448260869565
-  },
-  {
-    "text": "we have. But a wholesale of restoration of what was happening in 2019, that wouldn't be",
-    "start": 8396.827913043478,
-    "end": 8402.90234782609
-  },
-  {
-    "text": "fiscally responsible. And I say it from the vantage point of we had a lot of service that was out on the street, maybe that yielded one passenger boarding per hour, but that was out on",
-    "start": 8403.362,
-    "end": 8413.116305555579
-  },
-  {
-    "text": "the street. Does that really yield the return on investment",
-    "start": 8413.716,
-    "end": 8416.8156
-  },
-  {
-    "text": "going forward? Hence that's why there were modifications relative to reallocation of services",
-    "start": 8417.281,
     "end": 8424.121399999998
   },
   {
-    "text": "going forward. Karen",
+    "text": "Karen Benker: OK. But if I can--",
     "start": 8425.22,
-    "end": 8425.5126
+    "end": 8426.390400000002
   },
   {
-    "text": "Benker: OK. But if I can-- Julien Bouquet:",
-    "start": 8425.5126,
+    "text": "Julien Bouquet: Treasurer, yeah.",
+    "start": 8426.823,
     "end": 8427.8055
   },
   {
-    "text": "Treasurer, yeah. Karen Benker: Some of the issues that you just raised",
+    "text": "Karen Benker: Some of the issues that you just raised are important. There's no doubt. However, I don't believe it goes to the equity calculation. What I think is important to hear from staff-- and I know we're going to be talking about this at our retreat, which I'm looking forward to that-- is if it's possible for us to go back to over 100 million riders in three years. What barriers are we facing to try to do that so that we can go from 65 million to 100, 106, 110, and start quickly-- or not quickly, but faster than what we're doing now to get back up to higher service levels?",
     "start": 8428.868,
-    "end": 8432.440099999998
-  },
-  {
-    "text": "are important. There's",
-    "start": 8433.037,
-    "end": 8433.451666666668
-  },
-  {
-    "text": "no doubt. However, I don't believe it goes to the",
-    "start": 8434.02,
-    "end": 8437.8441
-  },
-  {
-    "text": "equity calculation. What I think is important to hear from staff-- and I know we're going to be talking about this at our retreat, which I'm looking forward to that-- is if it's possible for us to go back to over 100 million riders in",
-    "start": 8442.914,
-    "end": 8458.277021276564
-  },
-  {
-    "text": "three years. What barriers are we facing to try to do that so that we can go from 65 million to 100, 106, 110, and start quickly-- or not quickly, but faster than what we're doing now to get back up to higher",
-    "start": 8459.283,
     "end": 8478.392999999996
   },
   {
-    "text": "service levels? Julien",
+    "text": "Julien Bouquet: Ms. Johnson.",
     "start": 8480.81,
-    "end": 8480.81
-  },
-  {
-    "text": "Bouquet:",
-    "start": 8481.01,
     "end": 8481.01
   },
   {
-    "text": "Ms. Johnson. Debra Johnson:",
+    "text": "Debra Johnson: Thank you. There's a couple of external factors that play into that quite naturally. When we look at the central business district and the occupancy rate in the lack of people commuting in, it's important to keep in mind that there was-- I'm forgetting the name, but the City and County of Denver did the report relative to the usage rate in looking at the occupancy levels. But more specifically, what's important to note is that there hasn't been the level of bounce back relative to the central business district. I believe the last time I looked at stats, City and County of Denver was in the bottom three out of 50 major cities. And then as we know, the state of Colorado is the number-- is the third state relative to remote work and then city of Boulder is number one. While I factor that in, we don't have the same operating environment that we did in 2019 or prior to the pandemic. How do we get back to the transit usage that we had before? I think there's so many extenuating factors going forward relative to how we're delivering the service, but also having the vehicle capacity, the people power, and the reliability aspect, which bring us full circle to state of good repair, and the other aspects that have caused people to shy away from utilizing our network because we were sacrificing one element for something else relative to delivery. And I bring that up because as we talk about the people power, we clearly saw that our operating workforce was decreasing in 2016 as it was across the country, but more specifically, having other ancillary services that were readily available were people whereby were working extra shifts, and then we didn't have enough people for daily pull out on those other routes. And so I'm providing that context to say, to get back, there are certain things that the agency can surely do. But to get back to those numbers within the period of time that you specify would be very challenging, just because of the different operating characteristics that have been altered by factors that are no fault of this agency's.",
     "start": 8481.01,
-    "end": 8481.8315
-  },
-  {
-    "text": "Thank you. There's a couple of external factors that play into that",
-    "start": 8482.893,
-    "end": 8486.174142857142
-  },
-  {
-    "text": "quite naturally. When we look at the central business district and the occupancy rate in the lack of people commuting in, it's important to keep in mind that there was-- I'm forgetting the name, but the City and County of Denver did the report relative to the usage rate in looking at the",
-    "start": 8486.504285714285,
-    "end": 8504.810529411752
-  },
-  {
-    "text": "occupancy levels. But more specifically, what's important to note is that there hasn't been the level of bounce back relative to the central",
-    "start": 8505.421,
-    "end": 8514.205857142853
-  },
-  {
-    "text": "business district. I believe the last time I looked at stats, City and County of Denver was in the bottom three out of 50",
-    "start": 8515.78,
-    "end": 8526.222307692302
-  },
-  {
-    "text": "major cities. And then as we know, the state of Colorado is the number-- is the third state relative to remote work and then city of Boulder is",
-    "start": 8526.66,
-    "end": 8536.454250000012
-  },
-  {
-    "text": "number one. While I factor that in, we don't have the same operating environment that we did in 2019 or prior to",
-    "start": 8537.178,
-    "end": 8544.572863636346
-  },
-  {
-    "text": "the pandemic. How do we get back to the transit usage that we",
-    "start": 8545.285,
-    "end": 8554.007153846153
-  },
-  {
-    "text": "had before? I think there's so many extenuating factors going forward relative to how we're delivering the service, but also having the vehicle capacity, the people power, and the reliability aspect, which bring us full circle to state of good repair, and the other aspects that have caused people to shy away from utilizing our network because we were sacrificing one element for something else relative",
-    "start": 8555.394,
-    "end": 8582.792140350875
-  },
-  {
-    "text": "to delivery. And I bring that up because as we talk about the people power, we clearly saw that our operating workforce was decreasing in 2016 as it was across the country, but more specifically, having other ancillary services that were readily available were people whereby were working extra shifts, and then we didn't have enough people for daily pull out on those",
-    "start": 8583.726,
-    "end": 8610.945448979557
-  },
-  {
-    "text": "other routes. And so I'm providing that context to say, to get back, there are certain things that the agency can",
-    "start": 8611.862,
-    "end": 8620.393461538464
-  },
-  {
-    "text": "surely do. But to get back to those numbers within the period of time that you specify would be very challenging, just because of the different operating characteristics that have been altered by factors that are no fault of",
-    "start": 8620.777750000003,
     "end": 8635.380711538475
   },
   {
-    "text": "this agency's. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Ruscha.",
     "start": 8637.854,
     "end": 8638.315
   },
   {
-    "text": "Director Ruscha. Joyann Ruscha: Thank",
+    "text": "Joyann Ruscha: Thank you, sir. So I have a question for legal. So recognizing this has to be submitted shortly, I-- I'm going to be careful with my words. Can we make significant changes at this juncture after all of the public comment process? Or is that something that we-- I guess I don't know if it's a yes, no, or a gray area, and I wanted to get a bit of feedback on that. Not to disparage the motion. I just also want to understand the potential legal implications.",
     "start": 8638.315,
-    "end": 8638.315
-  },
-  {
-    "text": "you, sir. So I have a question",
-    "start": 8638.315,
-    "end": 8641.294375
-  },
-  {
-    "text": "for legal. So recognizing this has to be submitted shortly, I-- I'm going to be careful with",
-    "start": 8643.142,
-    "end": 8652.700749999996
-  },
-  {
-    "text": "my words. Can we make significant changes at this juncture after all of the public",
-    "start": 8655.141,
-    "end": 8664.675874999997
-  },
-  {
-    "text": "comment process? Or is that something that we-- I guess I don't know if it's a yes, no, or a gray area, and I wanted to get a bit of feedback",
-    "start": 8665.356937499997,
-    "end": 8673.716333333308
-  },
-  {
-    "text": "on that. Not to disparage",
-    "start": 8674.422,
-    "end": 8675.650533333335
-  },
-  {
-    "text": "the motion. I just also want to understand the potential",
-    "start": 8675.957666666669,
     "end": 8678.721866666672
   },
   {
-    "text": "legal implications. Debra Johnson: I will address that question and then I'll",
+    "text": "Debra Johnson: I will address that question and then I'll ask Mr. Green to expound. I think if anything, as we talk about public engagement and talk about the agencies, the perception of the agency being trustworthy, going forward and getting public engagement quite naturally and then not leveraging it for the betterment of the constituencies that we serve, I think, pose a risk as it relates to the agency in reference to the public perception. There is leeway relative to the circular in light of what can be done. We are sitting here on May 28, recognizing that we have a new administration and that we do need to have a Title VI program that's submitted, and we have been engaged on this topic since January. That's not to negate any amendments or anything like that. I am just trying to answer the question. But more specifically, Mr. Green, since you are very well versed in 4702.1b, would yield the floor to you. And that's the citation for the FTA circular that we're talking about.",
     "start": 8684.175,
-    "end": 8688.029769230767
-  },
-  {
-    "text": "ask Mr. Green",
-    "start": 8688.458076923074,
-    "end": 8689.31469230769
-  },
-  {
-    "text": "to expound. I think if anything, as we talk about public engagement and talk about the agencies, the perception of the agency being trustworthy, going forward and getting public engagement quite naturally and then not leveraging it for the betterment of the constituencies that we serve, I think, pose a risk as it relates to the agency in reference to the",
-    "start": 8689.823,
-    "end": 8716.761399999988
-  },
-  {
-    "text": "public perception. There is leeway relative to the circular in light of what can",
-    "start": 8717.69,
-    "end": 8723.211285714293
-  },
-  {
-    "text": "be done. We are sitting here on May 28, recognizing that we have a new administration and that we do need to have a Title VI program that's submitted, and we have been engaged on this topic",
-    "start": 8723.696,
-    "end": 8736.435135135125
-  },
-  {
-    "text": "since January. That's not to negate any amendments or anything",
-    "start": 8737.23,
-    "end": 8739.607799999996
-  },
-  {
-    "text": "like that. I am just trying to answer",
-    "start": 8739.953,
-    "end": 8742.10725
-  },
-  {
-    "text": "the question. But more",
-    "start": 8742.665,
-    "end": 8743.793631578948
-  },
-  {
-    "text": "specifically, Mr. Green, since you are very well versed in 4702.1b, would yield the floor",
-    "start": 8744.169842105264,
-    "end": 8749.436789473686
-  },
-  {
-    "text": "to you. And that's the citation for the FTA circular that we're",
-    "start": 8749.853,
     "end": 8753.579250000008
   },
   {
-    "text": "talking about. Carl",
+    "text": "Carl Green: Yes. Thank you so much, GM/CEO Johnson. Oh. Apologies. Apologies.",
     "start": 8754.359,
-    "end": 8754.359
-  },
-  {
-    "text": "Green: Yes. Thank you so much,",
-    "start": 8754.65425,
-    "end": 8756.425749999995
-  },
-  {
-    "text": "GM/CEO",
-    "start": 8757.522,
-    "end": 8757.522
-  },
-  {
-    "text": "Johnson.",
-    "start": 8759.024000000001,
-    "end": 8759.024000000001
-  },
-  {
-    "text": "Oh.",
-    "start": 8762.388,
     "end": 8762.388
   },
   {
-    "text": "Apologies. Apologies. Julien Bouquet:",
+    "text": "Julien Bouquet: Sensitive microphone.",
     "start": 8762.855333333335,
     "end": 8764.05025
   },
   {
-    "text": "Sensitive microphone. Carl",
+    "text": "Carl Green: Yes. Apologies. But to piggyback off of what GM/CEO Johnson has noted, I would couch that as the bigger risk is when we think about establishing policy as it relates to 4702.1b, the FTA Title VI circular, it does call upon the agency to do a lot of outreach and public involvement to ensure that we are collecting that feedback to inform decisions. So at the ground level, if we think about public involvement in Title VI, it's part and parcel of what the Title VI program stands for, ensuring that folks in the community are able to inform the decision, such as the policy. But with respect to the circular, we can, i.e. the Board of Directors could adopt a different threshold. So, for example, the one that Director Benker has put forth. Although we received a lot of feedback indicating the 25% threshold and 36 month cumulative change, et cetera, all that's packaged in within the proposed update, there is an exception to that within the circular where it states where the Board is ultimately approving the policy.",
     "start": 8764.290500000001,
-    "end": 8765.071
-  },
-  {
-    "text": "Green:",
-    "start": 8765.621500000001,
-    "end": 8765.621500000001
-  },
-  {
-    "text": "Yes. Apologies. But to piggyback off of what GM/CEO Johnson has noted, I would couch that as the bigger risk is when we think about establishing policy as it relates to 4702.1b, the FTA Title VI circular, it does call upon the agency to do a lot of outreach and public involvement to ensure that we are collecting that feedback to",
-    "start": 8766.232,
-    "end": 8792.335884615402
-  },
-  {
-    "text": "inform decisions. So at the ground level, if we think about public involvement in Title VI, it's part and parcel of what the Title VI program stands for, ensuring that folks in the community are able to inform the decision, such as",
-    "start": 8793.259,
-    "end": 8806.322380952379
-  },
-  {
-    "text": "the policy. But with respect to the circular, we can, i.e. the Board of Directors could adopt a",
-    "start": 8807.7595,
-    "end": 8815.280888888896
-  },
-  {
-    "text": "different threshold. So, for example, the one that Director Benker has",
-    "start": 8815.757,
-    "end": 8819.296189189196
-  },
-  {
-    "text": "put forth. Although we received a lot of feedback indicating the 25% threshold and 36 month cumulative change, et cetera, all that's packaged in within the proposed update, there is an exception to that within the circular where it states where the Board is ultimately approving",
-    "start": 8819.650108108115,
     "end": 8836.517600000003
   },
   {
-    "text": "the policy. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Director Ruscha? OK. Director Guissinger and then Director Larsen. Oh, perfect. Director Larsen. And then Harwick.",
     "start": 8838.768,
-    "end": 8838.968
-  },
-  {
-    "text": "Thank you.",
-    "start": 8840.009,
-    "end": 8840.009
-  },
-  {
-    "text": "Director",
-    "start": 8840.009,
-    "end": 8840.009
-  },
-  {
-    "text": "Ruscha? OK. Director Guissinger and then",
-    "start": 8840.009,
-    "end": 8843.279000000002
-  },
-  {
-    "text": "Director Larsen.",
-    "start": 8847.536,
-    "end": 8847.536
-  },
-  {
-    "text": "Oh, perfect.",
-    "start": 8847.536,
-    "end": 8847.8402
-  },
-  {
-    "text": "Director Larsen. And",
-    "start": 8848.144400000001,
     "end": 8848.752800000002
   },
   {
-    "text": "then Harwick. Matt Larsen:",
+    "text": "Matt Larsen: Thank you. I guess my question is, I looked through a lot of the Title VI updates that were for service changes, this Title VI analyses that were in the Board packet. And it seemed like most of the time-- sometimes there was a little bit of disparate impact on one route or the other, but mostly it sort of ended up that, in the aggregate, there wasn't really much, and there were legitimate justifications for what there was on an individual basis. I guess my basic question is with regard to this update and the changes that we're proposing. I mean, is there really a problem here? Are we just making this harder for ourselves? Because it doesn't seem like we're trying to generally start out making service changes with an intention of causing disparate impact, one place or the other. We make them, I guess, for a variety of reasons, and on balance they don't really seem to, under our current setup, ever, ever look like they were somehow some bad intent or just inattention to who we are serving. It seems we do a lot of analysis and then basically do what we would have done anyways. So why put a greater burden, regulate ourselves more than we have to? And why not just give us the freedom to operate as we would as much as we can, given that we don't-- it doesn't necessarily seem like it's been a problem for a long time? At least from what I could see. I mean, there weren't that many Title VI complaints in the information that was provided. I don't know. My basic question is, why would we make things harder for ourselves? Thanks.",
     "start": 8851.219,
-    "end": 8851.4395
-  },
-  {
-    "text": "Thank you. I guess my question is, I looked through a lot of the Title VI updates that were for service changes, this Title VI analyses that were in the",
-    "start": 8853.221,
-    "end": 8869.094
-  },
-  {
-    "text": "Board packet. And it seemed like most of the time-- sometimes there was a little bit of disparate impact on one route or the other, but mostly it sort of ended up that, in the aggregate, there wasn't really much, and there were legitimate justifications for what there was on an",
-    "start": 8870.022,
-    "end": 8890.488000000008
-  },
-  {
-    "text": "individual basis. I guess my basic question is with regard to this update and the changes that",
-    "start": 8891.728,
-    "end": 8899.937090909096
-  },
-  {
-    "text": "we're proposing. I mean, is there really a",
-    "start": 8901.400727272734,
-    "end": 8903.9620909091
-  },
-  {
-    "text": "problem here? Are we just making this harder",
-    "start": 8904.368,
-    "end": 8906.260625
-  },
-  {
-    "text": "for ourselves? Because it doesn't seem like we're trying to generally start out making service changes with an intention of causing disparate impact, one place or",
-    "start": 8906.591,
-    "end": 8917.296769230754
-  },
-  {
-    "text": "the other. We make them, I guess, for a variety of reasons, and on balance they don't really seem to, under our current setup, ever, ever look like they were somehow some bad intent or just inattention to who we",
-    "start": 8917.785,
-    "end": 8939.124161290338
-  },
-  {
-    "text": "are serving. It seems we do a lot of analysis and then basically do what we would have",
-    "start": 8939.581,
-    "end": 8945.36942105264
-  },
-  {
-    "text": "done anyways. So why put a greater burden, regulate ourselves more than we",
-    "start": 8946.059,
-    "end": 8951.250999999987
-  },
-  {
-    "text": "have to? And why not just give us the freedom to operate as we would as much as we can, given that we don't-- it doesn't necessarily seem like it's been a problem for a",
-    "start": 8951.59713333332,
-    "end": 8964.057933333292
-  },
-  {
-    "text": "long time? At least from what I",
-    "start": 8964.404066666624,
-    "end": 8966.48086666662
-  },
-  {
-    "text": "could see. I mean, there weren't that many Title VI complaints in the information that",
-    "start": 8966.848,
-    "end": 8974.81945000001
-  },
-  {
-    "text": "was provided. I",
-    "start": 8975.725,
-    "end": 8975.966333333332
-  },
-  {
-    "text": "don't know. My basic question is, why would we make things harder",
-    "start": 8977.293,
-    "end": 8980.130999999998
-  },
-  {
-    "text": "for",
-    "start": 8980.751,
     "end": 8980.751
   },
   {
-    "text": "ourselves? Thanks. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Ms. Johnson.",
     "start": 8982.762,
-    "end": 8983.056666666667
-  },
-  {
-    "text": "Thank",
-    "start": 8983.351333333334,
-    "end": 8983.351333333334
-  },
-  {
-    "text": "you.",
-    "start": 8983.687,
     "end": 8983.687
   },
   {
-    "text": "Ms. Johnson. Debra Johnson: Thank you",
+    "text": "Debra Johnson: Thank you very much. The one thing I would share, Director Larsen, is we look at the modification that's been put forward for your consideration, like a 36 month period as we're adding back service. There could be unforeseen consequences as we do them in a segmented fashion. And so that's one element as a whole. Because if we're making modifications going forward, there could be an adverse impact. And so that's what I would showcase there. Keeping in mind to the point that you raised. When we talk about the aspects of DIDB, it's what can we do as an agency to help mitigate that to your point going forward. But it's just to ensure that we have a program whereby we are not causing undue harm to certain population segments.",
     "start": 8983.687,
-    "end": 8986.096749999999
-  },
-  {
-    "text": "very much. The one thing I would share, Director Larsen, is we look at the modification that's been put forward for your consideration, like a 36 month period as we're adding",
-    "start": 8986.292,
-    "end": 8997.773136363636
-  },
-  {
-    "text": "back service. There could be unforeseen consequences as we do them in a",
-    "start": 8998.15584090909,
-    "end": 9002.748295454545
-  },
-  {
-    "text": "segmented fashion. And so that's one element as",
-    "start": 9003.471,
-    "end": 9006.654666666667
-  },
-  {
-    "text": "a whole. Because if we're making modifications going forward, there could be an",
-    "start": 9007.109476190477,
-    "end": 9012.567190476193
-  },
-  {
-    "text": "adverse impact. And so that's what I would",
-    "start": 9013.34,
-    "end": 9015.442625000005
-  },
-  {
-    "text": "showcase there. Keeping in mind to the point that",
-    "start": 9016.524,
-    "end": 9019.356235294117
-  },
-  {
-    "text": "you raised. When we talk about the aspects of DIDB, it's what can we do as an agency to help mitigate that to your point",
-    "start": 9019.710264705882,
-    "end": 9028.206970588235
-  },
-  {
-    "text": "going forward. But it's just to ensure that we have a program whereby we are not causing undue harm to certain",
-    "start": 9028.802,
     "end": 9040.53247619046
   },
   {
-    "text": "population segments. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 9043.158,
     "end": 9043.158
   },
   {
-    "text": "Director Larsen. Matt Larsen: But it just seems like, when I was reading the documents, that there's always a legitimate justification for everything we want to do or there's always this will have a disparate impact but we have a legitimate justification for doing this so we're just going to",
+    "text": "Matt Larsen: But it just seems like, when I was reading the documents, that there's always a legitimate justification for everything we want to do or there's always this will have a disparate impact but we have a legitimate justification for doing this so we're just going to do it. I mean, how many times in the last however many years has it been that we did this analysis, we looked at all the service changes we wanted to do, and we were like, OK, no, we're not going to do this list of service changes. We're going to cross out these ones because the aggregate impact is too much. I mean, does that happen? I just didn't-- from what I read in the packet, I don't know if I caught everything, but it didn't seem like there were a lot of those. Or is this happening at an earlier stage where when Bob and service says, let's just send a bunch of buses to Cherry Hills Village, somebody says, no, no, that's not going to work out, before it even gets to this point. You know?",
     "start": 9043.158,
-    "end": 9059.971303571434
-  },
-  {
-    "text": "do it. I mean, how many times in the last however many years has it been that we did this analysis, we looked at all the service changes we wanted to do, and we were like, OK, no, we're not going to do this list of",
-    "start": 9060.797,
-    "end": 9074.344875000013
-  },
-  {
-    "text": "service changes. We're going to cross out these ones because the aggregate impact is",
-    "start": 9074.664,
-    "end": 9080.52243750001
-  },
-  {
-    "text": "too much. I mean, does",
-    "start": 9081.493,
-    "end": 9083.1881875
-  },
-  {
-    "text": "that happen? I just didn't-- from what I read in the packet, I don't know if I caught everything, but it didn't seem like there were a lot",
-    "start": 9083.43478125,
-    "end": 9090.339406250003
-  },
-  {
-    "text": "of those. Or is this happening at an earlier stage where when Bob and service says, let's just send a bunch of buses to Cherry Hills Village, somebody says, no, no, that's not going to work out, before it even gets to",
-    "start": 9090.846,
-    "end": 9103.838249999993
-  },
-  {
-    "text": "this point.",
-    "start": 9105.399,
     "end": 9105.548999999999
   },
   {
-    "text": "You know? Debra Johnson:",
+    "text": "Debra Johnson: I'm sorry. Thank you for the question. For me, I've only been here for five years, and I came in the height of the pandemic, and we've been adding back service and not. So that's difficult for me to answer just because we have not been in a situation whereby it's been the opposite. Carl, do you have anything to add?",
     "start": 9108.102,
-    "end": 9108.342
-  },
-  {
-    "text": "I'm sorry. Thank you for",
-    "start": 9109.323,
-    "end": 9110.140600000002
-  },
-  {
-    "text": "the question. For me, I've only been here for five years, and I came in the height of the pandemic, and we've been adding back service",
-    "start": 9110.630444444445,
-    "end": 9116.766555555563
-  },
-  {
-    "text": "and not. So that's difficult for me to answer just because we have not been in a situation whereby it's been",
-    "start": 9117.413,
-    "end": 9129.032500000001
-  },
-  {
-    "text": "the opposite. Carl, do you have anything",
-    "start": 9129.954,
     "end": 9131.910857142853
   },
   {
-    "text": "to add? Carl Green: Yeah, I would just highlight, Chairman, if",
+    "text": "Carl Green: Yeah, I would just highlight, Chairman, if I may. Since January 2023, there was about 270 service change recommendations that have been implemented, and roughly 24-26 of those 276 were considered major service changes. And out of that 26, to Director Larsen's point, there has been 13 potential disparate impacts. And to your point, there was a substantial legitimate justification. I wouldn't necessarily couch it as an exercise, but I would say we work, the Transit Equity Office within the Civil Rights Division, works hand in glove with Jessie Carter and his team, Service Development. And as we are having those conversations after the service change recommendation are put forth and we analyze it, if there is a potential disparate impact, more often than not, to your point and to my earlier earlier point, that Title VI is not a stopping mechanism. And I wouldn't necessarily state that it's burdensome because it's one of our responsibilities to make sure that we are equitably distributing services across our service area. But more often than not, there is a legitimate justification to put forth the service recommendation as it is presented to the Board.",
     "start": 9132.838,
-    "end": 9135.928133333333
-  },
-  {
-    "text": "I may. Since January 2023, there was about 270 service change recommendations that have been implemented, and roughly 24-26 of those 276 were considered major",
-    "start": 9136.501699999999,
-    "end": 9151.414433333315
-  },
-  {
-    "text": "service changes. And out of that 26, to Director Larsen's point, there has been 13 potential",
-    "start": 9152.508,
-    "end": 9158.98800000001
-  },
-  {
-    "text": "disparate impacts. And to your point, there was a substantial",
-    "start": 9160.301,
-    "end": 9163.943171428571
-  },
-  {
-    "text": "legitimate justification. I wouldn't necessarily couch it as an exercise, but I would say we work, the Transit Equity Office within the Civil Rights Division, works hand in glove with Jessie Carter and his team,",
-    "start": 9165.157228571428,
-    "end": 9178.870749999993
-  },
-  {
-    "text": "Service Development. And as we are having those conversations after the service change recommendation are put forth and we analyze it, if there is a potential disparate impact, more often than not, to your point and to my earlier earlier point, that Title VI is not a",
-    "start": 9180.03,
-    "end": 9193.482047619034
-  },
-  {
-    "text": "stopping mechanism. And I wouldn't necessarily state that it's burdensome because it's one of our responsibilities to make sure that we are equitably distributing services across our",
-    "start": 9194.294,
-    "end": 9204.67377777778
-  },
-  {
-    "text": "service area. But more often than not, there is a legitimate justification to put forth the service recommendation as it is presented to",
-    "start": 9205.694,
     "end": 9212.884590909076
   },
   {
-    "text": "the Board. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Director? OK. I had Director Harwick. And just as a reminder, we're currently in discussion regarding this first motion. Just want to make sure that-- first amendment, excuse me. First amendment. So make sure comments are around that. Director Harwick.",
     "start": 9215.941,
-    "end": 9216.528666666667
-  },
-  {
-    "text": "Thank",
-    "start": 9217.116333333333,
-    "end": 9217.116333333333
-  },
-  {
-    "text": "you.",
-    "start": 9219.827,
-    "end": 9219.827
-  },
-  {
-    "text": "Director? OK. I had",
-    "start": 9220.303166666667,
-    "end": 9221.371666666666
-  },
-  {
-    "text": "Director Harwick. And just as a reminder, we're currently in discussion regarding this",
-    "start": 9221.727833333332,
-    "end": 9226.00183333333
-  },
-  {
-    "text": "first motion. Just want to make sure that-- first amendment,",
-    "start": 9226.438,
-    "end": 9229.858769230761
-  },
-  {
-    "text": "excuse me.",
-    "start": 9230.200846153837,
-    "end": 9230.542923076913
-  },
-  {
-    "text": "First amendment. So make sure comments are",
-    "start": 9230.905,
-    "end": 9233.954375000001
-  },
-  {
-    "text": "around that.",
-    "start": 9234.43,
     "end": 9234.940999999999
   },
   {
-    "text": "Director Harwick. Ian Harwick: Mine will be comments about this but also moving forward as well, because I am in support of this",
+    "text": "Ian Harwick: Mine will be comments about this but also moving forward as well, because I am in support of this Title VI. Not the amendment, just a straight Title VI. I don't think moving from 10% to 20% is going to increase ridership. I think that right now it allows our staff the ability to really center equity and effectively protect our communities. And while I get that Broomfield feels like they want more service, I don't think this is going to get it there. I think this is the 11th hour, and I think that it's really imperative that our staff has worked extremely hard on this. They've had to jump through a whole variety of hoops for a bunch of different Board members. And I think that we're here, they've done an incredible job. And I think that this is-- they are the subject matter experts, and it's our opportunity here to put our trust in them, our belief in them. And I think that we owe them that. And we have been talking about this since January, so we're well into four months. And I think that it is key that we support this Title Vi as is, and we allow them to move forward and we allow them to start handing this off to the feds and we can move forward. That's where I'm at. Thank you.",
     "start": 9234.940999999999,
-    "end": 9243.296727272718
-  },
-  {
-    "text": "Title VI. Not the amendment, just a straight",
-    "start": 9243.878606060596,
-    "end": 9246.497060606047
-  },
-  {
-    "text": "Title VI. I don't think moving from 10% to 20% is going to",
-    "start": 9249.504857142856,
-    "end": 9258.276666666661
-  },
-  {
-    "text": "increase ridership. I think that right now it allows our staff the ability to really center equity and effectively protect",
-    "start": 9259.091,
-    "end": 9268.779100000018
-  },
-  {
-    "text": "our communities. And while I get that Broomfield feels like they want more service, I don't think this is going to get",
-    "start": 9269.369,
-    "end": 9275.813136363648
-  },
-  {
-    "text": "it there. I think this is the 11th hour, and I think that it's really imperative that our staff has worked extremely hard",
-    "start": 9276.758,
-    "end": 9281.538695652192
-  },
-  {
-    "text": "on this. They've had to jump through a whole variety of hoops for a bunch of different",
-    "start": 9281.796,
-    "end": 9289.255935064932
-  },
-  {
-    "text": "Board members. And I think that we're here, they've done an",
-    "start": 9289.583168831165,
-    "end": 9292.855506493494
-  },
-  {
-    "text": "incredible job. And I think that this is-- they are the subject matter experts, and it's our opportunity here to put our trust in them, our belief",
-    "start": 9293.182740259726,
-    "end": 9301.690818181782
-  },
-  {
-    "text": "in them. And I think that we owe",
-    "start": 9302.018051948015,
-    "end": 9304.308688311645
-  },
-  {
-    "text": "them that. And we have been talking about this since January, so we're well into",
-    "start": 9304.635922077878,
-    "end": 9309.217194805138
-  },
-  {
-    "text": "four months. And I think that it is key that we support this Title Vi as is, and we allow them to move forward and we allow them to start handing this off to the feds and we can",
-    "start": 9309.544428571371,
-    "end": 9320.526457142849
-  },
-  {
-    "text": "move forward. That's where",
-    "start": 9321.036971428563,
-    "end": 9321.802742857133
-  },
-  {
-    "text": "I'm at.",
-    "start": 9322.178,
     "end": 9322.318500000001
   },
   {
-    "text": "Thank you. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Director. Any further conversation on this amendment? Secretary Nicholson.",
     "start": 9322.819,
-    "end": 9323.88594736842
-  },
-  {
-    "text": "you, Director. Any further conversation on",
-    "start": 9324.419421052631,
-    "end": 9327.086789473684
-  },
-  {
-    "text": "this amendment?",
-    "start": 9327.620263157894,
     "end": 9328.153736842105
   },
   {
-    "text": "Secretary Nicholson. Chris Nicholson: So this is for our deputy",
+    "text": "Chris Nicholson: So this is for our deputy General Counsel. If we were to pass this tonight, what's the legal risk to the agency when it comes to our federal Title VI approval as a result of this change? Is this going to have any-- would this have any legal repercussions or could we just feel pretty comfortable that we could do this and not have the federal government take issue with it?",
     "start": 9328.153736842105,
-    "end": 9332.42152631579
-  },
-  {
-    "text": "General Counsel. If we were to pass this tonight, what's the legal risk to the agency when it comes to our federal Title VI approval as a result of",
-    "start": 9333.222,
-    "end": 9344.979103448282
-  },
-  {
-    "text": "this change? Is this going to have any-- would this have any legal repercussions or could we just feel pretty comfortable that we could do this and not have the federal government take issue",
-    "start": 9345.884361111112,
     "end": 9357.592638888873
   },
   {
-    "text": "with it? Julien Bouquet: In regards to the",
+    "text": "Julien Bouquet: In regards to the amendment, Secretary?",
     "start": 9359.319,
     "end": 9360.437333333333
   },
   {
-    "text": "amendment, Secretary? Chris",
+    "text": "Chris Nicholson: Yeah.",
     "start": 9361.222,
     "end": 9361.222
   },
   {
-    "text": "Nicholson: Yeah. Julien",
-    "start": 9364.745,
-    "end": 9364.745
-  },
-  {
-    "text": "Bouquet: OK.",
+    "text": "Julien Bouquet: OK. Deputy Counsel.",
     "start": 9364.745,
     "end": 9365.0455
   },
   {
-    "text": "Deputy Counsel. Melanie Snyder: There",
+    "text": "Melanie Snyder: There we go. Excuse me. Thank you, Director Nicholson. I don't have concerns.",
     "start": 9369.252,
-    "end": 9369.479333333333
-  },
-  {
-    "text": "we go.",
-    "start": 9369.613,
-    "end": 9369.8635
-  },
-  {
-    "text": "Excuse me. Thank you,",
-    "start": 9370.931400000001,
-    "end": 9371.760600000003
-  },
-  {
-    "text": "Director Nicholson. I don't",
-    "start": 9373.005333333333,
     "end": 9373.646333333332
   },
   {
-    "text": "have concerns. Julien",
+    "text": "Julien Bouquet: Secretary.",
     "start": 9376.785,
     "end": 9376.785
   },
   {
-    "text": "Bouquet: Secretary. Chris Nicholson: That",
+    "text": "Chris Nicholson: That is all.",
     "start": 9379.028,
     "end": 9379.388666666668
   },
   {
-    "text": "is all. Julien Bouquet: Yeah,",
+    "text": "Julien Bouquet: Yeah, Treasurer Benker.",
     "start": 9380.771,
     "end": 9381.522500000001
   },
   {
-    "text": "Treasurer Benker. Karen Benker: Here is where I do",
+    "text": "Karen Benker: Here is where I do not understand. In 2019, we had the service. My area, my district, as many others, have grown. For example, the town of Erie just a few years ago was 20,000. Now it's 40,000 two, three years later. And when I met with Erie, they said, hey, we're planning on going to 80,000 in just the next couple of years. I also read in the Denver Post that the town of Erie is the 15th fastest city in the country in terms of population growth. So my question is if we had this service prior to the pandemic and it was serving all of these communities, why is it so difficult to get that restored?",
     "start": 9383.856,
-    "end": 9389.369999999994
-  },
-  {
-    "text": "not understand. In 2019, we had",
-    "start": 9389.98266666666,
-    "end": 9394.678750000003
-  },
-  {
-    "text": "the service. My area, my district, as many others,",
-    "start": 9396.359,
-    "end": 9400.265666666663
-  },
-  {
-    "text": "have grown. For example, the town of Erie just a few years ago",
-    "start": 9405.177,
-    "end": 9409.709571428572
-  },
-  {
-    "text": "was 20,000. Now it's 40,000 two, three",
-    "start": 9410.087285714286,
-    "end": 9412.731285714286
-  },
-  {
-    "text": "years later. And when I met with Erie, they said, hey, we're planning on going to 80,000 in just the next couple",
-    "start": 9413.149,
-    "end": 9420.818523809527
-  },
-  {
-    "text": "of years. I also read in the Denver Post that the town of Erie is the 15th fastest city in the country in terms of",
-    "start": 9421.943,
-    "end": 9432.191960000011
-  },
-  {
-    "text": "population growth. So my question is if we had this service prior to the pandemic and it was serving all of these communities, why is it so difficult to get",
-    "start": 9433.561,
     "end": 9448.681967741932
   },
   {
-    "text": "that restored? Julien",
+    "text": "Julien Bouquet: Ms. Johnson.",
     "start": 9453.332,
     "end": 9453.6425
   },
   {
-    "text": "Bouquet:",
+    "text": "Debra Johnson: So thank you, Director Benker. What I'm going to say goes back to the previous comments that I had before, recognizing that RTD is a regional service, and the way the service was outlined, for all intents and purposes, was bringing individuals into the central business district. That level of ridership isn't there. And that's not to negate that there is some elements centered on a need to move people to and fro. Hence, that's why there was the advent of the partnership program and one of the reasons why Erie basically wanted to join the district, because they were looking to put forward an application for the partnership program. And I know you're just using that as an example, but just wanted to further iterate that, because for all intents and purposes, as we're looking to provide mobility options, the intent behind the partnership program was more or less like a pilot in the sense that let's see how many people are utilizing this means of connection prior to putting out a 40 foot or 60 foot R tick that costs more money per revenue hour and doesn't yield the same return on investment relative to the cost per boarding. Does that help or did I complicate it more? No? OK.",
     "start": 9453.6425,
-    "end": 9453.6425
-  },
-  {
-    "text": "Ms. Johnson. Debra Johnson: So thank you,",
-    "start": 9453.6425,
-    "end": 9459.718199999998
-  },
-  {
-    "text": "Director Benker. What I'm going to say goes back to the previous comments that I had before, recognizing that RTD is a regional service, and the way the service was outlined, for all intents and purposes, was bringing individuals into the central",
-    "start": 9462.986395348837,
-    "end": 9482.190604651136
-  },
-  {
-    "text": "business district. That level of ridership",
-    "start": 9485.121,
-    "end": 9487.300230769233
-  },
-  {
-    "text": "isn't there. And that's not to negate that there is some elements centered on a need to move people to",
-    "start": 9487.73607692308,
-    "end": 9496.703615384613
-  },
-  {
-    "text": "and fro. Hence, that's why there was the advent of the partnership program and one of the reasons why Erie basically wanted to join the district, because they were looking to put forward an application for the",
-    "start": 9497.161,
-    "end": 9509.77307692308
-  },
-  {
-    "text": "partnership program. And I know you're just using that as an example, but just wanted to further iterate that, because for all intents and purposes, as we're looking to provide mobility options, the intent behind the partnership program was more or less like a pilot in the sense that let's see how many people are utilizing this means of connection prior to putting out a 40 foot or 60 foot R tick that costs more money per revenue hour and doesn't yield the same return on investment relative to the cost",
-    "start": 9510.135,
-    "end": 9546.103508196667
-  },
-  {
-    "text": "per boarding. Does that help or did I complicate",
-    "start": 9548.11,
-    "end": 9550.650999999996
-  },
-  {
-    "text": "it",
-    "start": 9551.855,
-    "end": 9551.855
-  },
-  {
-    "text": "more?",
-    "start": 9553.1765,
     "end": 9553.1765
   },
   {
-    "text": "No? OK. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Director Guzman and then Director Guissinger.",
     "start": 9554.518,
-    "end": 9554.678
-  },
-  {
-    "text": "Thank you. Director Guzman and then",
-    "start": 9555.099,
     "end": 9556.59983333333
   },
   {
-    "text": "Director Guissinger. Michael Guzman: So I would urge us to cleanly pass this through tonight, getting back to the motion before us, I would like to ask one question, which is the 10% to 20% is still not going to prevent us from",
+    "text": "Michael Guzman: So I would urge us to cleanly pass this through tonight, getting back to the motion before us, I would like to ask one question, which is the 10% to 20% is still not going to prevent us from adding services. It is simply a filter through which to look, if I understand this correctly, that we are not unintentionally harming community with protected status under the Title VI legislation, or those that might be disproportionately burdened or impacted by their financial and economic status within the region. The only purpose we need to pass this is because it is due, because it is the law, and it is how we ensure that we are able to receive our federal funding, which is approximately 25% of our total budget. So I just want to make sure I understand. What has been presented here does not tell the Board, no, we cannot provide transit service. It is simply a way to look at it and say, we may have an issue if it reaches a certain threshold that we need to be aware of in order to be able to approve changes in service, fare changes, or other changes that would create a potential burden on specific communities as defined within the Title VI language. Is that correct, or am I completely lost in this conversation?",
     "start": 9557.661,
-    "end": 9577.09717391304
-  },
-  {
-    "text": "adding services. It is simply a filter through which to look, if I understand this correctly, that we are not unintentionally harming community with protected status under the Title VI legislation, or those that might be disproportionately burdened or impacted by their financial and economic status within",
-    "start": 9578.028,
-    "end": 9600.187276595721
-  },
-  {
-    "text": "the region. The only purpose we need to pass this is because it is due, because it is the law, and it is how we ensure that we are able to receive our federal funding, which is approximately 25% of our",
-    "start": 9601.83,
-    "end": 9613.735499999982
-  },
-  {
-    "text": "total budget. So I just want to make sure",
-    "start": 9615.24,
-    "end": 9617.827692307686
-  },
-  {
-    "text": "I understand. What has been presented here does not tell the Board, no, we cannot provide",
-    "start": 9618.474615384608,
-    "end": 9623.32653846152
-  },
-  {
-    "text": "transit service. It is simply a way to look at it and say, we may have an issue if it reaches a certain threshold that we need to be aware of in order to be able to approve changes in service, fare changes, or other changes that would create a potential burden on specific communities as defined within the Title",
-    "start": 9624.471,
-    "end": 9647.928903225824
-  },
-  {
-    "text": "VI language. Is that correct, or am I completely lost in",
-    "start": 9648.563,
     "end": 9652.495727272732
   },
   {
-    "text": "this conversation? Carl Green: Chair, OK",
+    "text": "Carl Green: Chair, OK for me?",
     "start": 9654.711,
     "end": 9655.328499999998
   },
   {
-    "text": "for me? Julien Bouquet:",
+    "text": "Julien Bouquet: Absolutely, Mr. Green.",
     "start": 9655.832,
-    "end": 9656.105666666666
-  },
-  {
-    "text": "Absolutely,",
-    "start": 9656.379333333332,
     "end": 9656.379333333332
   },
   {
-    "text": "Mr. Green. Carl Green: If I'm tracking Director Guzman, I'll try to answer the question from what I hear, and if you have any double back, then I'll respond",
+    "text": "Carl Green: If I'm tracking Director Guzman, I'll try to answer the question from what I hear, and if you have any double back, then I'll respond to it. So the current 10%, so if we think about different thresholds for DIDB and we are in-- based off of the desk audit, we're in the middle tier of having a threshold that allows us as an agency, which ultimately each service equity analyses is approved by the Board of Directors, where it allows us-- again, to your point, when we're thinking about BIPOC or Black, Indigenous, people of color for disparate impact or low income communities for disproportionate burden, it allows us to make a well-informed, eyes-wide-open decision of better understanding of who's more likely to receive more of the impact. And when we're thinking about service increases, we're thinking about the fair share of benefits where if there is a service reduction, we're looking at who's more likely to receive more of the burden. So to your point, Director Guzman, it allows us to just get a better understanding of the level of impact that we can have on a particular community. It does not prevent us from moving forward.",
     "start": 9656.379333333332,
-    "end": 9663.469851851874
-  },
-  {
-    "text": "to it. So the current 10%, so if we think about different thresholds for DIDB and we are in-- based off of the desk audit, we're in the middle tier of having a threshold that allows us as an agency, which ultimately each service equity analyses is approved by the Board of Directors, where it allows us-- again, to your point, when we're thinking about BIPOC or Black, Indigenous, people of color for disparate impact or low income communities for disproportionate burden, it allows us to make a well-informed, eyes-wide-open decision of better understanding of who's more likely to receive more of",
-    "start": 9664.208,
-    "end": 9704.87182608695
-  },
-  {
-    "text": "the impact. And when we're thinking about service increases, we're thinking about the fair share of benefits where if there is a service reduction, we're looking at who's more likely to receive more of",
-    "start": 9705.308,
-    "end": 9713.607500000011
-  },
-  {
-    "text": "the burden. So to your point, Director Guzman, it allows us to just get a better understanding of the level of impact that we can have on a",
-    "start": 9714.4,
-    "end": 9723.67546153846
-  },
-  {
-    "text": "particular community. It does not prevent us from",
-    "start": 9724.423,
     "end": 9726.683125
   },
   {
-    "text": "moving forward. Michael Guzman:",
+    "text": "Michael Guzman: Thank you. I would just urge a no vote, and let's move on to the policy.",
     "start": 9729.089,
-    "end": 9729.269
-  },
-  {
-    "text": "Thank you. I would just urge a no vote, and let's move on to",
-    "start": 9730.23,
     "end": 9736.329785714292
   },
   {
-    "text": "the policy. Julien Bouquet:",
+    "text": "Julien Bouquet: All right. Director Guissinger, I'm going to have you as our final comment on this specific amendment.",
     "start": 9737.7,
-    "end": 9737.9405
-  },
-  {
-    "text": "All right. Director Guissinger, I'm going to have you as our final comment on this",
-    "start": 9738.982,
     "end": 9743.504933333323
   },
   {
-    "text": "specific amendment. Lynn Guissinger: I'll be",
+    "text": "Lynn Guissinger: I'll be super quick. That last explanation that Mr. Green gave helped me in terms of just giving us a better holistic view. But I shared Director Larsen's view of, are we just making this harder for ourselves, creating more work? Is that not right?",
     "start": 9744.061,
-    "end": 9744.93175
-  },
-  {
-    "text": "super quick. That last explanation",
-    "start": 9745.5534,
-    "end": 9746.799000000003
-  },
-  {
-    "text": "that Mr. Green gave helped me in terms of just giving us a better",
-    "start": 9747.110400000003,
-    "end": 9751.15860000001
-  },
-  {
-    "text": "holistic view. But I shared Director Larsen's view of, are we just making this harder for ourselves, creating",
-    "start": 9751.49,
-    "end": 9758.947499999998
-  },
-  {
-    "text": "more work? Is that",
-    "start": 9761.062,
     "end": 9761.66275
   },
   {
-    "text": "not right? Julien",
+    "text": "Julien Bouquet: Mr. Green.",
     "start": 9763.445,
-    "end": 9763.445
-  },
-  {
-    "text": "Bouquet:",
-    "start": 9763.675500000001,
     "end": 9763.675500000001
   },
   {
-    "text": "Mr. Green. Carl Green: Yeah, that's a great follow",
+    "text": "Carl Green: Yeah, that's a great follow up question. I wouldn't say it's making it harder because when we think about what we're ultimately trying to achieve and a percentage that's mathematically consistent relative to the populations that we serve. So in doing this work, given my background, and doing an assessment of whether if we-- and that's why we didn't want to make any modifications of increasing or decreasing the major service change, we just wanted to keep it consistent, is with doing this work or even doing an analysis of previous run boards or equity analyzes, 20% is something where you wouldn't see anything. And that's a disservice when we think about our populations within our service area, specifically, as we look at our Census data, where 38.1% is BIPOC, 13.1%-- or 14.1%, rather for low income. Right? And then if we look the onboard survey, 56% are considered BIPOC. And so I say all that to say, just to wrap it up, is that 10% threshold for DIDB allows us to make an informed decision that is backed by not only our desk audit, but the years of experience and knowing, having a better understanding of ultimately what we're trying to achieve.",
     "start": 9763.675500000001,
-    "end": 9765.87914285714
-  },
-  {
-    "text": "up question. I wouldn't say it's making it harder because when we think about what we're ultimately trying to achieve and a percentage that's mathematically consistent relative to the populations that",
-    "start": 9768.698,
-    "end": 9781.50993548386
-  },
-  {
-    "text": "we serve. So in doing this work, given my background, and doing an assessment of whether if we-- and that's why we didn't want to make any modifications of increasing or decreasing the major service change, we just wanted to keep it consistent, is with doing this work or even doing an analysis of previous run boards or equity analyzes, 20% is something where you wouldn't",
-    "start": 9782.498,
-    "end": 9807.519208333346
-  },
-  {
-    "text": "see anything. And that's a disservice when we think about our populations within our service area, specifically, as we look at our Census data, where 38.1% is BIPOC, 13.1%-- or 14.1%, rather for",
-    "start": 9809.226,
-    "end": 9822.607142857147
-  },
-  {
-    "text": "low",
-    "start": 9823.027571428576,
-    "end": 9823.027571428576
-  },
-  {
-    "text": "income. Right? And then if we look the onboard survey, 56% are",
-    "start": 9823.568,
-    "end": 9827.485538461537
-  },
-  {
-    "text": "considered BIPOC. And so I say all that to say, just to wrap it up, is that 10% threshold for DIDB allows us to make an informed decision that is backed by not only our desk audit, but the years of experience and knowing, having a better understanding of ultimately what we're trying",
-    "start": 9828.813,
     "end": 9849.241150943364
   },
   {
-    "text": "to achieve. Lynn Guissinger:",
+    "text": "Lynn Guissinger: Thank you.",
     "start": 9852.179,
     "end": 9852.549500000001
   },
   {
-    "text": "Thank you. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. All right, let's do a roll call vote. As a reminder, it is the first amendment being introduced, as you all can see on that screen, with Director Benker as the mover and Director Paglieri as the second. Again, we're voting on this first amendment. Treasurer Benker.",
     "start": 9852.94,
-    "end": 9853.1
-  },
-  {
-    "text": "Thank you. All right, let's do a roll",
-    "start": 9853.78,
-    "end": 9855.041749999997
-  },
-  {
-    "text": "call vote. As a reminder, it is the first amendment being introduced, as you all can see on that screen, with Director Benker as the mover and Director Paglieri as",
-    "start": 9855.482,
-    "end": 9865.254033333309
-  },
-  {
-    "text": "the second. Again, we're voting on this",
-    "start": 9865.711,
-    "end": 9867.976428571426
-  },
-  {
-    "text": "first amendment.",
-    "start": 9869.174,
     "end": 9869.4745
   },
   {
-    "text": "Treasurer Benker. Karen",
+    "text": "Karen Benker: Yes.",
     "start": 9870.636,
     "end": 9870.636
   },
   {
-    "text": "Benker: Yes. Julien Bouquet: Director Buzek",
+    "text": "Julien Bouquet: Director Buzek is gone. Director Catlin.",
     "start": 9871.677,
-    "end": 9872.502750000001
-  },
-  {
-    "text": "is gone.",
-    "start": 9873.558,
     "end": 9873.908500000001
   },
   {
-    "text": "Director Catlin. Peggy",
+    "text": "Peggy Catlin: No.",
     "start": 9875.841,
     "end": 9875.841
   },
   {
-    "text": "Catlin: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guissinger.",
     "start": 9876.901,
     "end": 9877.502
   },
   {
-    "text": "Director Guissinger. Lynn",
+    "text": "Lynn Guissinger: No.",
     "start": 9880.725,
     "end": 9880.725
   },
   {
-    "text": "Guissinger: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Gutschenritter.",
     "start": 9882.183,
     "end": 9882.684
   },
   {
-    "text": "Director Gutschenritter. Chris",
+    "text": "Chris Gutschenritter: No.",
     "start": 9883.024,
     "end": 9909.223
   },
   {
-    "text": "Gutschenritter: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Director Guzman. Michael",
+    "text": "Michael Guzman: No.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Guzman: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Harwick.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Director Harwick. Ian",
+    "text": "Ian Harwick: No.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Harwick: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Director Larsen. Matt",
+    "text": "Matt Larsen: No.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Larsen: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Nicholson.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Director Nicholson. Chris",
+    "text": "Chris Nicholson: Yes.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Nicholson: Yes. Julien Bouquet: First Vice",
+    "text": "Julien Bouquet: First Vice Chair O'Keefe.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Chair O'Keefe. Patrick",
+    "text": "Patrick O'Keefe: No.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "O'Keefe: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Paglieri.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Director Paglieri. Brett",
+    "text": "Brett Paglieri: No.",
     "start": 9909.223,
     "end": 9909.223
   },
   {
-    "text": "Paglieri: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Ruscha.",
     "start": 9911.9,
     "end": 9912.433624999998
   },
   {
-    "text": "Director Ruscha. Joyann",
+    "text": "Joyann Ruscha: No.",
     "start": 9912.611499999997,
     "end": 9912.967249999996
   },
   {
-    "text": "Ruscha: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Whitmore.",
     "start": 9913.145124999995,
     "end": 9915.856
   },
   {
-    "text": "Director Whitmore. Troy",
+    "text": "Troy Whitmore: No.",
     "start": 9916.3805,
     "end": 9917.429499999998
   },
   {
-    "text": "Whitmore: No. Julien Bouquet: I'm a yes, but the motion",
+    "text": "Julien Bouquet: I'm a yes, but the motion will fail. And we have 3 to 10. OK. Moving on. Yes, Director?",
     "start": 9919.278,
-    "end": 9920.821
-  },
-  {
-    "text": "will fail. And we have 3",
-    "start": 9920.821,
-    "end": 9920.821
-  },
-  {
-    "text": "to",
-    "start": 9920.821,
-    "end": 9920.821
-  },
-  {
-    "text": "10. OK.",
-    "start": 9920.821,
-    "end": 9921.0715
-  },
-  {
-    "text": "Moving on.",
-    "start": 9921.563,
     "end": 9921.8635
   },
   {
-    "text": "Yes, Director? Karen Benker: I would like to withdraw the next",
+    "text": "Karen Benker: I would like to withdraw the next two amendments.",
     "start": 9922.204,
     "end": 9924.075111111104
   },
   {
-    "text": "two amendments. Julien Bouquet: Next",
+    "text": "Julien Bouquet: Next two amendments?",
     "start": 9924.771,
     "end": 9925.238333333335
   },
   {
-    "text": "two amendments? Karen",
+    "text": "Karen Benker: Yes.",
     "start": 9925.592,
     "end": 9925.592
   },
   {
-    "text": "Benker: Yes. Julien",
+    "text": "Julien Bouquet: OK. The next two amendments have been withdrawn.",
     "start": 9926.495,
-    "end": 9927.477
-  },
-  {
-    "text": "Bouquet: OK. The next two amendments have",
-    "start": 9927.477,
     "end": 9929.676428571425
   },
   {
-    "text": "been withdrawn. Chris Nicholson: They were never introduced, so they're not",
+    "text": "Chris Nicholson: They were never introduced, so they're not really withdrawn. But now you would return back to the debate on the main motion, which is to approve the Title VI program update.",
     "start": 9931.373,
-    "end": 9933.89828571429
-  },
-  {
-    "text": "really withdrawn. But now you would return back to the debate on the main motion, which is to approve the Title VI",
-    "start": 9934.378428571434,
     "end": 9939.419928571451
   },
   {
-    "text": "program update. Julien",
+    "text": "Julien Bouquet: Excellent. Back to the main motion at hand. Director O'Keefe.",
     "start": 9940.102,
-    "end": 9940.102
-  },
-  {
-    "text": "Bouquet: Excellent. Back to the main motion",
-    "start": 9941.025,
-    "end": 9942.091285714281
-  },
-  {
-    "text": "at hand.",
-    "start": 9942.831,
     "end": 9943.162
   },
   {
-    "text": "Director O'Keefe. Patrick O'Keefe: So I contemplated a no vote out of principle on",
+    "text": "Patrick O'Keefe: So I contemplated a no vote out of principle on this action. There's a few things going on. First of all, it should never get to the last minute. The Board should never be asked to pass things because it's due in two days. And I know there's a lot of things that go into the delay. But that's just not the right-- that's not the right urgency to place on the Board to act. Secondly, I don't know very much about this topic, and I have sat in on two operations committee meetings. I've talked to a bunch of people. I've done my own research. And I still am looking for a succinct description of the program. I would note that there was a wonderful book written by Robert Caro. It's called The Power Broker. I'm sure a lot of people in this room know it. Talks a lot about bad policy decisions on disadvantaged communities and how those decisions were made and the harmful outcome of those decisions. It is 15 pages shorter than our packet tonight. He won the Pulitzer Prize for a 1,200 page treatise on impact by public infrastructure. I would request that when we're passing along documents as part of a packet, it needs to have a point, and it should be summarized from the committee for the rest of the Board. Simply passing things along for us does not help me understand this better. I'm probably a yes vote tonight, but I was a no vote until about an hour and a half ago. And so just, when you are putting together packets on complex questions for the Board, giving us reams of paper does not help us get to a better decision. So that's something, a request for the two, three-ish Committee Chairs as you're putting together topics like this, and that would be very helpful for me to make better decisions. Thanks.",
     "start": 9945.008,
-    "end": 9951.67033333333
-  },
-  {
-    "text": "this action. There's a few things",
-    "start": 9952.316,
-    "end": 9954.585166666666
-  },
-  {
-    "text": "going on. First of all, it should never get to the",
-    "start": 9955.099,
-    "end": 9957.97536363637
-  },
-  {
-    "text": "last minute. The Board should never be asked to pass things because it's due in",
-    "start": 9958.783,
-    "end": 9963.585933333328
-  },
-  {
-    "text": "two days. And I know there's a lot of things that go into",
-    "start": 9964.249,
-    "end": 9968.18184210527
-  },
-  {
-    "text": "the delay. But that's just not the right-- that's not the right urgency to place on the Board",
-    "start": 9968.509578947376,
-    "end": 9975.90472727273
-  },
-  {
-    "text": "to act. Secondly, I don't know very much about this topic, and I have sat in on two operations",
-    "start": 9977.667,
-    "end": 9984.389526315792
-  },
-  {
-    "text": "committee meetings. I've talked to a bunch",
-    "start": 9986.166,
-    "end": 9987.214285714288
-  },
-  {
-    "text": "of people. I've done my",
-    "start": 9987.449,
-    "end": 9989.597800000003
-  },
-  {
-    "text": "own research. And I still am looking for a succinct description of",
-    "start": 9990.115,
-    "end": 9994.998999999994
-  },
-  {
-    "text": "the program. I would note that there was a wonderful book written by",
-    "start": 9995.464,
-    "end": 10000.566769230776
-  },
-  {
-    "text": "Robert Caro. It's called The",
-    "start": 10001.092,
-    "end": 10001.989599999997
-  },
-  {
-    "text": "Power Broker. I'm sure a lot of people in this room",
-    "start": 10002.455,
-    "end": 10004.51227272727
-  },
-  {
-    "text": "know it. Talks a lot about bad policy decisions on disadvantaged communities and how those decisions were made and the harmful outcome of",
-    "start": 10005.439,
-    "end": 10019.550615384615
-  },
-  {
-    "text": "those decisions. It is 15 pages shorter than our",
-    "start": 10021.619,
-    "end": 10025.523888888894
-  },
-  {
-    "text": "packet tonight. He won the Pulitzer Prize for a 1,200 page treatise on impact by",
-    "start": 10026.582,
-    "end": 10035.519599999998
-  },
-  {
-    "text": "public infrastructure. I would request that when we're passing along documents as part of a packet, it needs to have a point, and it should be summarized from the committee for the rest of",
-    "start": 10036.178,
-    "end": 10048.077411764732
-  },
-  {
-    "text": "the Board. Simply passing things along for us does not help me understand",
-    "start": 10048.418,
-    "end": 10052.855230769224
-  },
-  {
-    "text": "this better. I'm probably a yes vote tonight, but I was a no vote until about an hour and a",
-    "start": 10053.265,
-    "end": 10061.428555555542
-  },
-  {
-    "text": "half ago. And so just, when you are putting together packets on complex questions for the Board, giving us reams of paper does not help us get to a",
-    "start": 10061.817296296282,
-    "end": 10073.868259259225
-  },
-  {
-    "text": "better decision. So that's something, a request for the two, three-ish Committee Chairs as you're putting together topics like this, and that would be very helpful for me to make",
-    "start": 10074.978,
-    "end": 10087.395416666668
-  },
-  {
-    "text": "better",
-    "start": 10088.267,
     "end": 10088.267
   },
   {
-    "text": "decisions. Thanks. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director O'Keefe. Any further comments or questions on the main motion? Director Guzman.",
     "start": 10088.848,
-    "end": 10089.538750000002
-  },
-  {
-    "text": "Director O'Keefe. Any further comments or questions on the",
-    "start": 10090.531,
-    "end": 10092.330111111105
-  },
-  {
-    "text": "main motion?",
-    "start": 10093.597,
     "end": 10093.8975
   },
   {
-    "text": "Director Guzman. Michael Guzman: I would just like to mention that the Denver City Council unanimously submitted a proclamation for RTD on May",
+    "text": "Michael Guzman: I would just like to mention that the Denver City Council unanimously submitted a proclamation for RTD on May 19, 2025. It is in the director's emails. It was sent over by City Council, that they wholeheartedly support the 2025-2028 Title VI program to include the proposed updates to major service change, disparate impact, and fare equity policies, as well as updates to RTD's public participation plan and language access plan, which we are voting on now, and that the clerk and recorder of the City and County of Denver did affix the seal, making it official. I believe that that is necessary. There's a whole proclamation. You can read through it. But former Board Director Lewis-- sorry, We had two Lewises and I wanted to make sure I said it right. Did work with city council member Serena Gutierrez Gonzalez. And the unanimity of that vote is remarkable from our city council. So they stand behind this as well with us to move this forward. Thank you.",
     "start": 10093.8975,
-    "end": 10104.384333333326
-  },
-  {
-    "text": "19, 2025. It is in the",
-    "start": 10105.094,
-    "end": 10106.428999999998
-  },
-  {
-    "text": "director's emails. It was sent over by City Council, that they wholeheartedly support the 2025-2028 Title VI program to include the proposed updates to major service change, disparate impact, and fare equity policies, as well as updates to RTD's public participation plan and language access plan, which we are voting on now, and that the clerk and recorder of the City and County of Denver did affix the seal, making",
-    "start": 10107.357,
-    "end": 10128.691799999999
-  },
-  {
-    "text": "it official. I believe that that",
-    "start": 10130.299571428572,
-    "end": 10131.57242857143
-  },
-  {
-    "text": "is necessary. There's a",
-    "start": 10131.847,
-    "end": 10132.70275
-  },
-  {
-    "text": "whole proclamation. You can read",
-    "start": 10133.289,
-    "end": 10134.941000000003
-  },
-  {
-    "text": "through it. But former Board Director Lewis-- sorry, We had two Lewises and I wanted to make sure I said",
-    "start": 10135.354000000003,
-    "end": 10144.027000000013
-  },
-  {
-    "text": "it right. Did work with city council member Serena",
-    "start": 10145.482166666667,
-    "end": 10149.641666666663
-  },
-  {
-    "text": "Gutierrez Gonzalez. And the unanimity of that vote is remarkable from our",
-    "start": 10150.103833333329,
-    "end": 10155.000909090913
-  },
-  {
-    "text": "city council. So they stand behind this as well with us to move",
-    "start": 10155.489,
-    "end": 10158.653307692299
-  },
-  {
-    "text": "this forward.",
-    "start": 10158.937,
     "end": 10159.097
   },
   {
-    "text": "Thank you. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director Guzman. Director Larsen.",
     "start": 10159.919,
-    "end": 10160.54975
-  },
-  {
-    "text": "Director Guzman.",
-    "start": 10161.542,
     "end": 10161.893
   },
   {
-    "text": "Director Larsen. Matt Larsen: I'm going to be a no vote, I think it's kind of, like I said, we're constraining our freedom",
+    "text": "Matt Larsen: I'm going to be a no vote, I think it's kind of, like I said, we're constraining our freedom to operate. We're spending a lot of energy and effort to track this. And I know the intentions behind that are good, but I think, just as a matter of principle, we shouldn't be trying to over-- regulating ourselves more. We should be thinking, there's not really a lot of evidence that we have disparately or ever had any recent plans to expand service or decrease service in a way that causes a disparate impact on these populations. And I honestly believe that if we focused 100% just on increasing ridership, which is what I think we should be doing, and not trying to expand our purview about when maybe we shouldn't increase ridership. I don't know. If it's legitimate, we'll do it anyways. I really think if we were focusing strictly on increasing ridership, we would actually-- it would all be disparately impacted in favor of all the communities we're worried about, just based on the way population is distributed in the area. And I would like for us to move towards a paradigm of focusing much, much more on increasing ridership across the board and less on finding possible reasons to not increase ridership. So I'll be a no vote. Thanks.",
     "start": 10163.647,
-    "end": 10171.42128571428
-  },
-  {
-    "text": "to operate. We're spending a lot of energy and effort to",
-    "start": 10171.756,
-    "end": 10174.505999999996
-  },
-  {
-    "text": "track this. And I know the intentions behind that are good, but I think, just as a matter of principle, we shouldn't be trying to over-- regulating",
-    "start": 10175.161,
-    "end": 10188.405300000019
-  },
-  {
-    "text": "ourselves more. We should be thinking, there's not really a lot of evidence that we have disparately or ever had any recent plans to expand service or decrease service in a way that causes a disparate impact on",
-    "start": 10189.282,
-    "end": 10209.694142857143
-  },
-  {
-    "text": "these populations. And I honestly believe that if we focused 100% just on increasing ridership, which is what I think we should be doing, and not trying to expand our purview about when maybe we shouldn't",
-    "start": 10210.616,
-    "end": 10225.33307317076
-  },
-  {
-    "text": "increase ridership. I",
-    "start": 10225.782,
-    "end": 10226.206666666665
-  },
-  {
-    "text": "don't know. If it's legitimate, we'll do",
-    "start": 10227.480666666663,
-    "end": 10228.75466666666
-  },
-  {
-    "text": "it anyways. I really think if we were focusing strictly on increasing ridership, we would actually-- it would all be disparately impacted in favor of all the communities we're worried about, just based on the way population is distributed in",
-    "start": 10229.318,
-    "end": 10244.095099999988
-  },
-  {
-    "text": "the area. And I would like for us to move towards a paradigm of focusing much, much more on increasing ridership across the board and less on finding possible reasons to not",
-    "start": 10244.514,
-    "end": 10259.347599999996
-  },
-  {
-    "text": "increase ridership. So I'll be a",
-    "start": 10261.015,
-    "end": 10261.833333333336
-  },
-  {
-    "text": "no",
-    "start": 10262.017,
     "end": 10262.017
   },
   {
-    "text": "vote. Thanks. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director Larsen. Secretary Nicholson.",
     "start": 10262.96,
-    "end": 10263.591500000002
-  },
-  {
-    "text": "Director Larsen.",
-    "start": 10263.883,
     "end": 10264.304
   },
   {
-    "text": "Secretary Nicholson. Chris Nicholson: So I sat through two committee meetings, a study session, and a town hall, all on",
+    "text": "Chris Nicholson: So I sat through two committee meetings, a study session, and a town hall, all on this topic. And I should say expertly facilitated by our co-chairs and by our Chair of Finance and our staff. And I feel like I'm just starting to get a decent understanding of it. I came into this knowing nothing about this, and I was an absolute no when we first started. And my public remarks made that very clear. But I want to commend staff and our Board leadership who were willing to indulge because I came to understand it. I came to understand what it was for. I came to understand how it works. And I don't necessarily agree with all of it and I think we could use more data in addition to the data we have now to determine this. But if we don't pass this, we lose federal funding. So there's a good reason to pass it even if you don't like it. But on top of that, I just think our staff did their jobs. They have demonstrated to me this is the right thing to do, despite my skepticism. And so I'm definitely voting for it tonight.",
     "start": 10264.304,
-    "end": 10274.490666666657
-  },
-  {
-    "text": "this topic. And I should say expertly facilitated by our co-chairs and by our Chair of Finance and",
-    "start": 10275.31,
-    "end": 10285.613888888874
-  },
-  {
-    "text": "our staff. And I feel like I'm just starting to get a decent understanding",
-    "start": 10286.5,
-    "end": 10291.890357142847
-  },
-  {
-    "text": "of it. I came into this knowing nothing about this, and I was an absolute no when we",
-    "start": 10292.772111111111,
-    "end": 10300.092294117641
-  },
-  {
-    "text": "first started. And my public remarks made that",
-    "start": 10300.562705882347,
-    "end": 10303.855588235283
-  },
-  {
-    "text": "very clear. But I want to commend staff and our Board leadership who were willing to indulge because I came to",
-    "start": 10304.426,
-    "end": 10315.746000000014
-  },
-  {
-    "text": "understand it. I came to understand what it",
-    "start": 10316.697,
-    "end": 10317.802999999996
-  },
-  {
-    "text": "was for. I came to understand how",
-    "start": 10318.221,
-    "end": 10319.304428571426
-  },
-  {
-    "text": "it works. And I don't necessarily agree with all of it and I think we could use more data in addition to the data we have now to",
-    "start": 10320.608,
-    "end": 10328.433263157898
-  },
-  {
-    "text": "determine this. But if we don't pass this, we lose",
-    "start": 10329.843,
-    "end": 10331.605666666663
-  },
-  {
-    "text": "federal funding. So there's a good reason to pass it even if you don't",
-    "start": 10332.167,
-    "end": 10334.156928571421
-  },
-  {
-    "text": "like it. But on top of that, I just think our staff did",
-    "start": 10335.873,
-    "end": 10340.27330769231
-  },
-  {
-    "text": "their jobs. They have demonstrated to me this is the right thing to do, despite",
-    "start": 10341.121,
-    "end": 10345.795133333322
-  },
-  {
-    "text": "my skepticism. And so I'm definitely voting for",
-    "start": 10346.37,
     "end": 10347.965125000004
   },
   {
-    "text": "it tonight. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Any further comments on the main motion? OK. Seeing none, we had Catlin as the mover and Guzman as the second. There is indication that there will be no votes so I will be doing a roll call vote on this. Treasure Benker.",
     "start": 10348.814,
-    "end": 10348.984
-  },
-  {
-    "text": "Thank you. Any further comments on the",
-    "start": 10349.595,
-    "end": 10350.762428571432
-  },
-  {
-    "text": "main",
-    "start": 10352.337,
-    "end": 10352.337
-  },
-  {
-    "text": "motion? OK. Seeing none, we had Catlin as the mover and Guzman as",
-    "start": 10352.587285714286,
-    "end": 10355.590714285721
-  },
-  {
-    "text": "the second. There is indication that there will be no votes so I will be doing a roll call vote",
-    "start": 10356.362,
-    "end": 10360.337749999997
-  },
-  {
-    "text": "on this.",
-    "start": 10361.929,
     "end": 10362.182666666668
   },
   {
-    "text": "Treasure Benker. Karen",
+    "text": "Karen Benker: No.",
     "start": 10362.436333333335,
     "end": 10363.350999999999
   },
   {
-    "text": "Benker: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Catlin.",
     "start": 10365.854,
     "end": 10366.1945
   },
   {
-    "text": "Director Catlin. Peggy",
+    "text": "Peggy Catlin: Yes.",
     "start": 10366.1945,
     "end": 10367.416
   },
   {
-    "text": "Catlin: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guissinger.",
     "start": 10370.08,
     "end": 10370.45
   },
   {
-    "text": "Director Guissinger. Lynn",
+    "text": "Lynn Guissinger: Yes.",
     "start": 10371.461,
     "end": 10371.461
   },
   {
-    "text": "Guissinger: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Gutschenritter.",
     "start": 10373.584,
     "end": 10373.584
   },
   {
-    "text": "Director Gutschenritter. Chris",
+    "text": "Chris Gutschenritter: Yes.",
     "start": 10373.584,
     "end": 10373.584
   },
   {
-    "text": "Gutschenritter: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 10373.584,
     "end": 10374.535
   },
   {
-    "text": "Director Guzman. Michael",
+    "text": "Michael Guzman: Yes.",
     "start": 10374.535,
     "end": 10375.687
   },
   {
-    "text": "Guzman: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Harwick.",
     "start": 10376.247,
     "end": 10376.557499999999
   },
   {
-    "text": "Director Harwick. Ian",
+    "text": "Ian Harwick: Yes.",
     "start": 10376.557499999999,
     "end": 10377.269
   },
   {
-    "text": "Harwick: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 10379.031,
     "end": 10379.361499999999
   },
   {
-    "text": "Director Larsen. Matt",
+    "text": "Matt Larsen: No.",
     "start": 10380.293,
     "end": 10380.293
   },
   {
-    "text": "Larsen: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Nicholson.",
     "start": 10381.008,
     "end": 10381.4385
   },
   {
-    "text": "Director Nicholson. Chris Nicholson:",
+    "text": "Chris Nicholson: I'm in.",
     "start": 10381.4385,
     "end": 10382.6805
   },
   {
-    "text": "I'm in. Julien Bouquet: First Vice",
+    "text": "Julien Bouquet: First Vice Chair O'Keefe.",
     "start": 10384.133,
     "end": 10384.778750000001
   },
   {
-    "text": "Chair O'Keefe. Patrick",
+    "text": "Patrick O'Keefe: Yes.",
     "start": 10385.855,
     "end": 10385.855
   },
   {
-    "text": "O'Keefe: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Paglieri.",
     "start": 10386.476,
     "end": 10388.88
   },
   {
-    "text": "Director Paglieri. Brett",
+    "text": "Brett Paglieri: Yes.",
     "start": 10388.88,
     "end": 10388.88
   },
   {
-    "text": "Paglieri: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Ruscha.",
     "start": 10389.801,
     "end": 10390.743
   },
   {
-    "text": "Director Ruscha. Joyann",
+    "text": "Joyann Ruscha: Yep.",
     "start": 10390.743,
     "end": 10390.743
   },
   {
-    "text": "Ruscha: Yep. Julien Bouquet: Second Vice",
+    "text": "Julien Bouquet: Second Vice Chair Whitmore.",
     "start": 10392.565,
     "end": 10393.271499999999
   },
   {
-    "text": "Chair Whitmore. Troy",
+    "text": "Troy Whitmore: Yes.",
     "start": 10393.271499999999,
     "end": 10393.907
   },
   {
-    "text": "Whitmore: Yes. Julien Bouquet: I'm also",
+    "text": "Julien Bouquet: I'm also a yes. So the motion, the main motion will pass 11, 2, and 2 absent. Yes. That math adds up. OK. Moving on. We're going to be moving to our next recommended action, which is the budget transfer articulated buses supporting Colfax Bus Rapid Transit or BRT service. Do I have a mover?",
     "start": 10394.909,
-    "end": 10395.496333333333
-  },
-  {
-    "text": "a yes. So the motion, the main motion will pass 11, 2, and",
-    "start": 10396.211,
-    "end": 10401.850076923085
-  },
-  {
-    "text": "2",
-    "start": 10403.762,
-    "end": 10403.762
-  },
-  {
-    "text": "absent. Yes. That math",
-    "start": 10404.090600000001,
-    "end": 10405.076400000004
-  },
-  {
-    "text": "adds",
-    "start": 10406.146,
-    "end": 10406.146
-  },
-  {
-    "text": "up. OK.",
-    "start": 10406.947,
-    "end": 10407.20276923077
-  },
-  {
-    "text": "Moving on. We're going to be moving to our next recommended action, which is the budget transfer articulated buses supporting Colfax Bus Rapid Transit or",
-    "start": 10407.458538461538,
-    "end": 10417.16000000001
-  },
-  {
-    "text": "BRT service. Do I have",
-    "start": 10417.69,
     "end": 10418.442800000003
   },
   {
-    "text": "a mover? Michael Guzman: So",
+    "text": "Michael Guzman: So moved, Guzman.",
     "start": 10419.553,
     "end": 10420.100333333332
   },
   {
-    "text": "moved, Guzman. Julien Bouquet: Guzman is",
+    "text": "Julien Bouquet: Guzman is the mover. Do I have a second?",
     "start": 10420.534,
-    "end": 10421.402333333328
-  },
-  {
-    "text": "the mover. Do I have",
-    "start": 10421.616,
     "end": 10422.437
   },
   {
-    "text": "a second? Troy",
+    "text": "Troy Whitmore: Second.",
     "start": 10422.437,
     "end": 10422.437
   },
   {
-    "text": "Whitmore: Second. Julien Bouquet: I have-- Joyann",
+    "text": "Julien Bouquet: I have--",
     "start": 10424.4,
     "end": 10424.4
   },
   {
-    "text": "Ruscha:",
+    "text": "Joyann Ruscha: Wait. Sir.",
     "start": 10424.4,
     "end": 10424.4
   },
   {
-    "text": "Wait. Sir. Julien",
+    "text": "Julien Bouquet: Yeah?",
     "start": 10424.941,
     "end": 10424.941
   },
   {
-    "text": "Bouquet: Yeah? Joyann Ruscha:",
+    "text": "Joyann Ruscha: Oh, wait. Well, I could be wrong. I'm sorry, I forgot we started late. I thought we hit our four hour mark. Please ignore me.",
     "start": 10425.662,
-    "end": 10425.792000000001
-  },
-  {
-    "text": "Oh, wait. Well, I could",
-    "start": 10426.343,
-    "end": 10426.839800000002
-  },
-  {
-    "text": "be wrong. I'm sorry, I forgot we",
-    "start": 10426.984,
-    "end": 10428.8746
-  },
-  {
-    "text": "started late. I thought we hit our four",
-    "start": 10429.347,
-    "end": 10430.293749999995
-  },
-  {
-    "text": "hour mark. Please",
-    "start": 10430.909,
     "end": 10433.273000000001
   },
   {
-    "text": "ignore me. Julien",
+    "text": "Julien Bouquet: Oh.",
     "start": 10434.475,
     "end": 10434.475
   },
   {
-    "text": "Bouquet: Oh. Joyann",
+    "text": "Joyann Ruscha: Sorry.",
     "start": 10434.835,
     "end": 10434.835
   },
   {
-    "text": "Ruscha: Sorry. Julien Bouquet: Guzman is",
+    "text": "Julien Bouquet: Guzman is the mover. Whitmore is the second. Any discussion on it? Yeah, Director Paglieri?",
     "start": 10434.975,
-    "end": 10436.282250000002
-  },
-  {
-    "text": "the mover. Whitmore is",
-    "start": 10436.778,
-    "end": 10437.8445
-  },
-  {
-    "text": "the second. Any discussion",
-    "start": 10441.5994,
-    "end": 10442.440599999998
-  },
-  {
-    "text": "on it? Yeah,",
-    "start": 10443.702,
     "end": 10444.263
   },
   {
-    "text": "Director Paglieri? Brett Paglieri: I just wanted to say a few quick words about why I will not be voting",
+    "text": "Brett Paglieri: I just wanted to say a few quick words about why I will not be voting for this. I was not necessarily sure how this would further the clean energy and zero emission goals of the State of Colorado and therefore will just be voting no. Thank you.",
     "start": 10444.263,
-    "end": 10449.370555555566
-  },
-  {
-    "text": "for this. I was not necessarily sure how this would further the clean energy and zero emission goals of the State of Colorado and therefore will just be",
-    "start": 10450.813608695651,
-    "end": 10466.38544444445
-  },
-  {
-    "text": "voting no.",
-    "start": 10466.936,
     "end": 10467.106
   },
   {
-    "text": "Thank you. Julien Bouquet: Any",
+    "text": "Julien Bouquet: Any further conversation? Secretary Nicholson.",
     "start": 10469.652,
-    "end": 10470.606000000002
-  },
-  {
-    "text": "further conversation?",
-    "start": 10471.083000000002,
     "end": 10471.560000000003
   },
   {
-    "text": "Secretary Nicholson. Chris Nicholson: Yeah, so I understand the importance of what we're",
+    "text": "Chris Nicholson: Yeah, so I understand the importance of what we're doing here. I think that these buses in particular-- in my religion, there's a thing. Why is this night different from all other nights? Why are these buses different from all other buses? These are going to be the flagship of our flagship BRT line, and if these suck, it will kill BRT. And if they are not comfortable, if they are not just awesome in every way possible-- you can make a lot of choices when you buy a bus about how nice it's going to be in the same way can make a lot of choices about how when you buy a car, about how nice it's going to be. And so I just want to lean in here, and I do have one question to say that we need to pull the stops out. We need to make sure we're giving you enough money, GM/CEO Johnson, to make sure we're buying top of the line, to make sure that these are things that when they run through my district, people go, wow, I want to get on that. Not, wow, that doesn't look very nice. And so my question for you is, how do you know that the amount of money that we're authorizing today is enough to get top of the line? And how many bites at the apple are we going to get to make sure that you are buying the right buses for this incredibly important project?",
     "start": 10471.560000000003,
-    "end": 10477.382230769223
-  },
-  {
-    "text": "doing here. I think that these buses in particular-- in my religion, there's",
-    "start": 10479.313,
-    "end": 10484.02726666667
-  },
-  {
-    "text": "a thing. Why is this night different from all",
-    "start": 10484.444,
-    "end": 10486.011999999999
-  },
-  {
-    "text": "other nights? Why are these buses different from all",
-    "start": 10486.248,
-    "end": 10488.403555555553
-  },
-  {
-    "text": "other buses? These are going to be the flagship of our flagship BRT line, and if these suck, it will",
-    "start": 10489.902,
-    "end": 10500.763500000005
-  },
-  {
-    "text": "kill BRT. And if they are not comfortable, if they are not just awesome in every way possible-- you can make a lot of choices when you buy a bus about how nice it's going to be in the same way can make a lot of choices about how when you buy a car, about how nice it's going",
-    "start": 10502.118,
-    "end": 10516.341750000005
-  },
-  {
-    "text": "to be. And so I just want to lean in here, and I do have one question to say that we need to pull the",
-    "start": 10516.497,
-    "end": 10525.632359999985
-  },
-  {
-    "text": "stops out. We need to make sure we're giving you enough money, GM/CEO Johnson, to make sure we're buying top of the line, to make sure that these are things that when they run through my district, people go, wow, I want to get",
-    "start": 10526.113,
-    "end": 10540.373711111111
-  },
-  {
-    "text": "on that. Not, wow, that doesn't look",
-    "start": 10540.705355555556,
-    "end": 10542.452000000001
-  },
-  {
-    "text": "very nice. And so my question for you is, how do you know that the amount of money that we're authorizing today is enough to get top of",
-    "start": 10543.48,
-    "end": 10551.684142857137
-  },
-  {
-    "text": "the line? And how many bites at the apple are we going to get to make sure that you are buying the right buses for this incredibly",
-    "start": 10552.008,
     "end": 10562.785481481491
   },
   {
-    "text": "important project? Julien",
+    "text": "Julien Bouquet: Ms. Johnson, is 51 million enough to make them not suck?",
     "start": 10564.421,
-    "end": 10564.421
-  },
-  {
-    "text": "Bouquet: Ms. Johnson, is 51 million enough to make them",
-    "start": 10564.641,
     "end": 10568.118599999994
   },
   {
-    "text": "not suck? Debra",
+    "text": "Debra Johnson: Yeah. So thank you very much, Mr. Chair, and thank you for the question.",
     "start": 10568.525,
-    "end": 10568.525
-  },
-  {
-    "text": "Johnson: Yeah. So thank you very",
-    "start": 10570.16,
-    "end": 10572.132857142855
-  },
-  {
-    "text": "much, Mr. Chair, and thank you for",
-    "start": 10572.527428571426,
     "end": 10575.234666666667
   },
   {
-    "text": "the question. Julien Bouquet:",
+    "text": "Julien Bouquet: My apologies. That was unprofessional.",
     "start": 10576.285,
-    "end": 10576.7655
-  },
-  {
-    "text": "My apologies. That",
-    "start": 10577.266,
     "end": 10577.634399999999
   },
   {
-    "text": "was unprofessional. Debra Johnson: Keep it in mind, this is a",
+    "text": "Debra Johnson: Keep it in mind, this is a budget transfer. And full transparency, Director Nicholson emailed me about this because I think there was some confusion about where we are. There is yet to be a solicitation. There's yet to be specifications. So these monies that are being transferred or needed for all intents and purposes so we can start a procurement. Now, keeping in mind there's a couple of elements. These buses have to be dedicated because this is designated as a bus rapid transit project as defined by the Federal Transit Administration. There are certain criteria that we have to ensure that we adhere to. This will be a dedicated fleet just by virtue of the configuration of BRT, with it being a center running platform. So when you talk about it being top of the line, that's yet to be seen in reference to what we had before us, because there's only two original equipment manufacturers in the United States, there's only so many suppliers, there are certain seats, and there is a national task force on which I sit, where we're talking about doing away with customization, because that increases prices. I bet you don't know how many shades of white there is with new flyer industries.",
     "start": 10577.818599999999,
-    "end": 10581.81633333334
-  },
-  {
-    "text": "budget transfer. And full transparency, Director Nicholson emailed me about this because I think there was some confusion about where",
-    "start": 10582.240000000007,
-    "end": 10588.308705882366
-  },
-  {
-    "text": "we are. There is yet to be",
-    "start": 10588.876,
-    "end": 10590.24828571429
-  },
-  {
-    "text": "a solicitation. There's yet to",
-    "start": 10590.537,
-    "end": 10591.994600000002
-  },
-  {
-    "text": "be specifications. So these monies that are being transferred or needed for all intents and purposes so we can start",
-    "start": 10592.739,
-    "end": 10602.03881818182
-  },
-  {
-    "text": "a procurement. Now, keeping in mind there's a couple",
-    "start": 10604.694,
-    "end": 10607.364222222222
-  },
-  {
-    "text": "of elements. These buses have to be dedicated because this is designated as a bus rapid transit project as defined by the Federal",
-    "start": 10608.038,
-    "end": 10615.873826086961
-  },
-  {
-    "text": "Transit Administration. There are certain criteria that we have to ensure that we",
-    "start": 10616.67,
-    "end": 10621.810666666674
-  },
-  {
-    "text": "adhere to. This will be a dedicated fleet just by virtue of the configuration of BRT, with it being a center",
-    "start": 10622.298,
-    "end": 10629.088476190473
-  },
-  {
-    "text": "running platform. So when you talk about it being top of the line, that's yet to be seen in reference to what we had before us, because there's only two original equipment manufacturers in the United States, there's only so many suppliers, there are certain seats, and there is a national task force on which I sit, where we're talking about doing away with customization, because that",
-    "start": 10629.965,
-    "end": 10651.065888888892
-  },
-  {
-    "text": "increases prices. I bet you don't know how many shades of white there is with new",
-    "start": 10651.632,
     "end": 10655.404500000004
   },
   {
-    "text": "flyer industries. Chris",
+    "text": "Chris Nicholson: 24.",
     "start": 10655.676,
     "end": 10655.676
   },
   {
-    "text": "Nicholson: 24. Debra Johnson:",
+    "text": "Debra Johnson: How many?",
     "start": 10656.216,
     "end": 10656.8765
   },
   {
-    "text": "How many? Chris",
+    "text": "Chris Nicholson: 24.",
     "start": 10657.557,
     "end": 10657.557
   },
   {
-    "text": "Nicholson: 24. Debra",
+    "text": "Debra Johnson: 23. I think I told you that earlier. So the point of the matter is, as we talk about this, we're going to do our due diligence and we're going to ensure it's a competitive solicitation. And we do understand the aspects, because that's what separates bus rapid transit from general fixed route service. Thank you.",
     "start": 10657.678,
-    "end": 10657.678
-  },
-  {
-    "text": "Johnson: 23. I think I told you",
-    "start": 10658.999,
-    "end": 10660.508428571426
-  },
-  {
-    "text": "that earlier. So the point of the matter is, as we talk about this, we're going to do our due diligence and we're going to ensure it's a",
-    "start": 10660.841,
-    "end": 10671.276063829784
-  },
-  {
-    "text": "competitive solicitation. And we do understand the aspects, because that's what separates bus rapid transit from general fixed",
-    "start": 10671.648744680848,
-    "end": 10677.98431914893
-  },
-  {
-    "text": "route service.",
-    "start": 10679.258,
     "end": 10679.478
   },
   {
-    "text": "Thank you. Julien",
+    "text": "Julien Bouquet: Secretary.",
     "start": 10680.337,
     "end": 10680.337
   },
   {
-    "text": "Bouquet: Secretary. Chris Nicholson: I really appreciate it and I look forward to you coming back often to update us on how the purchase",
+    "text": "Chris Nicholson: I really appreciate it and I look forward to you coming back often to update us on how the purchase is going.",
     "start": 10680.8258,
     "end": 10687.285388888891
   },
   {
-    "text": "is going.",
+    "text": "Speaker: Yes. And what white.",
     "start": 10689.931,
-    "end": 10689.931
-  },
-  {
-    "text": "Speaker: Yes. And",
-    "start": 10690.472,
     "end": 10690.911039999999
   },
   {
-    "text": "what white. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 10690.911039999999,
     "end": 10691.350079999998
   },
   {
-    "text": "Director Guzman. Michael Guzman: Just",
+    "text": "Michael Guzman: Just really quickly. With regards to this, moving this money from the unrestricted fund is simply to begin the procurement process. And although it's not part of the 2025 budget, we do need to get started on it. However, I would suggest that as we go forward, these buses are meant to be purchased in finality by 2027 to begin this service, and that is work that we will dutifully do on Finance and Planning to ensure that it is included in all necessary documents that come before this Board for approval. And I am certain that our new CFO is up to the task on that. So rest assured, Directors, we're not wantonly spending money. But we do need to authorize this for the procurement of the buses at this point. Thank you.",
     "start": 10691.789119999998,
-    "end": 10692.667199999996
-  },
-  {
-    "text": "really quickly. With regards to this, moving this money from the unrestricted fund is simply to begin the",
-    "start": 10693.545279999995,
-    "end": 10701.008959999983
-  },
-  {
-    "text": "procurement process. And although it's not part of the 2025 budget, we do need to get started",
-    "start": 10701.969,
-    "end": 10705.512529411777
-  },
-  {
-    "text": "on it. However, I would suggest that as we go forward, these buses are meant to be purchased in finality by 2027 to begin this service, and that is work that we will dutifully do on Finance and Planning to ensure that it is included in all necessary documents that come before this Board",
-    "start": 10706.8276,
-    "end": 10726.262874999982
-  },
-  {
-    "text": "for approval. And I am certain that our new CFO is up to the task",
-    "start": 10727.546,
-    "end": 10730.14440000001
-  },
-  {
-    "text": "on that. So rest assured, Directors, we're not wantonly",
-    "start": 10730.43,
-    "end": 10733.784133333327
-  },
-  {
-    "text": "spending money. But we do need to authorize this for the procurement of the buses at",
-    "start": 10734.203399999993,
-    "end": 10740.264044117643
-  },
-  {
-    "text": "this point.",
-    "start": 10740.596382352936,
     "end": 10740.92872058823
   },
   {
-    "text": "Thank you. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Director. Any further discussion on this item? All right. There is a no-- oh, no. Sounds good. All right, it was indicated there will be a no vote, so I will do a roll call vote. Again, this is the budget transfer articulated buses supporting Colfax BRT service. Treasurer Benker.",
     "start": 10741.261058823524,
-    "end": 10741.925735294111
-  },
-  {
-    "text": "you, Director. Any further discussion on",
-    "start": 10742.258073529405,
-    "end": 10743.919764705874
-  },
-  {
-    "text": "this item?",
-    "start": 10744.252102941167,
-    "end": 10744.584441176461
-  },
-  {
-    "text": "All right. There is a no--",
-    "start": 10744.916779411755,
-    "end": 10746.578470588223
-  },
-  {
-    "text": "oh, no.",
-    "start": 10746.910808823517,
-    "end": 10747.24314705881
-  },
-  {
-    "text": "Sounds good. All right, it was indicated there will be a no vote, so I will do a roll",
-    "start": 10747.575485294105,
-    "end": 10753.889911764685
-  },
-  {
-    "text": "call vote. Again, this is the budget transfer articulated buses supporting Colfax",
-    "start": 10754.222249999979,
-    "end": 10758.542647058797
-  },
-  {
-    "text": "BRT service.",
-    "start": 10758.874985294091,
     "end": 10759.207323529385
   },
   {
-    "text": "Treasurer Benker. Karen",
+    "text": "Karen Benker: Yes.",
     "start": 10759.539661764678,
     "end": 10760.307
   },
   {
-    "text": "Benker: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Catlin.",
     "start": 10761.289,
     "end": 10761.6295
   },
   {
-    "text": "Director Catlin. Peggy",
+    "text": "Peggy Catlin: Yes.",
     "start": 10761.6295,
     "end": 10762.23
   },
   {
-    "text": "Catlin: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guissinger.",
     "start": 10763.352,
     "end": 10765.015
   },
   {
-    "text": "Director Guissinger. Lynn",
+    "text": "Lynn Guissinger: Yes.",
     "start": 10765.3755,
     "end": 10766.096
   },
   {
-    "text": "Guissinger: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Gutschenritter.",
     "start": 10766.096,
     "end": 10766.096
   },
   {
-    "text": "Director Gutschenritter. Chris",
+    "text": "Chris Gutschenritter: Yes.",
     "start": 10766.096,
     "end": 10766.096
   },
   {
-    "text": "Gutschenritter: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 10766.858,
     "end": 10767.158500000001
   },
   {
-    "text": "Director Guzman. Michael",
+    "text": "Michael Guzman: Yes.",
     "start": 10767.158500000001,
     "end": 10767.939
   },
   {
-    "text": "Guzman: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Harwick.",
     "start": 10768.38,
     "end": 10768.700499999999
   },
   {
-    "text": "Director Harwick. Ian",
+    "text": "Ian Harwick: Yep.",
     "start": 10768.700499999999,
     "end": 10769.221
   },
   {
-    "text": "Harwick: Yep. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 10769.702,
     "end": 10770.0425
   },
   {
-    "text": "Director Larsen. Matt",
+    "text": "Matt Larsen: Yes.",
     "start": 10770.0425,
     "end": 10770.544
   },
   {
-    "text": "Larsen: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Nicholson.",
     "start": 10770.964,
     "end": 10772.226
   },
   {
-    "text": "Director Nicholson. Chris Nicholson: Nicholson",
+    "text": "Chris Nicholson: Nicholson go brr.",
     "start": 10772.226,
     "end": 10775.211
   },
   {
-    "text": "go brr. Peggy",
+    "text": "Peggy Catlin: What?",
     "start": 10775.211,
     "end": 10775.211
   },
   {
-    "text": "Catlin: What? Chris Nicholson: Sorry that was a bad internet",
+    "text": "Chris Nicholson: Sorry that was a bad internet ref-- yes.",
     "start": 10775.932,
     "end": 10777.535
   },
   {
-    "text": "ref-- yes. Julien Bouquet: Nicholson is",
+    "text": "Julien Bouquet: Nicholson is a yes. Director O'Keefe.",
     "start": 10778.977,
-    "end": 10779.59275
-  },
-  {
-    "text": "a yes.",
-    "start": 10779.879,
     "end": 10780.3295
   },
   {
-    "text": "Director O'Keefe. Patrick",
+    "text": "Patrick O'Keefe: Yes.",
     "start": 10783.19,
     "end": 10783.19
   },
   {
-    "text": "O'Keefe: Yes. Julien Bouquet: Director O'Keefe is",
+    "text": "Julien Bouquet: Director O'Keefe is a yes. Director Paglieri.",
     "start": 10783.19,
-    "end": 10784.311599999999
-  },
-  {
-    "text": "a yes.",
-    "start": 10785.072,
     "end": 10785.4925
   },
   {
-    "text": "Director Paglieri. Brett",
+    "text": "Brett Paglieri: No.",
     "start": 10786.074,
     "end": 10786.074
   },
   {
-    "text": "Paglieri: No. Julien Bouquet: Director Paglieri is",
+    "text": "Julien Bouquet: Director Paglieri is a no. Director Ruscha.",
     "start": 10786.815,
-    "end": 10787.6638
-  },
-  {
-    "text": "a no.",
-    "start": 10787.936,
     "end": 10788.2865
   },
   {
-    "text": "Director Ruscha. Joyann",
+    "text": "Joyann Ruscha: Yes.",
     "start": 10788.857,
     "end": 10788.857
   },
   {
-    "text": "Ruscha: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Whitmore.",
     "start": 10789.778,
     "end": 10790.1085
   },
   {
-    "text": "Director Whitmore. Troy",
+    "text": "Troy Whitmore: Yes.",
     "start": 10790.1085,
     "end": 10791.52
   },
   {
-    "text": "Whitmore: Yes. Julien",
+    "text": "Julien Bouquet: OK. So that passes 12, 1, and 2. All right. Thank you, folks. So we have one--",
     "start": 10793.523,
-    "end": 10793.523
+    "end": 10799.19975
   },
   {
-    "text": "Bouquet: OK. So that passes 12, 1,",
-    "start": 10793.603,
-    "end": 10796.195000000003
-  },
-  {
-    "text": "and 2.",
-    "start": 10797.528,
-    "end": 10797.678
-  },
-  {
-    "text": "All right. Thank",
-    "start": 10797.868,
-    "end": 10798.295333333333
-  },
-  {
-    "text": "you, folks. So we have one-- Jack Kroll: Chairman Bouquet, could you remind us",
-    "start": 10798.569,
-    "end": 10802.002692307693
-  },
-  {
-    "text": "over here? We missed who the mover and the seconder were",
-    "start": 10802.372384615386,
+    "text": "Jack Kroll: Chairman Bouquet, could you remind us over here? We missed who the mover and the seconder were on that.",
+    "start": 10800.011,
     "end": 10806.069307692318
   },
   {
-    "text": "on that. Julien Bouquet: I had Guzman",
+    "text": "Julien Bouquet: I had Guzman and Whitmore.",
     "start": 10806.799,
     "end": 10807.584600000004
   },
   {
-    "text": "and Whitmore. Jack",
+    "text": "Jack Kroll: OK. Thank you.",
     "start": 10808.281,
-    "end": 10808.281
-  },
-  {
-    "text": "Kroll: OK.",
-    "start": 10808.381,
     "end": 10808.531500000001
   },
   {
-    "text": "Thank you. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. OK. Excellent. Thank you all again for your patience. We do have one more item, and that is the equitable transit oriented development policy amendment. So for the Board of Directors to approve the amendment to resolution number two, series of 2021, which created the equitable transit oriented development policy that permits and encourages the development of affordable housing on RTD real property in order to include guidelines for disposing of RTD real property below fair market value or rent. Do we have a motion?",
     "start": 10809.403,
-    "end": 10809.553
-  },
-  {
-    "text": "Thank",
-    "start": 10810.578,
-    "end": 10810.578
-  },
-  {
-    "text": "you.",
-    "start": 10811.479,
-    "end": 10811.479
-  },
-  {
-    "text": "OK. Excellent. Thank you all again for",
-    "start": 10812.307625000001,
-    "end": 10813.433375000004
-  },
-  {
-    "text": "your patience. We do have one more item, and that is the equitable transit oriented development",
-    "start": 10813.661,
-    "end": 10819.198812500006
-  },
-  {
-    "text": "policy amendment. So for the Board of Directors to approve the amendment to resolution number two, series of 2021, which created the equitable transit oriented development policy that permits and encourages the development of affordable housing on RTD real property in order to include guidelines for disposing of RTD real property below fair market value",
-    "start": 10820.929,
-    "end": 10839.971400000002
-  },
-  {
-    "text": "or rent. Do we have",
-    "start": 10840.739,
     "end": 10841.2678
   },
   {
-    "text": "a motion? Michael Guzman: So",
+    "text": "Michael Guzman: So moved, Guzman.",
     "start": 10841.6,
     "end": 10842.522
   },
   {
-    "text": "moved, Guzman. Julien Bouquet: Guzman is",
+    "text": "Julien Bouquet: Guzman is the mover. Do we have a second?",
     "start": 10842.522,
-    "end": 10843.107750000003
-  },
-  {
-    "text": "the mover. Do we have",
-    "start": 10843.343,
     "end": 10843.807800000002
   },
   {
-    "text": "a second? Ian",
+    "text": "Ian Harwick: Second.",
     "start": 10843.807800000002,
     "end": 10843.807800000002
   },
   {
-    "text": "Harwick: Second. Julien Bouquet: I have Harwick as",
+    "text": "Julien Bouquet: I have Harwick as the second. I do understand that on this item, we have some proposed amendments from Director Nicholson and Director Ruscha. Since Director Nicholson's amendment was circulated to the Board first, we will start there. Director Nicholson, please now make your motion to amend.",
     "start": 10844.445,
-    "end": 10845.39666666667
-  },
-  {
-    "text": "the second. I do understand that on this item, we have some proposed amendments from Director Nicholson and",
-    "start": 10847.55,
-    "end": 10852.544222222208
-  },
-  {
-    "text": "Director Ruscha. Since Director Nicholson's amendment was circulated to the Board first, we will",
-    "start": 10853.78,
-    "end": 10857.351285714296
-  },
-  {
-    "text": "start there. Director Nicholson, please now make your motion",
-    "start": 10858.247,
     "end": 10860.757222222219
   },
   {
-    "text": "to amend. Chris",
+    "text": "Chris Nicholson: Yes. I'd like to move to amend the ETOD policy. And I'm hoping that GM/CEO-- not GM/CEO. That Mr. Kroll can put up that language on the screen.",
     "start": 10861.675,
-    "end": 10861.675
-  },
-  {
-    "text": "Nicholson: Yes. I'd like to move to amend the",
-    "start": 10862.181107142856,
-    "end": 10866.229964285714
-  },
-  {
-    "text": "ETOD policy. And I'm hoping that GM/CEO--",
-    "start": 10866.736071428571,
-    "end": 10869.772714285715
-  },
-  {
-    "text": "not GM/CEO.",
-    "start": 10869.772714285715,
-    "end": 10870.278821428572
-  },
-  {
-    "text": "That Mr. Kroll can put up that language on",
-    "start": 10870.78492857143,
     "end": 10875.339892857144
   },
   {
-    "text": "the screen. Speaker:",
+    "text": "Speaker: It's there.",
     "start": 10876.808,
     "end": 10877.0185
   },
   {
-    "text": "It's there. Chris",
+    "text": "Chris Nicholson: Great. May I?",
     "start": 10877.89,
-    "end": 10879.774
-  },
-  {
-    "text": "Nicholson: Great.",
-    "start": 10879.774,
     "end": 10879.914499999999
   },
   {
-    "text": "May I? Julien Bouquet: Would you like to read the motion and then we'll get",
+    "text": "Julien Bouquet: Would you like to read the motion and then we'll get a second?",
     "start": 10881.47,
     "end": 10884.036571428562
   },
   {
-    "text": "a second? Chris Nicholson:",
+    "text": "Chris Nicholson: Thank you. Yeah. So move to amend the policy such that Section 5 of the equitable transit oriented development policy regarding negotiated land price be updated as follows. To raise the maximum negotiated land price discount to 75% from 50% and add the following additional factors to favorably consider projects which include more accessible units than required by law, limit residential parking, are deeply affordable, emphasize priority groups as identified by the Colorado Housing and Finance Authority, and incorporate smaller footprint retail, including below market rate units-- below market rate retail, excuse me, that prioritizes local businesses and entrepreneurs.",
     "start": 10884.374,
-    "end": 10884.5545
-  },
-  {
-    "text": "Thank",
-    "start": 10884.775,
-    "end": 10884.775
-  },
-  {
-    "text": "you. Yeah. So move to amend the policy such that Section 5 of the equitable transit oriented development policy regarding negotiated land price be updated",
-    "start": 10885.315,
-    "end": 10894.768333333357
-  },
-  {
-    "text": "as follows. To raise the maximum negotiated land price discount to 75% from 50% and add the following additional factors to favorably consider projects which include more accessible units than required by law, limit residential parking, are deeply affordable, emphasize priority groups as identified by the Colorado Housing and Finance Authority, and incorporate smaller footprint retail, including below market rate units-- below market rate retail, excuse me, that prioritizes local businesses",
-    "start": 10895.131923076948,
     "end": 10928.442559322031
   },
   {
-    "text": "and entrepreneurs. Julien",
+    "text": "Julien Bouquet: Excellent.",
     "start": 10929.125,
     "end": 10929.125
   },
   {
-    "text": "Bouquet: Excellent. Jack Kroll: Do we have",
+    "text": "Jack Kroll: Do we have a second?",
     "start": 10933.271,
     "end": 10933.846625000002
   },
   {
-    "text": "a second? Julien Bouquet: And do we have a second",
+    "text": "Julien Bouquet: And do we have a second on that?",
     "start": 10933.846625000002,
     "end": 10934.076875000002
   },
   {
-    "text": "on that? Ian",
+    "text": "Ian Harwick: Second.",
     "start": 10934.793,
     "end": 10934.793
   },
   {
-    "text": "Harwick: Second. Julien Bouquet: Harwick is",
+    "text": "Julien Bouquet: Harwick is the second. Secretary, would you like to discuss further?",
     "start": 10935.454,
-    "end": 10936.110799999997
-  },
-  {
-    "text": "the second. Secretary, would you like to",
-    "start": 10938.458,
     "end": 10940.003428571434
   },
   {
-    "text": "discuss further? Chris Nicholson:",
+    "text": "Chris Nicholson: Thank you. Yes. Before I get into my remarks, I'd like to ask Executive Manager Kroll to briefly describe the five pieces of written public comment that we received on this recommended action from some of our local public officials.",
     "start": 10940.281,
-    "end": 10940.4715
-  },
-  {
-    "text": "Thank",
-    "start": 10940.682,
-    "end": 10940.682
-  },
-  {
-    "text": "you. Yes. Before I get into my remarks, I'd like to ask Executive Manager Kroll to briefly describe the five pieces of written public comment that we received on this recommended action from some of our local",
-    "start": 10941.222,
     "end": 10953.246000000026
   },
   {
-    "text": "public officials. Jack",
+    "text": "Jack Kroll: Yes. So four of the written public comment items were submitted by individuals specifically supportive of the change Director Nicholson is offering. And those four individuals were the mayor of Boulder, a city council member from Boulder, a city council member from Westminster, and the Colorado Cross Disability Coalition. And then the fifth letter was submitted by SWEEP in joint with Conservation Colorado and Denver Streets Partnership, which spoke more broadly to the overall changes being offered this evening.",
     "start": 10954.083,
-    "end": 10954.083
-  },
-  {
-    "text": "Kroll: Yes. So four of the written public comment items were submitted by individuals specifically supportive of the change Director Nicholson",
-    "start": 10954.452636363636,
-    "end": 10961.845363636381
-  },
-  {
-    "text": "is offering. And those four individuals were the mayor of Boulder, a city council member from Boulder, a city council member from Westminster, and the Colorado Cross",
-    "start": 10962.255,
-    "end": 10971.532185185193
-  },
-  {
-    "text": "Disability Coalition. And then the fifth letter was submitted by SWEEP in joint with Conservation Colorado and Denver Streets Partnership, which spoke more broadly to the overall changes being offered",
-    "start": 10971.869,
     "end": 10985.484499999979
   },
   {
-    "text": "this evening. Julien",
+    "text": "Julien Bouquet: Perfect. Secretary.",
     "start": 10988.799,
-    "end": 10988.799
-  },
-  {
-    "text": "Bouquet:",
-    "start": 10989.1095,
     "end": 10989.1095
   },
   {
-    "text": "Perfect. Secretary. Chris Nicholson:",
+    "text": "Chris Nicholson: Thank you. And thank you, Mr. Executive Manager Kroll. So here at RTD, we make lives better through connections. Tonight as a Board, we have an opportunity to do that in a particularly powerful way. Our rider surveys tell a clear story. Over half of our passengers live below 200% of the federal poverty level, and they are far less likely to own a car. Our riders with disabilities use RTD at disproportionately high rates, as do other vulnerable populations in our community. Yet only a fraction of affordable housing developed near our stations truly meets the needs of our most dedicated riders. Communities in our state have struggled to create housing targeted at our ridership. Inclusionary zoning has mostly led to housing at 60% AMI, about $51,000 a year in earnings. This housing is necessary, but priced well out of reach for someone making only $31,000, which is 200% of the federal poverty line. This amendment empowers RTD to deepen our land discount offerings up to 75% to incentivize projects specifically tailored to the actual economic realities of our riders. Here's how that can work in practice. Just this month, Denver Health donated the land to create Tapestry, a deeply affordable, accessible, transit- oriented housing project. It supports a range of affordability from 30% to 80% as well as far more three bedroom and even four bedroom units than most affordable projects being built today. It targets accessibility because distance to transit is a major barrier for people with disabilities to use transit. This holds for all types of disabilities, and unfortunately, painfully few class A fully accessible units exist in the RTD service area. By creating greater incentives for developers, we can do a lot to play our part in fixing that. It's late, so I won't go through the argument for reduced parking and service of CFHA's priority populations. You all have an email from me with that data. But I do want Director Harwick to speak after me to address the language, he added on smaller footprint and below market retail. Community is about more than housing, and I enthusiastically added his language for the reasons he'll highlight. This framework recognizes that we are not the housing policy experts. It increases the scope of our tools and trusts our staff to use them effectively to bring us thoughtful projects, projects that align with our strategic priority of community value and enable us to grow ridership by putting the people who most need transit where they can best be served by it. I ask your support for this amendment.",
     "start": 10989.881,
-    "end": 10990.482
-  },
-  {
-    "text": "Thank you. And thank",
-    "start": 10991.204,
-    "end": 10992.455999999998
-  },
-  {
-    "text": "you, Mr. Executive",
-    "start": 10992.455999999998,
-    "end": 10993.290666666664
-  },
-  {
-    "text": "Manager Kroll. So here at RTD, we make lives better",
-    "start": 10994.465,
-    "end": 10996.970599999993
-  },
-  {
-    "text": "through connections. Tonight as a Board, we have an opportunity to do that in a particularly",
-    "start": 10997.61,
-    "end": 11000.970937499993
-  },
-  {
-    "text": "powerful way. Our rider surveys tell a",
-    "start": 11002.076,
-    "end": 11003.72428571429
-  },
-  {
-    "text": "clear story. Over half of our passengers live below 200% of the federal poverty level, and they are far less likely to own",
-    "start": 11004.5,
-    "end": 11010.827681818193
-  },
-  {
-    "text": "a car. Our riders with disabilities use RTD at disproportionately high rates, as do other vulnerable populations in",
-    "start": 11011.87,
-    "end": 11018.320555555561
-  },
-  {
-    "text": "our community. Yet only a fraction of affordable housing developed near our stations truly meets the needs of our most",
-    "start": 11018.68,
-    "end": 11025.22455000001
-  },
-  {
-    "text": "dedicated riders. Communities in our state have struggled to create housing targeted at",
-    "start": 11026.25,
-    "end": 11029.929384615389
-  },
-  {
-    "text": "our ridership. Inclusionary zoning has mostly led to housing at 60% AMI, about $51,000 a year",
-    "start": 11030.636,
-    "end": 11037.075687500006
-  },
-  {
-    "text": "in earnings. This housing is necessary, but priced well out of reach for someone making only $31,000, which is 200% of the federal",
-    "start": 11037.525,
-    "end": 11045.87734782609
-  },
-  {
-    "text": "poverty line. This amendment empowers RTD to deepen our land discount offerings up to 75% to incentivize projects specifically tailored to the actual economic realities of",
-    "start": 11046.237,
-    "end": 11055.251423076905
-  },
-  {
-    "text": "our riders. Here's how that can work",
-    "start": 11056.273,
-    "end": 11057.749857142853
-  },
-  {
-    "text": "in practice. Just this month, Denver Health donated the land to create Tapestry, a deeply affordable, accessible, transit- oriented",
-    "start": 11058.016,
-    "end": 11064.808444444447
-  },
-  {
-    "text": "housing project. It supports a range of affordability from 30% to 80% as well as far more three bedroom and even four bedroom units than most affordable projects being",
-    "start": 11065.627,
-    "end": 11074.33892592591
-  },
-  {
-    "text": "built today. It targets accessibility because distance to transit is a major barrier for people with disabilities to",
-    "start": 11075.456,
-    "end": 11081.943181818186
-  },
-  {
-    "text": "use transit. This holds for all types of disabilities, and unfortunately, painfully few class A fully accessible units exist in the RTD",
-    "start": 11082.703,
-    "end": 11091.178409090906
-  },
-  {
-    "text": "service area. By creating greater incentives for developers, we can do a lot to play our part in",
-    "start": 11092.143,
-    "end": 11096.666888888903
-  },
-  {
-    "text": "fixing that. It's late, so I won't go through the argument for reduced parking and service of CFHA's",
-    "start": 11097.082,
-    "end": 11103.248421052618
-  },
-  {
-    "text": "priority populations. You all have an email from me with",
-    "start": 11103.892,
-    "end": 11105.351800000006
-  },
-  {
-    "text": "that data. But I do want Director Harwick to speak after me to address the language, he added on smaller footprint and below",
-    "start": 11106.015,
-    "end": 11112.183608695657
-  },
-  {
-    "text": "market retail. Community is about more than housing, and I enthusiastically added his language for the reasons",
-    "start": 11113.285,
-    "end": 11119.335823529425
-  },
-  {
-    "text": "he'll highlight. This framework recognizes that we are not the housing",
-    "start": 11119.947,
-    "end": 11124.244272727272
-  },
-  {
-    "text": "policy experts. It increases the scope of our tools and trusts our staff to use them effectively to bring us thoughtful projects, projects that align with our strategic priority of community value and enable us to grow ridership by putting the people who most need transit where they can best be served",
-    "start": 11125.195,
-    "end": 11143.799211538459
-  },
-  {
-    "text": "by it. I ask your support for",
-    "start": 11144.665,
     "end": 11146.484714285718
   },
   {
-    "text": "this amendment. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Director Harwick.",
     "start": 11147.469,
-    "end": 11147.5795
-  },
-  {
-    "text": "Thank you.",
-    "start": 11147.71,
     "end": 11147.869999999999
   },
   {
-    "text": "Director Harwick. Ian",
+    "text": "Ian Harwick: Yeah. So I wanted to make sure that when we're talking about TOD, that we're really thinking also about mixed use TOD. And I'm wildly in favor of anything that we can do to bring more housing, let alone affordable housing, to our park and rides. I do think it's really key that we also think about what are the businesses that we are bringing in there. And having spent a lot of time working at Starbucks and a good friend of mine works at Starbucks, I'm also really in favor of coffee shops like Prodigy and smaller shops. But also thinking about when I've traveled to travel to other communities throughout the world, there oftentimes are smaller retail shops that give young entrepreneurs that opportunity to start a business and not be burdened by a larger footprint that some of our larger restaurants or larger retail shops can. They can cover those costs. So this, to me, was a way to encourage local businesses to start up or expand give them the opportunity in a place that we all-- when we go to a park and ride and there's not something there to grab that quick bite to eat, I want to give them that opportunity, everyone that opportunity. One to shop there and sell there.",
     "start": 11149.512,
-    "end": 11149.512
-  },
-  {
-    "text": "Harwick: Yeah. So I wanted to make sure that when we're talking about TOD, that we're really thinking also about mixed",
-    "start": 11149.900214285715,
-    "end": 11157.664500000008
-  },
-  {
-    "text": "use TOD. And I'm wildly in favor of anything that we can do to bring more housing, let alone affordable housing, to our park",
-    "start": 11158.052714285723,
-    "end": 11166.758600000003
-  },
-  {
-    "text": "and rides. I do think it's really key that we also think about what are the businesses that we are bringing",
-    "start": 11167.019,
-    "end": 11173.245969696982
-  },
-  {
-    "text": "in there. And having spent a lot of time working at Starbucks and a good friend of mine works at Starbucks, I'm also really in favor of coffee shops like Prodigy and",
-    "start": 11173.55731818183,
-    "end": 11184.454515151549
-  },
-  {
-    "text": "smaller shops. But also thinking about when I've traveled to travel to other communities throughout the world, there oftentimes are smaller retail shops that give young entrepreneurs that opportunity to start a business and not be burdened by a larger footprint that some of our larger restaurants or larger retail",
-    "start": 11184.765863636398,
-    "end": 11201.764433333306
-  },
-  {
-    "text": "shops can. They can cover",
-    "start": 11202.138549999972,
-    "end": 11204.009133333302
-  },
-  {
-    "text": "those costs. So this, to me, was a way to encourage local businesses to start up or expand give them the opportunity in a place that we all-- when we go to a park and ride and there's not something there to grab that quick bite to eat, I want to give them that opportunity, everyone",
-    "start": 11204.383249999968,
-    "end": 11223.498140350855
-  },
-  {
-    "text": "that opportunity. One to shop there and",
-    "start": 11223.774122806995,
     "end": 11225.430017543835
   },
   {
-    "text": "sell there. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director Harwick. Any further discussion on this amendment? Director Ruscha?",
     "start": 11227.089,
-    "end": 11227.68975
-  },
-  {
-    "text": "Director Harwick. Any further discussion on",
-    "start": 11228.632,
-    "end": 11229.86783333333
-  },
-  {
-    "text": "this amendment?",
-    "start": 11231.217,
     "end": 11231.5075
   },
   {
-    "text": "Director Ruscha? Joyann",
+    "text": "Joyann Ruscha: Mr. Chair, maybe you can help me here. So I had a comment, but I had a comment on the main motion. But we moved to amendments. But recognizing that Secretary Nicholson's language can't exist without the motion language or the way it's drafted. May I just make a general comment? Does that make sense? It would apply to both, but I don't know if I would be called out of order. And I'm tired. I will do what you say.",
     "start": 11232.082,
-    "end": 11232.335777777778
-  },
-  {
-    "text": "Ruscha: Mr. Chair, maybe you can help",
-    "start": 11232.589555555556,
-    "end": 11234.112222222224
-  },
-  {
-    "text": "me here. So I had a comment, but I had a comment on the",
-    "start": 11234.446,
-    "end": 11238.176299999988
-  },
-  {
-    "text": "main motion. But we moved",
-    "start": 11238.442749999987,
-    "end": 11239.508549999984
-  },
-  {
-    "text": "to amendments. But recognizing that Secretary Nicholson's language can't exist without the motion language or the way",
-    "start": 11240.216,
-    "end": 11245.79766666666
-  },
-  {
-    "text": "it's drafted. May I just make a",
-    "start": 11246.346,
-    "end": 11248.011428571424
-  },
-  {
-    "text": "general comment? Does that",
-    "start": 11248.31,
-    "end": 11249.194166666664
-  },
-  {
-    "text": "make sense? It would apply to both, but I don't know if I would be called out",
-    "start": 11249.391,
-    "end": 11252.243799999993
-  },
-  {
-    "text": "of order. And",
-    "start": 11252.422099999992,
-    "end": 11252.778699999992
-  },
-  {
-    "text": "I'm tired. I will do what",
-    "start": 11253.779,
     "end": 11254.313166666667
   },
   {
-    "text": "you say. Julien Bouquet: You",
+    "text": "Julien Bouquet: You know what? Why not? Let's give it a try.",
     "start": 11254.52,
-    "end": 11254.787333333334
-  },
-  {
-    "text": "know what?",
-    "start": 11255.081,
-    "end": 11255.2915
-  },
-  {
-    "text": "Why not? Let's give it",
-    "start": 11255.562,
     "end": 11256.346800000001
   },
   {
-    "text": "a try. Joyann Ruscha:",
+    "text": "Joyann Ruscha: OK, thanks. I'm doing my best. So this morning, we got an email from staff that addressed some outstanding questions that I still had, just so I knew what I was voting on. And the issue-- I have heartburn over just the main motion because the way it's written. We, as a Board, are not just expanding the bounds of what a policy is. We're also signing away 30 plus years of precedent of having this guardrail that says, before you go dispense a real property, get our preliminary authorization. So I am already a little bit uncomfortable. And also the policy says that if a developer, as it relates to housing, cannot meet our 50% standard, they could still get a major discount and it could be millions and millions of dollars. And so those two combined and just recognizing that these deals take a long, long time. They're not summer projects. In some, it means that all of that is going to happen. And then it's going to come back to the Board when all of those decisions have been made. So for that, because I'm struggling with the original proposal, but I can accept it for now, is why I can't vote yes on Secretary Nicholson's amendment, because we don't have guardrails that I would prefer. So I hope that was not out of order. And if it was, thanks for not calling me out of order.",
     "start": 11256.564,
-    "end": 11257.014500000001
-  },
-  {
-    "text": "OK, thanks. I'm doing",
-    "start": 11257.445,
-    "end": 11257.955749999997
-  },
-  {
-    "text": "my best. So this morning, we got an email from staff that addressed some outstanding questions that I still had, just so I knew what I was",
-    "start": 11259.087928571427,
-    "end": 11270.058071428555
-  },
-  {
-    "text": "voting on. And the issue-- I have heartburn over just the main motion because the way",
-    "start": 11271.04,
-    "end": 11280.571052631589
-  },
-  {
-    "text": "it's written. We, as a Board, are not just expanding the bounds of what a",
-    "start": 11281.251842105274,
-    "end": 11287.889368421043
-  },
-  {
-    "text": "policy is. We're also signing away 30 plus years of precedent of having this guardrail that says, before you go dispense a real property, get our",
-    "start": 11288.245605263148,
-    "end": 11297.507763157862
-  },
-  {
-    "text": "preliminary authorization. So I am already a little",
-    "start": 11298.484,
-    "end": 11305.789833333341
-  },
-  {
-    "text": "bit uncomfortable. And also the policy says that if a developer, as it relates to housing, cannot meet our 50% standard, they could still get a major discount and it could be millions and millions",
-    "start": 11306.855,
-    "end": 11321.619374999993
-  },
-  {
-    "text": "of dollars. And so those two combined and just recognizing that these deals take a long,",
-    "start": 11322.496,
-    "end": 11327.496250000011
-  },
-  {
-    "text": "long time. They're not",
-    "start": 11327.829600000012,
-    "end": 11328.829650000014
-  },
-  {
-    "text": "summer projects. In some, it means that all of that is going",
-    "start": 11330.645,
-    "end": 11333.88963333333
-  },
-  {
-    "text": "to happen. And then it's going to come back to the Board when all of those decisions have",
-    "start": 11334.184599999997,
-    "end": 11339.199033333325
-  },
-  {
-    "text": "been made. So for that, because I'm struggling with the original proposal, but I can accept it for now, is why I can't vote yes on Secretary Nicholson's amendment, because we don't have guardrails that I",
-    "start": 11340.985866666666,
-    "end": 11357.793133333333
-  },
-  {
-    "text": "would prefer. So I hope that was not out",
-    "start": 11358.224088888888,
-    "end": 11360.88445
-  },
-  {
-    "text": "of order. And if it was, thanks for not calling me out",
-    "start": 11361.0888,
     "end": 11363.33665
   },
   {
-    "text": "of order. Julien Bouquet:",
+    "text": "Julien Bouquet: Thank you. Thank you, Director Ruscha. Director Guzman.",
     "start": 11363.561,
-    "end": 11363.7415
-  },
-  {
-    "text": "Thank you. Thank you,",
-    "start": 11364.202,
-    "end": 11365.324
-  },
-  {
-    "text": "Director Ruscha.",
-    "start": 11365.324,
     "end": 11365.5945
   },
   {
-    "text": "Director Guzman. Michael Guzman: So ETOD has been discussed a number of times in the committee, and this is",
+    "text": "Michael Guzman: So ETOD has been discussed a number of times in the committee, and this is my concern. Although I am with you in spirit-- deeply affordable housing is really important-- I'm not sure that giving an additional 25% discount in our policy is wise for a number of reasons. I do believe, however-- and maybe Madam CEO or Ms. Chessy Brady might be able to speak to this. I'm not sure. What we were asked for in this policy was to give guidelines to begin negotiation that would eventually come back to this Board. Let's say a developer comes to us and just brings us an amazing proposal that includes everything that you could want in a development and more. I don't see why they wouldn't necessarily come back to us and say, hey, they're willing to do all of these things-- they being staff-- and asking for an additional amount of up to whatever amount makes sense to give that discount from the Board that we would consider properly and then be able to authorize in that moment. But in order to begin the process, we were simply asked to give authorization for them to work within a parameter. That way, there was no confusion that they would be able to do a 30% to 50% discount as was written in the original policy. Beyond that, the Board would still have authority, as I understand it, if we were asked to offer an additional discount for more. I don't know that we need to lock that into policy, and it does the one thing that I was trained by former Directors and members that are currently here not to do, which is bind future boards in a way that creates difficulty for us to do our job as the fiduciaries of the agency. And so I would like to ask that question. Is there anything that would prevent you from coming back to us if we were to receive such an excellent proposal that prevents you from saying, can we receive an additional discount to offer a developer, Board, and would you approve this so we can make a project work?",
     "start": 11365.5945,
-    "end": 11373.09964705882
-  },
-  {
-    "text": "my concern. Although I am with you in spirit-- deeply affordable housing is really important-- I'm not sure that giving an additional 25% discount in our policy is wise for a number",
-    "start": 11376.302,
-    "end": 11390.586578947368
-  },
-  {
-    "text": "of reasons. I do believe, however-- and maybe Madam CEO",
-    "start": 11391.605,
-    "end": 11396.039300000006
-  },
-  {
-    "text": "or Ms. Chessy Brady might be able to speak",
-    "start": 11396.572,
-    "end": 11398.334000000003
-  },
-  {
-    "text": "to this. I'm",
-    "start": 11398.554250000003,
-    "end": 11398.994750000003
-  },
-  {
-    "text": "not sure. What we were asked for in this policy was to give guidelines to begin negotiation that would eventually come back to",
-    "start": 11401.058,
-    "end": 11408.010956521728
-  },
-  {
-    "text": "this Board. Let's say a developer comes to us and just brings us an amazing proposal that includes everything that you could want in a development",
-    "start": 11409.539,
-    "end": 11421.234192307707
-  },
-  {
-    "text": "and more. I don't see why they wouldn't necessarily come back to us and say, hey, they're willing to do all of these things-- they being staff-- and asking for an additional amount of up to whatever amount makes sense to give that discount from the Board that we would consider properly and then be able to authorize in",
-    "start": 11421.722,
-    "end": 11443.060520000021
-  },
-  {
-    "text": "that moment. But in order to begin the process, we were simply asked to give authorization for them to work within",
-    "start": 11444.244,
-    "end": 11450.405904761903
-  },
-  {
-    "text": "a parameter. That way, there was no confusion that they would be able to do a 30% to 50% discount as was written in the",
-    "start": 11450.774,
-    "end": 11456.870959999995
-  },
-  {
-    "text": "original policy. Beyond that, the Board would still have authority, as I understand it, if we were asked to offer an additional discount",
-    "start": 11457.626,
-    "end": 11465.913142857153
-  },
-  {
-    "text": "for more. I don't know that we need to lock that into policy, and it does the one thing that I was trained by former Directors and members that are currently here not to do, which is bind future boards in a way that creates difficulty for us to do our job as the fiduciaries of",
-    "start": 11466.888,
-    "end": 11484.319071428565
-  },
-  {
-    "text": "the agency. And so I would like to ask",
-    "start": 11484.796,
-    "end": 11486.558666666662
-  },
-  {
-    "text": "that question. Is there anything that would prevent you from coming back to us if we were to receive such an excellent proposal that prevents you from saying, can we receive an additional discount to offer a developer, Board, and would you approve this so we can make a",
-    "start": 11487.265,
     "end": 11502.982916666664
   },
   {
-    "text": "project work? Julien",
+    "text": "Julien Bouquet: Ms. Brady. First off, thank you for your patience and greatly appreciate you sticking around tonight.",
     "start": 11504.967,
-    "end": 11504.967
-  },
-  {
-    "text": "Bouquet:",
-    "start": 11505.167,
-    "end": 11505.167
-  },
-  {
-    "text": "Ms. Brady. First off, thank you for your patience and greatly appreciate you sticking",
-    "start": 11505.382375,
     "end": 11508.663142857145
   },
   {
-    "text": "around tonight. Chessy Brady:",
+    "text": "Chessy Brady: Of course.",
     "start": 11508.993,
     "end": 11509.213
   },
   {
-    "text": "Of course. Julien Bouquet:",
+    "text": "Julien Bouquet: You're recognized.",
     "start": 11509.774,
     "end": 11510.414499999999
   },
   {
-    "text": "You're recognized. Chessy Brady:",
+    "text": "Chessy Brady: Thank you. No, there is nothing that would stop us from doing that. As you say, the point of the policy is to create guardrails and certainty within those guardrails. We would use the opinions of the Board to guide developers towards what we think the Board would be interested in, as we're negotiating with them, and we come back to the Board for approval of any given project.",
     "start": 11511.376,
-    "end": 11511.546
-  },
-  {
-    "text": "Thank you. No, there is nothing that would stop us from",
-    "start": 11512.357,
-    "end": 11515.033363636365
-  },
-  {
-    "text": "doing that. As you say, the point of the policy is to create guardrails and certainty within",
-    "start": 11515.762,
-    "end": 11521.153058823531
-  },
-  {
-    "text": "those guardrails. We would use the opinions of the Board to guide developers towards what we think the Board would be interested in, as we're negotiating with them, and we come back to the Board for approval of any",
-    "start": 11522.231,
     "end": 11534.73133333333
   },
   {
-    "text": "given project. Karen Benker:",
+    "text": "Karen Benker: Thank you. One more quick thing. And Director Benker, Treasurer Benker, the sales and the lease income from our real estate properties are put into a specific account. Can you guess which one? Because when we deeply discount things beyond where we should, we are saying no to the potential income that we could use for operations and maintenance and service provision elsewhere in the agency. So on balance, real estate and real property are a finite resource and dollars can be stretched thin. But how we use the opportunity to either receive money to prolong and serve the public further is a huge consideration in this. So although I am with you in spirit, I would be voting no on the amendment as it is right now.",
     "start": 11535.906,
-    "end": 11536.076000000001
-  },
-  {
-    "text": "Thank you. One more",
-    "start": 11537.047,
-    "end": 11537.797750000002
-  },
-  {
-    "text": "quick thing. And Director Benker, Treasurer Benker, the sales and the lease income from our real estate properties are put into a",
-    "start": 11538.388,
-    "end": 11548.783000000018
-  },
-  {
-    "text": "specific account. Can you guess",
-    "start": 11549.298,
-    "end": 11550.050800000003
-  },
-  {
-    "text": "which one? Because when we deeply discount things beyond where we should, we are saying no to the potential income that we could use for operations and maintenance and service provision elsewhere in",
-    "start": 11550.979,
-    "end": 11564.21575
-  },
-  {
-    "text": "the agency. So on balance, real estate and real property are a finite resource and dollars can be",
-    "start": 11565.147,
-    "end": 11572.33138888889
-  },
-  {
-    "text": "stretched thin. But how we use the opportunity to either receive money to prolong and serve the public further is a huge consideration",
-    "start": 11573.515,
-    "end": 11583.702913043497
-  },
-  {
-    "text": "in this. So although I am with you in spirit, I would be voting no on the amendment as it is",
-    "start": 11584.386,
     "end": 11588.809809523797
   },
   {
-    "text": "right now. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Director. Director Paglieri.",
     "start": 11589.711,
-    "end": 11591.273
-  },
-  {
-    "text": "you, Director.",
-    "start": 11591.273,
     "end": 11591.7435
   },
   {
-    "text": "Director Paglieri. Brett Paglieri:",
+    "text": "Brett Paglieri: Thank you. I'll be brief. I really like the language that highlights these things that I deeply agree with. I am a little bit concerned about two things. The first is the language deeply affordable. It's a little bit ambiguous, if I'm saying that right. And I think using language like that can-- what's to say they discounted $100? To some, that's a deep discount. To others, that's nothing. So I'd recommend removing that word and just maybe also deeply affordable unless you can define it elsewhere. But I do want to leave this language. And the other thing is I just have a hard time giving a 75% discount even with these things that I want. And perhaps that this is a really limited circumstance that we'd give 75% But this is our property, and I really would like to see it sold for the highest value to benefit all. Thank you.",
     "start": 11592.481,
-    "end": 11592.681199999999
-  },
-  {
-    "text": "Thank you. I'll",
-    "start": 11592.881399999998,
-    "end": 11593.281799999997
-  },
-  {
-    "text": "be brief. I really like the language that highlights these things that I deeply",
-    "start": 11594.563,
-    "end": 11598.949571428577
-  },
-  {
-    "text": "agree with. I am a little bit concerned about",
-    "start": 11600.068,
-    "end": 11601.45644444444
-  },
-  {
-    "text": "two things. The first is the language",
-    "start": 11601.67,
-    "end": 11603.968857142858
-  },
-  {
-    "text": "deeply affordable. It's a little bit ambiguous, if I'm saying",
-    "start": 11604.813,
-    "end": 11608.740600000005
-  },
-  {
-    "text": "that right. And I think using language like that can-- what's to say they",
-    "start": 11610.118,
-    "end": 11616.138000000004
-  },
-  {
-    "text": "discounted $100? To some, that's a",
-    "start": 11616.568000000005,
-    "end": 11618.718000000006
-  },
-  {
-    "text": "deep discount. To others,",
-    "start": 11619.148000000007,
-    "end": 11620.438000000007
-  },
-  {
-    "text": "that's nothing. So I'd recommend removing that word and just maybe also deeply affordable unless you can define",
-    "start": 11620.848,
-    "end": 11628.318555555552
-  },
-  {
-    "text": "it elsewhere. But I do want to leave",
-    "start": 11629.279,
-    "end": 11631.206624999995
-  },
-  {
-    "text": "this language. And the other thing is I just have a hard time giving a 75% discount even with these things that",
-    "start": 11631.502,
-    "end": 11638.421499999997
-  },
-  {
-    "text": "I want. And perhaps that this is a really limited circumstance that we'd give 75% But this is our property, and I really would like to see it sold for the highest value to",
-    "start": 11639.352,
-    "end": 11656.150142857145
-  },
-  {
-    "text": "benefit all.",
-    "start": 11656.772,
     "end": 11656.952000000001
   },
   {
-    "text": "Thank you. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Director. Treasurer Benker.",
     "start": 11657.152,
-    "end": 11658.433333333332
-  },
-  {
-    "text": "you, Director.",
-    "start": 11659.094,
     "end": 11659.3845
   },
   {
-    "text": "Treasurer Benker. Karen Benker: Just a",
+    "text": "Karen Benker: Just a quick question. Some of the surplus properties that we're talking about, we are not including our current park and rides. Correct? Would be excess land, perhaps around a park and ride, but not one of our park and rides. Just clarification.",
     "start": 11661.657,
-    "end": 11662.82775
-  },
-  {
-    "text": "quick question. Some of the surplus properties that we're talking about, we are not including our current park",
-    "start": 11663.739,
-    "end": 11670.36631578948
-  },
-  {
-    "text": "and",
-    "start": 11670.756157894744,
-    "end": 11670.756157894744
-  },
-  {
-    "text": "rides. Correct? Would be excess land, perhaps around a park and ride, but not one of our park",
-    "start": 11672.147,
-    "end": 11678.159333333322
-  },
-  {
-    "text": "and rides.",
-    "start": 11679.758,
     "end": 11680.2785
   },
   {
-    "text": "Just clarification. Chessy Brady:",
+    "text": "Chessy Brady: Thank you. So this policy is aimed at transit oriented development. So property that RTD owns at transit stations or near high frequency transit. Excess property and surplus property are definable terms that perhaps Michelle could help us with. But those are distinctive properties that the Board has named to be excess and surplus. And so I just want to separate that from a park and ride. A park and ride is certainly not excess or surplus. It may have underutilized land. It may have a large drainage area that is part of the park and ride, but not every development that we would consider on a park and ride would remove parking, if that's getting more to your question.",
     "start": 11681.56,
-    "end": 11681.8005
-  },
-  {
-    "text": "Thank you. So this policy is aimed at transit",
-    "start": 11682.061,
-    "end": 11685.514333333338
-  },
-  {
-    "text": "oriented development. So property that RTD owns at transit stations or near high",
-    "start": 11686.487,
-    "end": 11691.422755102041
-  },
-  {
-    "text": "frequency transit. Excess property and surplus property are definable terms that perhaps Michelle could help",
-    "start": 11692.182102040817,
-    "end": 11698.256877551023
-  },
-  {
-    "text": "us with. But those are distinctive properties that the Board has named to be excess",
-    "start": 11698.63655102041,
-    "end": 11704.711326530616
-  },
-  {
-    "text": "and surplus. And so I just want to separate that from a park",
-    "start": 11705.531,
-    "end": 11708.06481818181
-  },
-  {
-    "text": "and ride. A park and ride is certainly not excess",
-    "start": 11708.256,
-    "end": 11710.041599999993
-  },
-  {
-    "text": "or surplus. It may have",
-    "start": 11711.081,
-    "end": 11712.8762
-  },
-  {
-    "text": "underutilized land. It may have a large drainage area that is part of the park and ride, but not every development that we would consider on a park and ride would remove parking, if that's getting more to",
-    "start": 11713.525,
     "end": 11726.926789473715
   },
   {
-    "text": "your question. Karen",
+    "text": "Karen Benker: OK.",
     "start": 11728.09,
     "end": 11728.4405
   },
   {
-    "text": "Benker: OK. Chessy",
+    "text": "Chessy Brady: Yes.",
     "start": 11728.4405,
     "end": 11728.4405
   },
   {
-    "text": "Brady: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Secretary Nicholson.",
     "start": 11731.275,
     "end": 11731.776
   },
   {
-    "text": "Secretary Nicholson. Chris Nicholson: I actually have some questions",
+    "text": "Chris Nicholson: I actually have some questions for Ms. Brady. So first off, Director Paglieri raised the concern about the term deep affordability. I think you and I know what that means, but maybe the rest of the Board doesn't, given it's a term of art. Can you elaborate on what that's referring to?",
     "start": 11731.776,
-    "end": 11735.585857142862
-  },
-  {
-    "text": "for",
-    "start": 11736.493,
-    "end": 11736.493
-  },
-  {
-    "text": "Ms. Brady. So first off, Director Paglieri raised the concern about the term",
-    "start": 11737.454,
-    "end": 11741.870923076933
-  },
-  {
-    "text": "deep affordability. I think you and I know what that means, but maybe the rest of the Board doesn't, given it's a term",
-    "start": 11742.859,
-    "end": 11747.263782608694
-  },
-  {
-    "text": "of art. Can you elaborate on what that's",
-    "start": 11747.505,
     "end": 11750.728500000005
   },
   {
-    "text": "referring to? Julien",
+    "text": "Julien Bouquet: Ms. Brady.",
     "start": 11751.929,
-    "end": 11751.929
-  },
-  {
-    "text": "Bouquet:",
-    "start": 11752.13,
     "end": 11752.13
   },
   {
-    "text": "Ms. Brady. Chessy Brady:",
+    "text": "Chessy Brady: Sure, yes. Deep affordability is a term in the affordable housing network that means generally 30% to 40% of AMI. It is squishy, I think still, but generally it's understood to mean 30% to 40%.",
     "start": 11752.13,
-    "end": 11753.191
-  },
-  {
-    "text": "Sure, yes. Deep affordability is a term in the affordable housing network that means generally 30% to 40%",
-    "start": 11753.671,
-    "end": 11761.291722222219
-  },
-  {
-    "text": "of AMI. It is squishy, I think still, but generally it's understood to mean 30%",
-    "start": 11762.159,
     "end": 11766.936733333328
   },
   {
-    "text": "to 40%. Julien",
+    "text": "Julien Bouquet: Secretary.",
     "start": 11767.338,
     "end": 11767.338
   },
   {
-    "text": "Bouquet: Secretary. Chris Nicholson: So",
+    "text": "Chris Nicholson: So second question. I've heard a couple of concerns about 75% as a discount. I was hoping maybe you could speak to the-- because I mentioned it a little bit. But as someone who's an expert in the space, and I will say you and I worked pretty closely together on this language and went back and forth. You did a meeting with me. So this isn't just something that I wrote myself. This is something that got vetted pretty heavily by staff. What impact does a greater discount have on the types of projects that, in the affordable housing space, you tend to see people able to build? At least from where I sit, the reason for doing this is that when it comes to those deeply affordable, which are deeply subsidized units, when it comes to things like units that are fully accessible, those are expensive. They cost developers money, which is why, when you don't have those subsidies, those units don't get built. I think it's about half the projects that are in the CHFA Database have zero units at 30% AMI, and very few of them have anything with regard to accessibility. So I'm hoping you can maybe elaborate on-- you're the one who would be using this tool at the end of the day. How do you see it coming in handy with regard to what you're able to do? And then I have one last follow up.",
     "start": 11769.905,
-    "end": 11770.949142857144
-  },
-  {
-    "text": "second question. I've heard a couple of concerns about 75% as",
-    "start": 11771.471214285715,
-    "end": 11776.69192857143
-  },
-  {
-    "text": "a discount. I was hoping maybe you could speak to the-- because I mentioned it a",
-    "start": 11778.896,
-    "end": 11782.945100000003
-  },
-  {
-    "text": "little bit. But as someone who's an expert in the space, and I will say you and I worked pretty closely together on this language and went back",
-    "start": 11783.215040000003,
-    "end": 11790.503420000006
-  },
-  {
-    "text": "and forth. You did a meeting",
-    "start": 11790.773360000007,
-    "end": 11792.123060000007
-  },
-  {
-    "text": "with me. So this isn't just something that I",
-    "start": 11792.473,
-    "end": 11794.608999999999
-  },
-  {
-    "text": "wrote myself. This is something that got vetted pretty heavily",
-    "start": 11794.956,
-    "end": 11798.884499999998
-  },
-  {
-    "text": "by staff. What impact does a greater discount have on the types of projects that, in the affordable housing space, you tend to see people able",
-    "start": 11800.229,
-    "end": 11815.26746153846
-  },
-  {
-    "text": "to build? At least from where I sit, the reason for doing this is that when it comes to those deeply affordable, which are deeply subsidized units, when it comes to things like units that are fully accessible, those",
-    "start": 11815.909,
-    "end": 11829.31630769233
-  },
-  {
-    "text": "are expensive. They cost developers money, which is why, when you don't have those subsidies, those units don't",
-    "start": 11829.947,
-    "end": 11836.036777777792
-  },
-  {
-    "text": "get built. I think it's about half the projects that are in the CHFA Database have zero units at 30% AMI, and very few of them have anything with regard",
-    "start": 11836.455,
-    "end": 11847.86185714286
-  },
-  {
-    "text": "to accessibility. So I'm hoping you can maybe elaborate on-- you're the one who would be using this tool at the end of",
-    "start": 11848.328,
-    "end": 11854.15039999999
-  },
-  {
-    "text": "the day. How do you see it coming in handy with regard to what you're able",
-    "start": 11854.433,
-    "end": 11858.786750000001
-  },
-  {
-    "text": "to do? And then I have one last",
-    "start": 11859.698,
     "end": 11860.976374999997
   },
   {
-    "text": "follow up. Julien",
+    "text": "Julien Bouquet: Ms. Brady.",
     "start": 11862.981,
-    "end": 11866.804
-  },
-  {
-    "text": "Bouquet:",
-    "start": 11869.116,
     "end": 11869.116
   },
   {
-    "text": "Ms. Brady. Chessy Brady:",
+    "text": "Chessy Brady: Thank you. So affordable housing projects are notoriously difficult to finance. And I think if you use the example earlier of Tapestry and Denver Health. Denver Health, as you stated, as I assume it's correct, donated the land for Tapestry. I can assure you that development was still very difficult to finance. So even if we were giving the land at 100% discount, the projects would still not pencil, in many cases. And so our ability to discount the land to 75% as the Board prefers, in many cases, could get us over the hump from a project not being built to a project being built, and to that project having more affordable units as opposed to a higher, more of a middle income range. And that's the difference that the land discount makes. And that's the certainty that this policy helps me bring to conversations with developers. Gets them in the mindset of we're going to get some help here from RTD. We can focus on deeper affordability units. We can make bigger promises to CHFA or other financing entities that host in Denver. And it helps us keep the projects moving. And I'll be frank with you. As I said, Tapestry, even with 100% discount, it's still hard to do. This is not a silver bullet. But it moves the needle and it helps us actually keep projects afloat and get to the finish line.",
     "start": 11873.804,
-    "end": 11875.8565
-  },
-  {
-    "text": "Thank you. So affordable housing projects are notoriously difficult",
-    "start": 11878.65,
-    "end": 11882.210888888896
-  },
-  {
-    "text": "to finance. And I think if you use the example earlier of Tapestry and",
-    "start": 11883.337,
-    "end": 11889.03378571428
-  },
-  {
-    "text": "Denver Health. Denver Health, as you stated, as I assume it's correct, donated the land",
-    "start": 11889.413571428566,
-    "end": 11893.591214285705
-  },
-  {
-    "text": "for Tapestry. I can assure you that development was still very difficult",
-    "start": 11894.011,
-    "end": 11897.744846153853
-  },
-  {
-    "text": "to finance. So even if we were giving the land at 100% discount, the projects would still not pencil, in",
-    "start": 11898.937,
-    "end": 11908.332499999995
-  },
-  {
-    "text": "many cases. And so our ability to discount the land to 75% as the Board prefers, in many cases, could get us over the hump from a project not being built to a project being built, and to that project having more affordable units as opposed to a higher, more of a middle",
-    "start": 11909.4,
-    "end": 11931.192814814798
-  },
-  {
-    "text": "income range. And that's the difference that the land",
-    "start": 11931.905,
-    "end": 11934.28988888889
-  },
-  {
-    "text": "discount makes. And that's the certainty that this policy helps me bring to conversations",
-    "start": 11934.949,
-    "end": 11939.547533333334
-  },
-  {
-    "text": "with developers. Gets them in the mindset of we're going to get some help here",
-    "start": 11940.255000000001,
-    "end": 11945.207266666668
-  },
-  {
-    "text": "from RTD. We can focus on deeper",
-    "start": 11946.342,
-    "end": 11948.573142857138
-  },
-  {
-    "text": "affordability units. We can make bigger promises to CHFA or other financing entities that host",
-    "start": 11948.965,
-    "end": 11954.159933333332
-  },
-  {
-    "text": "in Denver. And it helps us keep the",
-    "start": 11955.192,
-    "end": 11958.310499999998
-  },
-  {
-    "text": "projects moving. And I'll be frank",
-    "start": 11959.659,
-    "end": 11961.123999999998
-  },
-  {
-    "text": "with you. As I said, Tapestry, even with 100% discount, it's still hard",
-    "start": 11962.095705882353,
-    "end": 11966.566647058824
-  },
-  {
-    "text": "to do. This is not a",
-    "start": 11967.066,
-    "end": 11968.6685
-  },
-  {
-    "text": "silver bullet. But it moves the needle and it helps us actually keep projects afloat and get to the",
-    "start": 11969.268565217391,
     "end": 11974.71943478261
   },
   {
-    "text": "finish line. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Ms. Brady. We're going to wrap up with Director O'Keefe and then Director Larsen.",
     "start": 11975.399,
-    "end": 11975.693000000001
-  },
-  {
-    "text": "you,",
-    "start": 11975.88,
-    "end": 11975.88
-  },
-  {
-    "text": "Ms. Brady. We're going to wrap up with Director O'Keefe and then",
-    "start": 11976.461,
     "end": 11979.546500000008
   },
   {
-    "text": "Director Larsen. Patrick O'Keefe: Oh, I thought I got",
+    "text": "Patrick O'Keefe: Oh, I thought I got last word. So I support this amendment. I think it is a reasonable step toward developing communities that are very likely to use our services. I think increasing ridership is something we all agree on. This is a concrete way to do that. It also takes land not just for our benefit in ridership, but also puts improvements on it that helps the tax base. And I think the communities that we serve would rather see a housing project end up on that property where it becomes improved versus somewhere else. We're not the only game in town. There's a lot of discounts out there. And so we're not necessarily in a tight buyer's market. There's a lot of projects that can go forward. And I think we need to put our best deal, and at least give Chessy and the rest of the team the tools to bring the deal forward. I do want to put one plug-in. We talked about it. I don't think ground leases are the best tool in Colorado. First of all, it's not as common as other places in the world. And the other thing is, toward the end of your ground lease, no matter how long you make it, the property will fall into disrepair. They are not going to put money into physical facilities that are going to roll off their books. So for that reason, the discount's great and I love a sale versus a ground lease. And I know you'll keep that in mind as we go forward. And anyway, that's another argument in favor of that tactic.",
     "start": 11980.307,
-    "end": 11981.76671428571
-  },
-  {
-    "text": "last word. So I support",
-    "start": 11982.682,
-    "end": 11985.101999999999
-  },
-  {
-    "text": "this amendment. I think it is a reasonable step toward developing communities that are very likely to use",
-    "start": 11985.848,
-    "end": 11996.368166666676
-  },
-  {
-    "text": "our services. I think increasing ridership is something we all",
-    "start": 11997.743285714285,
-    "end": 12002.227749999998
-  },
-  {
-    "text": "agree on. This is a concrete way to",
-    "start": 12002.508,
-    "end": 12004.453124999998
-  },
-  {
-    "text": "do that. It also takes land not just for our benefit in ridership, but also puts improvements on it that helps the",
-    "start": 12005.873,
-    "end": 12015.430863636366
-  },
-  {
-    "text": "tax base. And I think the communities that we serve would rather see a housing project end up on that property where it becomes improved versus",
-    "start": 12016.307,
-    "end": 12031.160333333331
-  },
-  {
-    "text": "somewhere else. We're not the only game",
-    "start": 12031.688,
-    "end": 12032.803999999998
-  },
-  {
-    "text": "in town. There's a lot of discounts",
-    "start": 12033.03,
-    "end": 12034.421142857142
-  },
-  {
-    "text": "out there. And so we're not necessarily in a tight",
-    "start": 12034.674,
-    "end": 12040.714800000007
-  },
-  {
-    "text": "buyer's market. There's a lot of projects that can",
-    "start": 12041.486,
-    "end": 12043.499333333337
-  },
-  {
-    "text": "go forward. And I think we need to put our best deal, and at least give Chessy and the rest of the team the tools to bring the",
-    "start": 12044.452,
-    "end": 12052.556296296318
-  },
-  {
-    "text": "deal forward. I do want to put",
-    "start": 12052.848,
-    "end": 12054.501750000001
-  },
-  {
-    "text": "one plug-in. We talked",
-    "start": 12055.153,
-    "end": 12055.784500000002
-  },
-  {
-    "text": "about it. I don't think ground leases are the best tool",
-    "start": 12056.296,
-    "end": 12060.796909090912
-  },
-  {
-    "text": "in Colorado. First of all, it's not as common as other places in",
-    "start": 12061.287,
-    "end": 12064.395923076929
-  },
-  {
-    "text": "the world. And the other thing is, toward the end of your ground lease, no matter how long you make it, the property will fall",
-    "start": 12065.296,
-    "end": 12073.038166666665
-  },
-  {
-    "text": "into disrepair. They are not going to put money into physical facilities that are going to roll off",
-    "start": 12073.773,
-    "end": 12078.70866666668
-  },
-  {
-    "text": "their books. So for that reason, the discount's great and I love a sale versus a",
-    "start": 12079.68,
-    "end": 12086.547473684226
-  },
-  {
-    "text": "ground lease. And I know you'll keep that in mind as we",
-    "start": 12086.949,
-    "end": 12089.041749999997
-  },
-  {
-    "text": "go forward. And anyway, that's another argument in favor of",
-    "start": 12089.953,
     "end": 12097.522000000003
   },
   {
-    "text": "that tactic. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 12100.182,
     "end": 12100.182
   },
   {
-    "text": "Director Larsen. Matt Larsen:",
+    "text": "Matt Larsen: Thank you. I'm going to be a no vote on this. I don't agree with our transit oriented development policy as it is right now. I don't agree with the goal of trying to provide affordable housing or encourage it, incentivize it. I think we should be focused on trying to increase ridership. If we want to provide discounts on our land, we should provide them with the goal in mind of increasing the number of people that can live on the property, whatever is developed, and the amount of traffic that is on the property. So I'm a no on this.",
     "start": 12100.182,
-    "end": 12100.4225
-  },
-  {
-    "text": "Thank you. I'm going to be a no vote",
-    "start": 12101.284,
-    "end": 12102.743555555557
-  },
-  {
-    "text": "on this. I don't agree with our transit oriented development policy as it is",
-    "start": 12103.286,
-    "end": 12108.281000000008
-  },
-  {
-    "text": "right now. I don't agree with the goal of trying to provide affordable housing or encourage it,",
-    "start": 12108.834,
-    "end": 12115.205764705895
-  },
-  {
-    "text": "incentivize it. I think we should be focused on trying to",
-    "start": 12115.984,
-    "end": 12119.553090909096
-  },
-  {
-    "text": "increase ridership. If we want to provide discounts on our land, we should provide them with the goal in mind of increasing the number of people that can live on the property, whatever is developed, and the amount of traffic that is on",
-    "start": 12120.07,
-    "end": 12134.746937499991
-  },
-  {
-    "text": "the property. So I'm a no",
-    "start": 12136.212,
     "end": 12138.263666666666
   },
   {
-    "text": "on this. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director Larsen. All right. With the indication there is a no vote, I am going to do a roll call vote. As a reminder, we are voting on Director Nicholson's amendment. He was the mover and Director Harwick is the second Treasurer Benker.",
     "start": 12139.355,
-    "end": 12140.015000000003
-  },
-  {
-    "text": "Director Larsen.",
-    "start": 12140.396,
-    "end": 12140.536
-  },
-  {
-    "text": "All right. With the indication there is a no vote, I am going to do a roll",
-    "start": 12141.116,
-    "end": 12144.790888888883
-  },
-  {
-    "text": "call vote. As a reminder, we are voting on Director",
-    "start": 12145.04,
-    "end": 12147.8687
-  },
-  {
-    "text": "Nicholson's amendment. He was the mover and Director Harwick is the second",
-    "start": 12148.683,
     "end": 12152.747
   },
   {
-    "text": "Treasurer Benker. Karen",
+    "text": "Karen Benker: Yes.",
     "start": 12153.147,
     "end": 12153.147
   },
   {
-    "text": "Benker: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Catlin.",
     "start": 12156.651,
     "end": 12156.981
   },
   {
-    "text": "Director Catlin. Peggy",
+    "text": "Peggy Catlin: Yes.",
     "start": 12156.981,
     "end": 12158.773
   },
   {
-    "text": "Catlin: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guissinger.",
     "start": 12159.92,
     "end": 12160.3205
   },
   {
-    "text": "Director Guissinger. Lynn",
+    "text": "Lynn Guissinger: Yes.",
     "start": 12161.041,
     "end": 12161.041
   },
   {
-    "text": "Guissinger: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Gutschenritter.",
     "start": 12161.602,
     "end": 12162.0125
   },
   {
-    "text": "Director Gutschenritter. Chris",
+    "text": "Chris Gutschenritter: Yes.",
     "start": 12162.944,
     "end": 12162.944
   },
   {
-    "text": "Gutschenritter: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 12163.484,
     "end": 12163.8245
   },
   {
-    "text": "Director Guzman. Michael",
+    "text": "Michael Guzman: No.",
     "start": 12163.8245,
     "end": 12164.446
   },
   {
-    "text": "Guzman: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Harwick.",
     "start": 12165.607,
     "end": 12165.9175
   },
   {
-    "text": "Director Harwick. Ian",
+    "text": "Ian Harwick: Yes.",
     "start": 12165.9175,
     "end": 12166.408
   },
   {
-    "text": "Harwick: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 12167.569,
     "end": 12167.9295
   },
   {
-    "text": "Director Larsen. Matt",
+    "text": "Matt Larsen: No.",
     "start": 12167.9295,
     "end": 12169.271
   },
   {
-    "text": "Larsen: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Secretary Nicholson.",
     "start": 12170.553,
     "end": 12170.9335
   },
   {
-    "text": "Secretary Nicholson. Chris",
+    "text": "Chris Nicholson: Yes.",
     "start": 12170.9335,
     "end": 12171.794
   },
   {
-    "text": "Nicholson: Yes. Julien Bouquet: First Vice",
+    "text": "Julien Bouquet: First Vice Chair O'Keefe.",
     "start": 12172.916,
     "end": 12173.476666666667
   },
   {
-    "text": "Chair O'Keefe. Patrick",
+    "text": "Patrick O'Keefe: Yes.",
     "start": 12173.476666666667,
     "end": 12174.558
   },
   {
-    "text": "O'Keefe: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Paglieri.",
     "start": 12175.339,
     "end": 12175.7395
   },
   {
-    "text": "Director Paglieri. Brett",
+    "text": "Brett Paglieri: Yes.",
     "start": 12176.6,
     "end": 12176.6
   },
   {
-    "text": "Paglieri: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Ruscha.",
     "start": 12177.421,
     "end": 12177.7415
   },
   {
-    "text": "Director Ruscha. Joyann Ruscha:",
+    "text": "Joyann Ruscha: Sorry, no.",
     "start": 12177.7415,
     "end": 12181.015500000001
   },
   {
-    "text": "Sorry, no. Julien Bouquet: And finally, Second Vice",
+    "text": "Julien Bouquet: And finally, Second Vice Chair Whitmore.",
     "start": 12182.227,
     "end": 12183.364600000003
   },
   {
-    "text": "Chair Whitmore. Troy",
+    "text": "Troy Whitmore: Yes.",
     "start": 12183.364600000003,
     "end": 12184.21
   },
   {
-    "text": "Whitmore: Yes. Julien Bouquet: And I am",
+    "text": "Julien Bouquet: And I am a yes. That amendment will pass 10, 2-- excuse me. 10, 3, and 2. Yes. 10 yes, 3 no, 2 absent. That is the math. OK. Moving on. We are going to do our second amendment, which was brought forward by Director Ruscha. And Director Ruscha, would you like to introduce the language of the amendment?",
     "start": 12185.317,
-    "end": 12188.426999999996
-  },
-  {
-    "text": "a yes. That amendment will pass 10, 2-- excuse me. 10, 3,",
-    "start": 12189.048999999995,
-    "end": 12195.890999999989
-  },
-  {
-    "text": "and 2. Yes. 10 yes, 3 no,",
-    "start": 12198.697,
-    "end": 12201.308090909093
-  },
-  {
-    "text": "2 absent. That is",
-    "start": 12201.743272727275,
-    "end": 12203.048818181822
-  },
-  {
-    "text": "the",
-    "start": 12204.105,
-    "end": 12204.105
-  },
-  {
-    "text": "math. OK.",
-    "start": 12204.482,
-    "end": 12204.859
-  },
-  {
-    "text": "Moving on. We are going to do our second amendment, which was brought forward by",
-    "start": 12205.236,
-    "end": 12210.137000000006
-  },
-  {
-    "text": "Director Ruscha. And Director Ruscha, would you like to introduce the language of",
-    "start": 12211.979,
     "end": 12215.12115384615
   },
   {
-    "text": "the amendment? Joyann Ruscha: It's being brought forth by Directors Ruscha and Guzman, and I-- Michael Guzman: I can make",
+    "text": "Joyann Ruscha: It's being brought forth by Directors Ruscha and Guzman, and I--",
     "start": 12217.286,
-    "end": 12224.861666666666
+    "end": 12221.684333333333
   },
   {
-    "text": "the",
-    "start": 12225.716,
+    "text": "Michael Guzman: I can make the motion. Sorry.",
+    "start": 12221.684333333333,
     "end": 12225.716
   },
   {
-    "text": "motion. Sorry. Joyann Ruscha: I think he has the language in front",
+    "text": "Joyann Ruscha: I think he has the language in front of him.",
     "start": 12226.197,
     "end": 12227.3868
   },
   {
-    "text": "of him. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 12227.919,
     "end": 12228.2395
   },
   {
-    "text": "Director Guzman. Michael Guzman: Thank",
+    "text": "Michael Guzman: Thank you, Mr. Chair. We would like to make a motion to add the language to the end of this policy that says, additionally, no project will be eligible for any discounts unless it complies with the greater of the following. 5% of all units are accessible to persons with mobility disabilities, and an additional 2% of all units are accessible to persons with hearing or visual disabilities, or two, current US Department of Housing Urban Development accessibility requirements. Do we have a second? We have Ruscha as the second. Mr. Kroll, I'm sorry.",
     "start": 12228.2395,
-    "end": 12229.5715
-  },
-  {
-    "text": "you,",
-    "start": 12229.81675,
-    "end": 12229.81675
-  },
-  {
-    "text": "Mr. Chair. We would like to make a motion to add the language to the end of this policy that says, additionally, no project will be eligible for any discounts unless it complies with the greater of the following. 5% of all units are accessible to persons with mobility disabilities, and an additional 2% of all units are accessible to persons with hearing or visual disabilities, or two, current US Department of Housing Urban Development",
-    "start": 12230.102,
-    "end": 12256.032000000001
-  },
-  {
-    "text": "accessibility requirements. Do we have",
-    "start": 12258.755,
-    "end": 12259.379799999997
-  },
-  {
-    "text": "a second? We have Ruscha as",
-    "start": 12260.579,
-    "end": 12263.229
-  },
-  {
-    "text": "the",
-    "start": 12263.229,
-    "end": 12263.229
-  },
-  {
-    "text": "second. Mr. Kroll,",
-    "start": 12263.496,
     "end": 12263.9535
   },
   {
-    "text": "I'm sorry. Jack Kroll: Just to clarify, Director Guzman, as I understood you reading that into the record, the highlighted portion above would",
+    "text": "Jack Kroll: Just to clarify, Director Guzman, as I understood you reading that into the record, the highlighted portion above would be deleted. And is not included in your motion. Correct?",
     "start": 12264.464,
-    "end": 12272.761142857154
+    "end": 12277.241
   },
   {
-    "text": "be deleted. And is not included in",
-    "start": 12273.176000000012,
-    "end": 12275.665142857159
-  },
-  {
-    "text": "your",
+    "text": "Michael Guzman: Correct.",
     "start": 12277.241,
     "end": 12277.241
   },
   {
-    "text": "motion. Correct? Michael",
-    "start": 12277.241,
-    "end": 12277.241
-  },
-  {
-    "text": "Guzman: Correct. Julien Bouquet: So the language we see, this would substitute",
+    "text": "Julien Bouquet: So the language we see, this would substitute the language? OK, perfect.",
     "start": 12279.985,
-    "end": 12283.337499999996
-  },
-  {
-    "text": "the language?",
-    "start": 12284.311,
     "end": 12284.712
   },
   {
-    "text": "OK, perfect. Michael Guzman: Simplifying it to the bare minimum to get",
+    "text": "Michael Guzman: Simplifying it to the bare minimum to get this done.",
     "start": 12285.452,
     "end": 12287.885599999994
   },
   {
-    "text": "this done. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Ruscha.",
     "start": 12289.778,
     "end": 12290.0385
   },
   {
-    "text": "Director Ruscha. Joyann Ruscha: I was happy to speak to the motion, but I wasn't sure if we were--",
+    "text": "Joyann Ruscha: I was happy to speak to the motion, but I wasn't sure if we were-- I'm tired. Is that OK?",
     "start": 12291.764,
-    "end": 12296.32493749999
-  },
-  {
-    "text": "I'm tired. Is",
-    "start": 12296.95,
     "end": 12297.189999999999
   },
   {
-    "text": "that OK? Julien",
+    "text": "Julien Bouquet: Mhm.",
     "start": 12298.411,
     "end": 12298.656
   },
   {
-    "text": "Bouquet: Mhm. Joyann",
+    "text": "Joyann Ruscha: OK.",
     "start": 12298.656,
     "end": 12298.656
   },
   {
-    "text": "Ruscha: OK. Julien Bouquet: We got Guzman as the mover and Ruscha as the second, and we're up",
+    "text": "Julien Bouquet: We got Guzman as the mover and Ruscha as the second, and we're up for conversation.",
     "start": 12298.656,
     "end": 12302.331000000013
   },
   {
-    "text": "for conversation. Joyann",
+    "text": "Joyann Ruscha: OK.",
     "start": 12302.636,
     "end": 12302.816
   },
   {
-    "text": "Ruscha: OK. Julien Bouquet: You're up,",
+    "text": "Julien Bouquet: You're up, Director Ruscha.",
     "start": 12302.816,
     "end": 12303.371750000002
   },
   {
-    "text": "Director Ruscha. Joyann Ruscha: Thank",
+    "text": "Joyann Ruscha: Thank you sir. OK. So just for everyone's edification, we struck the first sentence. It was a two sentence amendment. Just recognizing that we didn't have full staff concurrence on the first sentence, which would have applied this accessibility minimum to market rate housing. And sometimes you shoot for the stars and land on the moon. The second sentence, which just applies to the HUD requirement to affordable housing, we did get staff concurrence. That was the context behind that. I sent out like a Q&A, frequently asked questions in anticipation of some questions. So I'm happy to entertain any or we can address them. I will say that we worked for three weeks and some change on this with housing advocates and folks who had worked in the space, and people had worked at CHFA and at the state level on similar policy and advocacy organizations and then staff and legal. So, I mean, just-- I'm sorry. I am tired. In case anybody has any questions about what this is, I think it just simplify it and say that HUD has a current minimum accessibility requirement for funding. And it's 5% of units are accessible to persons with mobility disabilities. Additional 2% of units are accessible to persons with hearing or visual disabilities. And so a lot of times in these projects, that HUD requirement is going to kick in. But not all projects are going to have HUD dollars. So just recognizing that a lot of jurisdictions take that HUD standard, which is-- maybe Ms. Brady can correct me, but I think it's 20 plus years, 30 plus years old now. And they also incorporate that into their policies or their code or statute. We did the same. Good for goose, good for gander. I will stop there unless anyone else has further questions or comments.",
     "start": 12303.917,
-    "end": 12304.264333333334
-  },
-  {
-    "text": "you",
-    "start": 12304.458,
-    "end": 12304.458
-  },
-  {
-    "text": "sir. OK. So just for everyone's edification, we struck the",
-    "start": 12304.945818181819,
-    "end": 12309.336181818186
-  },
-  {
-    "text": "first sentence. It was a two",
-    "start": 12309.884,
-    "end": 12311.500363636364
-  },
-  {
-    "text": "sentence amendment. Just recognizing that we didn't have full staff concurrence on the first sentence, which would have applied this accessibility minimum to market",
-    "start": 12311.904454545454,
-    "end": 12320.322277777776
-  },
-  {
-    "text": "rate housing. And sometimes you shoot for the stars and land on",
-    "start": 12321.557,
-    "end": 12325.46658333334
-  },
-  {
-    "text": "the moon. The second sentence, which just applies to the HUD requirement to affordable housing, we did get",
-    "start": 12326.843,
-    "end": 12333.607235294105
-  },
-  {
-    "text": "staff concurrence. That was the context",
-    "start": 12335.2918,
-    "end": 12336.542800000003
-  },
-  {
-    "text": "behind that. I sent out like a Q&A, frequently asked questions in anticipation of",
-    "start": 12338.595,
-    "end": 12344.554272727271
-  },
-  {
-    "text": "some questions. So I'm happy to entertain any or we can",
-    "start": 12344.885499999999,
-    "end": 12348.19777272727
-  },
-  {
-    "text": "address them. I will say that we worked for three weeks and some change on this with housing advocates and folks who had worked in the space, and people had worked at CHFA and at the state level on similar policy and advocacy organizations and then staff",
-    "start": 12349.029,
-    "end": 12369.94302083333
-  },
-  {
-    "text": "and legal. So, I mean, just--",
-    "start": 12370.79,
-    "end": 12374.04015151515
-  },
-  {
-    "text": "I'm sorry. I",
-    "start": 12374.69018181818,
-    "end": 12375.99024242424
-  },
-  {
-    "text": "am tired. In case anybody has any questions about what this is, I think it just simplify it and say that HUD has a current minimum accessibility requirement",
-    "start": 12377.290303030299,
-    "end": 12395.21357142857
-  },
-  {
-    "text": "for funding. And it's 5% of units are accessible to persons with",
-    "start": 12396.389,
-    "end": 12400.151000000005
-  },
-  {
-    "text": "mobility disabilities. Additional 2% of units are accessible to persons with hearing or",
-    "start": 12400.493000000006,
-    "end": 12404.597000000012
-  },
-  {
-    "text": "visual disabilities. And so a lot of times in these projects, that HUD requirement is going to",
-    "start": 12405.74,
-    "end": 12410.260296296308
-  },
-  {
-    "text": "kick in. But not all projects are going to have",
-    "start": 12410.542814814828,
-    "end": 12413.085481481501
-  },
-  {
-    "text": "HUD dollars. So just recognizing that a lot of jurisdictions take that HUD standard, which is--",
-    "start": 12413.969,
-    "end": 12420.1835
-  },
-  {
-    "text": "maybe Ms. Brady can correct me, but I think it's 20 plus years, 30 plus years",
-    "start": 12420.494,
-    "end": 12423.885058823531
-  },
-  {
-    "text": "old now. And they also incorporate that into their policies or their code",
-    "start": 12425.439,
-    "end": 12429.384333333337
-  },
-  {
-    "text": "or statute. We did",
-    "start": 12430.043,
-    "end": 12430.748749999999
-  },
-  {
-    "text": "the same. Good for goose, good",
-    "start": 12431.454499999998,
-    "end": 12432.630749999997
-  },
-  {
-    "text": "for gander. I will stop there unless anyone else has further questions",
-    "start": 12433.627,
     "end": 12438.784166666657
   },
   {
-    "text": "or comments. Julien Bouquet: Questions or comments on",
+    "text": "Julien Bouquet: Questions or comments on this amendment? Director Catlin, then Secretary Nicholson.",
     "start": 12440.314,
-    "end": 12441.998999999998
-  },
-  {
-    "text": "this amendment? Director Catlin, then",
-    "start": 12443.677,
     "end": 12446.592200000003
   },
   {
-    "text": "Secretary Nicholson. Peggy Catlin: I appreciate the thought going into this, but I believe that the first amendment that we passed does give a lot of latitude towards Chessy and her staff to negotiate, and I fear that this one might be a little bit too regulatory",
+    "text": "Peggy Catlin: I appreciate the thought going into this, but I believe that the first amendment that we passed does give a lot of latitude towards Chessy and her staff to negotiate, and I fear that this one might be a little bit too regulatory and prescriptive. And if that's the HUD requirement and somebody is applying for a HUD grant, then this would be taken care of automatically. So right now, I'm willing to listen to other discussions, but I fear that it would not give Ms. Brady and her staff the maximum flexibility to look at the comprehensive merits of a proposal.",
     "start": 12447.571,
-    "end": 12471.276666666668
-  },
-  {
-    "text": "and prescriptive. And if that's the HUD requirement and somebody is applying for a HUD grant, then this would be taken care",
-    "start": 12473.542,
-    "end": 12483.096285714293
-  },
-  {
-    "text": "of automatically. So right now, I'm willing to listen to other discussions, but I fear that it would not",
-    "start": 12484.175,
-    "end": 12492.824473684195
-  },
-  {
-    "text": "give Ms. Brady and her staff the maximum flexibility to look at the comprehensive merits of",
-    "start": 12493.326,
     "end": 12500.046000000004
   },
   {
-    "text": "a proposal. Julien Bouquet:",
+    "text": "Julien Bouquet: Yeah, Ms. Brady.",
     "start": 12503.309,
-    "end": 12504.337000000001
-  },
-  {
-    "text": "Yeah,",
-    "start": 12504.871,
     "end": 12504.871
   },
   {
-    "text": "Ms. Brady. Chessy Brady: Would you like me",
+    "text": "Chessy Brady: Would you like me to comment? So this is a bare minimum requirement that Denver already requires, for example, and the Colorado Department of Housing is already considering a higher threshold of requirement. So I have no concerns about incorporating this. I think it's already going to be taken care of in most cases.",
     "start": 12506.312,
-    "end": 12506.673
-  },
-  {
-    "text": "to comment? So this is a bare minimum requirement that Denver already requires, for example, and the Colorado Department of Housing is already considering a higher threshold",
-    "start": 12506.673,
-    "end": 12518.85833333331
-  },
-  {
-    "text": "of requirement. So I have no concerns about",
-    "start": 12519.427,
-    "end": 12521.949700000003
-  },
-  {
-    "text": "incorporating this. I think it's already going to be taken care of in",
-    "start": 12522.29,
     "end": 12525.711785714291
   },
   {
-    "text": "most cases. Peggy Catlin: If",
+    "text": "Peggy Catlin: If I might? That's kind of my point. It seems a little bit redundant.",
     "start": 12526.375,
-    "end": 12527.03575
-  },
-  {
-    "text": "I might? That's kind of",
-    "start": 12527.366124999999,
-    "end": 12528.687624999997
-  },
-  {
-    "text": "my point. It seems a little",
-    "start": 12529.118,
     "end": 12530.436333333331
   },
   {
-    "text": "bit redundant. Julien Bouquet:",
+    "text": "Julien Bouquet: Secretary Nicholson.",
     "start": 12534.19,
     "end": 12534.591
   },
   {
-    "text": "Secretary Nicholson. Chris Nicholson: I'd like to offer an amendment, if that's",
+    "text": "Chris Nicholson: I'd like to offer an amendment, if that's all right.",
     "start": 12534.591,
     "end": 12538.924299999995
   },
   {
-    "text": "all right. Julien Bouquet: To",
+    "text": "Julien Bouquet: To the Amendment?",
     "start": 12540.844,
     "end": 12541.217999999999
   },
   {
-    "text": "the Amendment? Chris Nicholson:",
+    "text": "Chris Nicholson: Thank you.",
     "start": 12541.606,
     "end": 12541.806499999999
   },
   {
-    "text": "Thank you. Julien Bouquet: Just to clarify, that was",
+    "text": "Julien Bouquet: Just to clarify, that was a question. You would like to offer an amendment to the amendment?",
     "start": 12543.249,
-    "end": 12544.434428571425
-  },
-  {
-    "text": "a question. You would like to offer an amendment to",
-    "start": 12544.672,
     "end": 12546.257777777771
   },
   {
-    "text": "the amendment? Chris",
+    "text": "Chris Nicholson: Yes. Sub-amendment.",
     "start": 12546.817,
-    "end": 12548.681250000001
-  },
-  {
-    "text": "Nicholson:",
-    "start": 12548.841500000002,
     "end": 12548.841500000002
   },
   {
-    "text": "Yes. Sub-amendment. Julien",
+    "text": "Julien Bouquet: Mr. Kroll?",
     "start": 12549.001750000003,
-    "end": 12549.378
-  },
-  {
-    "text": "Bouquet:",
-    "start": 12550.099,
     "end": 12550.099
   },
   {
-    "text": "Mr. Kroll? Jack Kroll: Technically, the initial motion on the table is to amend the ETOD policy, and this is an amendment to",
+    "text": "Jack Kroll: Technically, the initial motion on the table is to amend the ETOD policy, and this is an amendment to that amendment. And at this point would be amending an amendment to an amendment, which is not allowed under Robert's Rules. So you would need to tackle this amendment as it's being presented. And then, if you feel so inclined, offer an amendment to whatever or whatever state the policy is in at that point.",
     "start": 12550.84,
-    "end": 12558.636060606052
-  },
-  {
-    "text": "that amendment. And at this point would be amending an amendment to an amendment, which is not allowed under",
-    "start": 12559.025863636354,
-    "end": 12566.432121212103
-  },
-  {
-    "text": "Robert's Rules. So you would need to tackle this amendment as it's",
-    "start": 12566.821924242406,
-    "end": 12571.109757575734
-  },
-  {
-    "text": "being presented. And then, if you feel so inclined, offer an amendment to whatever or whatever state the policy is in at",
-    "start": 12571.499560606037,
     "end": 12580.832333333334
   },
   {
-    "text": "that point. Julien Bouquet:",
+    "text": "Julien Bouquet: Rock on. Secretary.",
     "start": 12581.971,
-    "end": 12582.419666666667
-  },
-  {
-    "text": "Rock",
-    "start": 12582.868333333334,
     "end": 12582.868333333334
   },
   {
-    "text": "on. Secretary. Chris",
+    "text": "Chris Nicholson: Yeah. So at that point, I would say I'd have to be a no for the very simple reason. Where it says no project will be eligible, we're talking about an equitable TOD policy here, which is specifically focused on using our land to facilitate the-- literally the policy is about giving discounts. I can't see putting something like this in there unless it is related to said discount. So I'd be fine if it said, additionally, no project receiving a discount will be eligible for any discounts, et cetera, unless it complies with. But I don't necessarily think it makes sense to do market rate policy in an ETOD policy.",
     "start": 12583.769,
-    "end": 12583.769
-  },
-  {
-    "text": "Nicholson: Yeah. So at that point, I would say I'd have to be a no for the very",
-    "start": 12584.08552,
-    "end": 12588.833320000005
-  },
-  {
-    "text": "simple reason. Where it says no project will be eligible, we're talking about an equitable TOD policy here, which is specifically focused on using our land to facilitate the-- literally the policy is about",
-    "start": 12589.149840000005,
-    "end": 12601.477384615406
-  },
-  {
-    "text": "giving discounts. I can't see putting something like this in there unless it is related to",
-    "start": 12602.439,
-    "end": 12608.861812499996
-  },
-  {
-    "text": "said discount. So I'd be fine if it said, additionally, no project receiving a discount will be eligible for any discounts, et cetera, unless it",
-    "start": 12609.31,
-    "end": 12616.785500000007
-  },
-  {
-    "text": "complies with. But I don't necessarily think it makes sense to do market rate policy in an",
-    "start": 12617.181000000008,
     "end": 12623.509000000016
   },
   {
-    "text": "ETOD policy. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Secretary. Treasurer Benker and then Director Ruscha.",
     "start": 12623.904500000017,
-    "end": 12624.695500000018
-  },
-  {
-    "text": "you, Secretary. Treasurer Benker and then",
-    "start": 12625.88200000002,
     "end": 12627.859500000022
   },
   {
-    "text": "Director Ruscha. Karen Benker: Just",
+    "text": "Karen Benker: Just real quick. Have you perhaps considered something more positive, saying something along the lines, greater consideration would be given a project if these items were attained? As opposed to make it mandatory.",
     "start": 12628.471,
-    "end": 12629.4625
-  },
-  {
-    "text": "real quick. Have you perhaps considered something more positive, saying something along the lines, greater consideration would be given a project if these items",
-    "start": 12629.973,
-    "end": 12640.085516129011
-  },
-  {
-    "text": "were attained? As opposed to make",
-    "start": 12640.50687096772,
     "end": 12642.613645161264
   },
   {
-    "text": "it mandatory. Julien Bouquet: Director Ruscha or",
+    "text": "Julien Bouquet: Director Ruscha or Director Guzman.",
     "start": 12646.04,
     "end": 12647.321600000003
   },
   {
-    "text": "Director Guzman. Karen Benker: Again, sort of an amendment, but just",
+    "text": "Karen Benker: Again, sort of an amendment, but just a thought.",
     "start": 12647.662,
     "end": 12649.745555555553
   },
   {
-    "text": "a thought. Joyann Ruscha: So I just want to address what Secretary",
+    "text": "Joyann Ruscha: So I just want to address what Secretary Nicholson said. I might have missed part of the closed captioning, but I think you said you don't think we should be applying accessibility minimums to market rate. OK. That's exactly. We don't. So this amendment doesn't do that. And the second piece. The reason why it doesn't say it doesn't reference discounts is because-- so this goes at the end of the policy, which is all-- the way it's nested under the paragraph, this is talking about when discounts apply, if that makes sense. It does what you said you wanted it to do. It's just late.",
     "start": 12650.807,
-    "end": 12654.537400000001
-  },
-  {
-    "text": "Nicholson said. I might have missed part of the closed captioning, but I think you said you don't think we should be applying accessibility minimums to",
-    "start": 12655.707,
-    "end": 12663.426230769226
-  },
-  {
-    "text": "market",
-    "start": 12664.676,
-    "end": 12664.676
-  },
-  {
-    "text": "rate. OK.",
-    "start": 12665.237,
-    "end": 12665.5275
-  },
-  {
-    "text": "That's exactly.",
-    "start": 12666.038,
-    "end": 12666.198
-  },
-  {
-    "text": "We don't. So this amendment doesn't",
-    "start": 12666.659,
-    "end": 12667.392333333337
-  },
-  {
-    "text": "do that. And the",
-    "start": 12667.94,
-    "end": 12668.712588235296
-  },
-  {
-    "text": "second piece. The reason why it doesn't say it doesn't reference discounts is because-- so this goes at the end of the policy, which is all-- the way it's nested under the paragraph, this is talking about when discounts apply, if that",
-    "start": 12669.227647058826,
-    "end": 12680.816470588254
-  },
-  {
-    "text": "makes sense. It does what you said you wanted it",
-    "start": 12683.753,
-    "end": 12686.672599999996
-  },
-  {
-    "text": "to do. It's",
-    "start": 12687.037,
     "end": 12687.544333333335
   },
   {
-    "text": "just late. Julien",
+    "text": "Julien Bouquet: Nicholson.",
     "start": 12688.518,
     "end": 12688.7785
   },
   {
-    "text": "Bouquet: Nicholson. Chris Nicholson:",
+    "text": "Chris Nicholson: Thank you. And then I guess the only question I have for-- and this is actually for Ms. Brady, if that's OK. Because you mentioned that Denver has a policy that supersedes or that matches this, and the state currently is considering a policy that would supersede it, but currently does not. Under what circumstances would this have any effect at all? In what circumstances can you imagine in your professional capacity do you see this being something that would matter?",
     "start": 12688.7785,
-    "end": 12689.4295
-  },
-  {
-    "text": "Thank you. And then I guess the only question I have for-- and this is actually",
-    "start": 12690.02,
-    "end": 12693.958823529403
-  },
-  {
-    "text": "for Ms. Brady, if",
-    "start": 12694.225,
-    "end": 12695.350750000001
-  },
-  {
-    "text": "that's OK. Because you mentioned that Denver has a policy that supersedes or that matches this, and the state currently is considering a policy that would supersede it, but currently",
-    "start": 12696.9840625,
-    "end": 12707.671468750004
-  },
-  {
-    "text": "does not. Under what circumstances would this have any effect",
-    "start": 12708.509,
-    "end": 12712.114400000006
-  },
-  {
-    "text": "at all? In what circumstances can you imagine in your professional capacity do you see this being something that",
-    "start": 12713.0806,
     "end": 12720.3814
   },
   {
-    "text": "would matter? Julien",
+    "text": "Julien Bouquet: Ms. Brady.",
     "start": 12721.869,
-    "end": 12721.869
-  },
-  {
-    "text": "Bouquet:",
-    "start": 12722.069,
     "end": 12722.069
   },
   {
-    "text": "Ms. Brady. Chessy",
+    "text": "Chessy Brady: Yes. In a jurisdiction that doesn't currently require accessible units-- and Director Ruscha has mentioned some. I'm not aware of them, but this is not my area of expertise. But in a jurisdiction that does not already have those requirements, that is not accepting HUD money, and, if Colorado Department of Housing changes their rules, does not accept department of housing money, then that project would then be subject to this policy requirement.",
     "start": 12722.069,
-    "end": 12723.11
-  },
-  {
-    "text": "Brady: Yes. In a jurisdiction that doesn't currently require accessible units-- and Director Ruscha has",
-    "start": 12723.5527,
-    "end": 12729.058052631577
-  },
-  {
-    "text": "mentioned some. I'm not aware of them, but this is not my area",
-    "start": 12729.334263157893,
-    "end": 12732.648789473678
-  },
-  {
-    "text": "of expertise. But in a jurisdiction that does not already have those requirements, that is not accepting HUD money, and, if Colorado Department of Housing changes their rules, does not accept department of housing money, then that project would then be subject to this",
-    "start": 12733.2748,
     "end": 12751.307833333332
   },
   {
-    "text": "policy requirement. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Ms. Brady. Secretary.",
     "start": 12753.665,
-    "end": 12753.945
-  },
-  {
-    "text": "you,",
-    "start": 12754.125,
-    "end": 12754.125
-  },
-  {
-    "text": "Ms.",
-    "start": 12754.726,
     "end": 12754.726
   },
   {
-    "text": "Brady. Secretary. Chris",
+    "text": "Chris Nicholson: Yeah. Just, I guess for Director Ruscha or Director Guzman. Are there any jurisdictions in the RDD service area that don't have that same requirement that Denver does?",
     "start": 12755.1165,
-    "end": 12756.388
-  },
-  {
-    "text": "Nicholson: Yeah. Just, I guess for Director Ruscha or",
-    "start": 12756.817333333334,
-    "end": 12759.822666666669
-  },
-  {
-    "text": "Director Guzman. Are there any jurisdictions in the RDD service area that don't have that same requirement that",
-    "start": 12760.252000000002,
     "end": 12767.550666666672
   },
   {
-    "text": "Denver does? Julien Bouquet:",
+    "text": "Julien Bouquet: Either Directors.",
     "start": 12769.951,
     "end": 12770.341499999999
   },
   {
-    "text": "Either Directors. Joyann",
+    "text": "Joyann Ruscha: Yeah. I think I'm pretty smart, but I'm not qualified to talk about 53 separate jurisdictions. So I'm just going to have to lean into this is ETOD and the E in it is equitable. We spent a lot of time talking about equity today, including spending a significant amount of time talking about people with disabilities. And so just, again, recognizing that the HUD requirement is about equity and not excluding people on the basis of disability from accessing affordable housing, because the Fair Housing Act, the ADA, and other areas of anti-discrimination law, including state law, don't effectively cover that aspect. Sorry, that was more than what you asked. But no, I can't answer your question, just like you probably couldn't answer my question about every single jurisdiction in the RTD region that has something regarding parking minimums. It's a broad concept.",
     "start": 12772.154,
-    "end": 12772.154
-  },
-  {
-    "text": "Ruscha: Yeah. I think I'm pretty smart, but I'm not qualified to talk about 53",
-    "start": 12772.447,
-    "end": 12776.548999999995
-  },
-  {
-    "text": "separate jurisdictions. So I'm just going to have to lean into this is ETOD and the E in it",
-    "start": 12776.902,
-    "end": 12784.771111111117
-  },
-  {
-    "text": "is equitable. We spent a lot of time talking about equity today, including spending a significant amount of time talking about people",
-    "start": 12785.735,
-    "end": 12790.897181818185
-  },
-  {
-    "text": "with disabilities. And so just, again, recognizing that the HUD requirement is about equity and not excluding people on the basis of disability from accessing affordable housing, because the Fair Housing Act, the ADA, and other areas of anti-discrimination law, including state law, don't effectively cover",
-    "start": 12791.664,
-    "end": 12817.761945945971
-  },
-  {
-    "text": "that aspect. Sorry, that was more than what",
-    "start": 12819.444,
-    "end": 12821.097866666667
-  },
-  {
-    "text": "you asked. But no, I can't answer your question, just like you probably couldn't answer my question about every single jurisdiction in the RTD region that has something regarding",
-    "start": 12821.334133333334,
-    "end": 12835.202428571432
-  },
-  {
-    "text": "parking minimums. It's a",
-    "start": 12835.853,
     "end": 12836.693749999999
   },
   {
-    "text": "broad concept. Julien Bouquet: Thank you,",
+    "text": "Julien Bouquet: Thank you, Director Ruscha. Any further conversation on this amendment. Director Guzman.",
     "start": 12838.355,
-    "end": 12838.910750000001
-  },
-  {
-    "text": "Director Ruscha. Any further conversation on",
-    "start": 12839.536,
-    "end": 12841.254333333338
-  },
-  {
-    "text": "this amendment.",
-    "start": 12842.739,
     "end": 12843.089
   },
   {
-    "text": "Director Guzman. Michael Guzman: I will offer this last thing, and then we probably should go to",
+    "text": "Michael Guzman: I will offer this last thing, and then we probably should go to a vote. But very simply put, we need to make sure that we are protecting the vulnerable. Providing access to these housing units, even in the City and County of Denver's building codes, is not clear. It's as clear as mud. There is reference to this if certain dollars are used, but stacking in the way that developers work, it's not necessarily required. We aspire to a certain ICAA rule, but it's not clear if that means that they have to do this or not in order to get licensed. And so, to be fair to ourselves and to ensure that we are taking care of the ADA community and providing those accessible units, I would like to see this in the policy. I would be fine, by the way, to adjust language on this, to say we would consider giving additional discount, but I don't want any project to go forward that doesn't meet a bare minimum requirement that's established. And although it is established in other places, it is not established in our policy. And we are the government of this region and we should take it seriously that we have a due diligence and responsibility to those members of our community that would need this. Thank you.",
     "start": 12843.089,
-    "end": 12846.833777777774
-  },
-  {
-    "text": "a vote. But very simply put, we need to make sure that we are protecting",
-    "start": 12847.143,
-    "end": 12856.259800000003
-  },
-  {
-    "text": "the vulnerable. Providing access to these housing units, even in the City and County of Denver's building codes, is",
-    "start": 12857.414,
-    "end": 12863.00726315791
-  },
-  {
-    "text": "not clear. It's as clear",
-    "start": 12863.378,
-    "end": 12864.374
-  },
-  {
-    "text": "as mud. There is reference to this if certain dollars are used, but stacking in the way that developers work, it's not",
-    "start": 12864.991,
-    "end": 12870.858590909074
-  },
-  {
-    "text": "necessarily required. We aspire to a certain ICAA rule, but it's not clear if that means that they have to do this or not in order to",
-    "start": 12871.218,
-    "end": 12879.663185185167
-  },
-  {
-    "text": "get licensed. And so, to be fair to ourselves and to ensure that we are taking care of the ADA community and providing those accessible units, I would like to see this in",
-    "start": 12880.688,
-    "end": 12892.030888888883
-  },
-  {
-    "text": "the policy. I would be fine, by the way, to adjust language on this, to say we would consider giving additional discount, but I don't want any project to go forward that doesn't meet a bare minimum requirement",
-    "start": 12892.81,
-    "end": 12905.893394736811
-  },
-  {
-    "text": "that's established. And although it is established in other places, it is not established in",
-    "start": 12906.287,
-    "end": 12909.944043478255
-  },
-  {
-    "text": "our policy. And we are the government of this region and we should take it seriously that we have a due diligence and responsibility to those members of our community that would",
-    "start": 12910.20526086956,
-    "end": 12918.230083333345
-  },
-  {
-    "text": "need this.",
-    "start": 12918.719,
     "end": 12918.859
   },
   {
-    "text": "Thank you. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Harwick.",
     "start": 12920.242,
     "end": 12920.5625
   },
   {
-    "text": "Director Harwick. Ian Harwick: I always have to follow you,",
+    "text": "Ian Harwick: I always have to follow you, Director Guzman. But obviously, I'm very in support. Any time that we can be supportive of our communities most in need, those suffering from a whole variety of disabilities, I want to be able to put our best foot forward there. And while we can't call out specific jurisdictions, if there is that chance that there is a jurisdiction that isn't meeting this requirement, then we should make sure we're getting there. And if in the process the state comes up with something better or something in the future, that's OK. But I think that this is like a safety net in my mind about how to really get there for this community. And I think that also, as we're tying-- as these developments spur up around our transit, that's also giving them better access to the resources and giving them that the life that they want and the freedom of movement that we so cherish. So I'm highly in support of this. Thank you.",
     "start": 12920.5625,
-    "end": 12924.6795
-  },
-  {
-    "text": "Director Guzman. But obviously, I'm very",
-    "start": 12924.978571428572,
-    "end": 12926.174857142858
-  },
-  {
-    "text": "in support. Any time that we can be supportive of our communities most in need, those suffering from a whole variety of disabilities, I want to be able to put our best foot",
-    "start": 12927.108,
-    "end": 12939.126424242444
-  },
-  {
-    "text": "forward there. And while we can't call out specific jurisdictions, if there is that chance that there is a jurisdiction that isn't meeting this requirement, then we should make sure we're",
-    "start": 12939.962,
-    "end": 12950.987483870962
-  },
-  {
-    "text": "getting there. And if in the process the state comes up with something better or something in the future,",
-    "start": 12951.555,
-    "end": 12956.790157894742
-  },
-  {
-    "text": "that's OK. But I think that this is like a safety net in my mind about how to really get there for",
-    "start": 12957.061,
-    "end": 12963.761833333318
-  },
-  {
-    "text": "this community. And I think that also, as we're tying-- as these developments spur up around our transit, that's also giving them better access to the resources and giving them that the life that they want and the freedom of movement that we",
-    "start": 12964.06641666665,
-    "end": 12982.61635
-  },
-  {
-    "text": "so cherish. So I'm highly in support",
-    "start": 12983.048,
-    "end": 12984.439142857142
-  },
-  {
-    "text": "of this.",
-    "start": 12985.192,
     "end": 12985.5525
   },
   {
-    "text": "Thank you. Julien Bouquet: Secretary, less than",
+    "text": "Julien Bouquet: Secretary, less than 30 seconds.",
     "start": 12985.933,
     "end": 12987.5834
   },
   {
-    "text": "30 seconds. Chris Nicholson: This question is",
+    "text": "Chris Nicholson: This question is for Chessy. My understanding with this language is that it applies to buildings with elevators in it. And so with single stair buildings, that there are different policies around equitable access because of the challenges, obviously in a single stair building, of getting people into the second, the third, the fourth, the fifth floor. You're probably the biggest expert on this in the room. Do you see any concerns with this language when it comes to buildings with stairs only versus elevators?",
     "start": 12987.976,
-    "end": 12991.1952
-  },
-  {
-    "text": "for Chessy. My understanding with this language is that it applies to buildings with elevators",
-    "start": 12992.261,
-    "end": 12999.641800000007
-  },
-  {
-    "text": "in it. And so with single stair buildings, that there are different policies around equitable access because of the challenges, obviously in a single stair building, of getting people into the second, the third, the fourth, the",
-    "start": 13000.269,
-    "end": 13015.073756756748
-  },
-  {
-    "text": "fifth floor. You're probably the biggest expert on this in",
-    "start": 13015.617,
-    "end": 13018.250400000006
-  },
-  {
-    "text": "the room. Do you see any concerns with this language when it comes to buildings with stairs only",
-    "start": 13019.726,
     "end": 13030.383111111098
   },
   {
-    "text": "versus elevators? Julien",
+    "text": "Julien Bouquet: Ms. Brady.",
     "start": 13031.716,
     "end": 13031.716
   },
   {
-    "text": "Bouquet:",
+    "text": "Chessy Brady: I am not the biggest expert on this in the room, but I would say that equitable-- I do know that equitable access and accessible units are different things and have different requirements. And so we're talking specifically about accessible units. We're tending to be talking about larger buildings because we do want them to be dense at stations, so I think they're typically going to be elevator buildings. But yeah, I don't have any concerns about that.",
     "start": 13031.716,
-    "end": 13031.716
-  },
-  {
-    "text": "Ms. Brady. Chessy Brady: I am not the biggest expert on this in the room, but I would say that equitable-- I do know that equitable access and accessible units are different things and have",
-    "start": 13031.716,
-    "end": 13041.1336969697
-  },
-  {
-    "text": "different requirements. And so we're talking specifically about",
-    "start": 13042.249,
-    "end": 13045.280874999997
-  },
-  {
-    "text": "accessible units. We're tending to be talking about larger buildings because we do want them to be dense at stations, so I think they're typically going to be",
-    "start": 13047.945714285714,
-    "end": 13055.28825
-  },
-  {
-    "text": "elevator buildings. But yeah, I don't have any concerns",
-    "start": 13055.5065,
     "end": 13057.470749999999
   },
   {
-    "text": "about that. Julien Bouquet: Thank",
+    "text": "Julien Bouquet: Thank you, Ms. Brady. Let's do the roll call vote. Again, this is the amendment offered by Director Guzman and Director Ruscha. Treasurer Benker. Director Catlin.",
     "start": 13058.07,
-    "end": 13058.296666666665
-  },
-  {
-    "text": "you,",
-    "start": 13058.45,
-    "end": 13058.45
-  },
-  {
-    "text": "Ms. Brady. Let's do the roll",
-    "start": 13059.211,
-    "end": 13060.445999999996
-  },
-  {
-    "text": "call vote. Again, this is the amendment offered by Director Guzman and",
-    "start": 13060.792,
-    "end": 13065.52592857143
-  },
-  {
-    "text": "Director Ruscha.",
-    "start": 13065.956285714286,
-    "end": 13066.386642857144
-  },
-  {
-    "text": "Treasurer Benker.",
-    "start": 13070.781,
     "end": 13071.091
   },
   {
-    "text": "Director Catlin. Peggy",
+    "text": "Peggy Catlin: No.",
     "start": 13071.091,
     "end": 13072.883
   },
   {
-    "text": "Catlin: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guissinger.",
     "start": 13074.244,
     "end": 13074.604500000001
   },
   {
-    "text": "Director Guissinger. Lynn",
+    "text": "Lynn Guissinger: Yes.",
     "start": 13076.186,
     "end": 13076.186
   },
   {
-    "text": "Guissinger: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Gutschenritter.",
     "start": 13076.286,
     "end": 13076.666000000001
   },
   {
-    "text": "Director Gutschenritter. Chris",
+    "text": "Chris Gutschenritter: Yes.",
     "start": 13078.087,
     "end": 13078.087
   },
   {
-    "text": "Gutschenritter: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 13078.848,
     "end": 13079.148000000001
   },
   {
-    "text": "Director Guzman. Michael",
+    "text": "Michael Guzman: Yes.",
     "start": 13079.148000000001,
     "end": 13079.689
   },
   {
-    "text": "Guzman: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Harwick.",
     "start": 13080.67,
     "end": 13080.970000000001
   },
   {
-    "text": "Director Harwick. Ian",
+    "text": "Ian Harwick: Yep.",
     "start": 13080.970000000001,
     "end": 13081.41
   },
   {
-    "text": "Harwick: Yep. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 13082.551,
     "end": 13082.9015
   },
   {
-    "text": "Director Larsen. Matt",
+    "text": "Matt Larsen: No.",
     "start": 13084.153,
     "end": 13084.153
   },
   {
-    "text": "Larsen: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Nicholson.",
     "start": 13085.354,
     "end": 13085.734
   },
   {
-    "text": "Director Nicholson. Chris",
+    "text": "Chris Nicholson: Yes.",
     "start": 13085.734,
     "end": 13088.496
   },
   {
-    "text": "Nicholson: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director O'Keefe.",
     "start": 13089.617,
     "end": 13089.9375
   },
   {
-    "text": "Director O'Keefe. Patrick",
+    "text": "Patrick O'Keefe: No.",
     "start": 13089.9375,
     "end": 13092.938
   },
   {
-    "text": "O'Keefe: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Paglieri.",
     "start": 13093.96,
     "end": 13094.547999999999
   },
   {
-    "text": "Director Paglieri. Brett",
+    "text": "Brett Paglieri: No.",
     "start": 13095.523,
     "end": 13095.523
   },
   {
-    "text": "Paglieri: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Ruscha.",
     "start": 13096.425,
     "end": 13096.9055
   },
   {
-    "text": "Director Ruscha. Joyann",
+    "text": "Joyann Ruscha: Yes.",
     "start": 13098.609,
     "end": 13098.609
   },
   {
-    "text": "Ruscha: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Whitmore.",
     "start": 13099.711,
     "end": 13100.191666666666
   },
   {
-    "text": "Director Whitmore. Troy",
+    "text": "Troy Whitmore: Yes.",
     "start": 13100.191666666666,
     "end": 13100.472
   },
   {
-    "text": "Whitmore: Yes. Julien Bouquet: I'm also",
+    "text": "Julien Bouquet: I'm also a yes. So that'll pass. 1, 2, 3, 4. I think I got 10 yeses, 3 nos, and 2 absent. OK.",
     "start": 13103.318,
-    "end": 13103.993749999998
-  },
-  {
-    "text": "a yes. So that'll pass. 1, 2,",
-    "start": 13104.5,
-    "end": 13106.463
-  },
-  {
-    "text": "3, 4. I think I got 10 yeses, 3 nos, and",
-    "start": 13106.463,
-    "end": 13113.859363636362
-  },
-  {
-    "text": "2",
-    "start": 13115.661,
     "end": 13115.661
   },
   {
-    "text": "absent. OK. Jack Kroll: There are",
+    "text": "Jack Kroll: There are 4 nos.",
     "start": 13117.07,
     "end": 13117.745749999998
   },
   {
-    "text": "4 nos. Julien Bouquet: Excuse me,",
+    "text": "Julien Bouquet: Excuse me, four nos. Thank you.",
     "start": 13117.991,
-    "end": 13118.892499999998
-  },
-  {
-    "text": "four nos.",
-    "start": 13119.213,
     "end": 13119.383
   },
   {
-    "text": "Thank you. Jack Kroll: So 9, 4,",
+    "text": "Jack Kroll: So 9, 4, and 2.",
     "start": 13119.894,
     "end": 13120.806799999998
   },
   {
-    "text": "and 2. Julien Bouquet: 9, 4",
+    "text": "Julien Bouquet: 9, 4 and 2. My apologies. We'll save that for the record. OK. Now moving on back to the main motion as amended. Do we have any further discussion on the main motion? OK. I will do a roll call vote for the main motion, as amended. Treasurer Benker.",
     "start": 13121.235,
-    "end": 13121.775749999999
-  },
-  {
-    "text": "and 2.",
-    "start": 13122.076,
-    "end": 13122.3665
-  },
-  {
-    "text": "My apologies. We'll save that for",
-    "start": 13122.857,
-    "end": 13123.641166666672
-  },
-  {
-    "text": "the",
-    "start": 13125.22,
-    "end": 13125.22
-  },
-  {
-    "text": "record. OK. Now moving on back to the main motion",
-    "start": 13126.263272727272,
-    "end": 13129.703727272727
-  },
-  {
-    "text": "as amended. Do we have any further discussion on the",
-    "start": 13130.126,
-    "end": 13131.765799999994
-  },
-  {
-    "text": "main",
-    "start": 13133.991,
-    "end": 13133.991
-  },
-  {
-    "text": "motion? OK. I will do a roll call vote for the main motion,",
-    "start": 13134.392,
-    "end": 13138.802000000007
-  },
-  {
-    "text": "as amended.",
-    "start": 13140.058333333334,
     "end": 13140.318666666668
   },
   {
-    "text": "Treasurer Benker. Karen",
+    "text": "Karen Benker: Yes.",
     "start": 13142.762,
     "end": 13143.002333333334
   },
   {
-    "text": "Benker: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Catlin.",
     "start": 13143.002333333334,
     "end": 13143.242666666667
   },
   {
-    "text": "Director Catlin. Peggy",
+    "text": "Peggy Catlin: Yes.",
     "start": 13143.242666666667,
     "end": 13144.024
   },
   {
-    "text": "Catlin: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guissinger.",
     "start": 13145.099,
     "end": 13146.541
   },
   {
-    "text": "Director Guissinger. Lynn",
+    "text": "Lynn Guissinger: Yes.",
     "start": 13146.9615,
     "end": 13148.183
   },
   {
-    "text": "Guissinger: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Gutschenritter.",
     "start": 13148.183,
     "end": 13148.183
   },
   {
-    "text": "Director Gutschenritter. Chris",
+    "text": "Chris Gutschenritter: Yes.",
     "start": 13148.183,
     "end": 13148.183
   },
   {
-    "text": "Gutschenritter: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 13148.623,
     "end": 13148.9935
   },
   {
-    "text": "Director Guzman. Michael",
+    "text": "Michael Guzman: Yes.",
     "start": 13148.9935,
     "end": 13150.025
   },
   {
-    "text": "Guzman: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Harwick.",
     "start": 13150.465,
     "end": 13150.8455
   },
   {
-    "text": "Director Harwick. Ian",
+    "text": "Ian Harwick: Yes.",
     "start": 13150.8455,
     "end": 13151.246
   },
   {
-    "text": "Harwick: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Larsen.",
     "start": 13152.047,
     "end": 13153.348
   },
   {
-    "text": "Director Larsen. Matt",
+    "text": "Matt Larsen: No.",
     "start": 13153.348,
     "end": 13153.348
   },
   {
-    "text": "Larsen: No. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Nicholson.",
     "start": 13154.91,
     "end": 13155.3405
   },
   {
-    "text": "Director Nicholson. Chris",
+    "text": "Chris Nicholson: Yes.",
     "start": 13155.3405,
     "end": 13156.372
   },
   {
-    "text": "Nicholson: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director O'Keefe.",
     "start": 13156.973,
     "end": 13157.373
   },
   {
-    "text": "Director O'Keefe. Patrick",
+    "text": "Patrick O'Keefe: Yes.",
     "start": 13157.373,
     "end": 13158.054
   },
   {
-    "text": "O'Keefe: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Paglieri.",
     "start": 13158.494,
     "end": 13160.477
   },
   {
-    "text": "Director Paglieri. Brett",
+    "text": "Brett Paglieri: Yes.",
     "start": 13160.477,
     "end": 13160.477
   },
   {
-    "text": "Paglieri: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Ruscha.",
     "start": 13162.539,
     "end": 13163.049500000001
   },
   {
-    "text": "Director Ruscha. Joyann",
+    "text": "Joyann Ruscha: Yes.",
     "start": 13163.049500000001,
     "end": 13163.58
   },
   {
-    "text": "Ruscha: Yes. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Whitmore.",
     "start": 13164.141,
     "end": 13164.4815
   },
   {
-    "text": "Director Whitmore. Troy",
+    "text": "Troy Whitmore: Yes.",
     "start": 13164.4815,
     "end": 13165.102
   },
   {
-    "text": "Whitmore: Yes. Julien Bouquet: I am also",
+    "text": "Julien Bouquet: I am also a yes. It will pass. 12 yes, 1 no, 2 absent. Thank you. All right. Moving on. That was all our recommended actions. Board of Director activities. I think you're all good on that. Other matters?",
     "start": 13165.883,
-    "end": 13166.457
-  },
-  {
-    "text": "a yes. It will pass. 12 yes, 1 no,",
-    "start": 13166.904,
-    "end": 13172.615125000002
-  },
-  {
-    "text": "2 absent.",
-    "start": 13173.612,
-    "end": 13173.802
-  },
-  {
-    "text": "Thank you.",
-    "start": 13174.85,
-    "end": 13175.4465
-  },
-  {
-    "text": "All right.",
-    "start": 13176.043,
-    "end": 13176.6395
-  },
-  {
-    "text": "Moving on. That was all our",
-    "start": 13177.276,
-    "end": 13179.34766666667
-  },
-  {
-    "text": "recommended actions. Board of",
-    "start": 13180.584,
-    "end": 13181.50125
-  },
-  {
-    "text": "Director activities. I think you're all good",
-    "start": 13183.631,
-    "end": 13184.54214285714
-  },
-  {
-    "text": "on that.",
-    "start": 13185.035,
     "end": 13185.325499999999
   },
   {
-    "text": "Other matters? Speaker:",
+    "text": "Speaker: Amen, buddy.",
     "start": 13188.563,
     "end": 13189.4955
   },
   {
-    "text": "Amen, buddy. Julien Bouquet:",
+    "text": "Julien Bouquet: Director Guzman.",
     "start": 13190.56,
     "end": 13191.201000000001
   },
   {
-    "text": "Director Guzman. Michael Guzman: I got",
+    "text": "Michael Guzman: I got one quick. Sorry. Thank you, Mr. Chair, for approving the travel consideration for lodging and assistance to go to the NTI Public Engagement course in Florida. Really packed, but came in really handy because as soon as I returned, we held the town hall to do exactly what I was sent to go learn about. So I appreciate that. And I was grateful for the assistance from staff and from Director Ruscha to be able to host that town hall. Thanks.",
     "start": 13191.201000000001,
-    "end": 13192.372749999999
-  },
-  {
-    "text": "one",
-    "start": 13192.563,
-    "end": 13192.563
-  },
-  {
-    "text": "quick. Sorry. Thank",
-    "start": 13193.384,
-    "end": 13194.077217391305
-  },
-  {
-    "text": "you, Mr. Chair, for approving the travel consideration for lodging and assistance to go to the NTI Public Engagement course",
-    "start": 13194.423826086957,
-    "end": 13201.009391304351
-  },
-  {
-    "text": "in Florida. Really packed, but came in really handy because as soon as I returned, we held the town hall to do exactly what I was sent to go",
-    "start": 13202.458,
-    "end": 13208.375655172431
-  },
-  {
-    "text": "learn about. So I",
-    "start": 13208.747,
-    "end": 13209.543499999998
-  },
-  {
-    "text": "appreciate that. And I was grateful for the assistance from staff and from Director Ruscha to be able to host that",
-    "start": 13210.37,
-    "end": 13215.309999999989
-  },
-  {
-    "text": "town",
-    "start": 13215.577,
     "end": 13215.577
   },
   {
-    "text": "hall. Thanks. Julien Bouquet: Secretary-- thank you,",
+    "text": "Julien Bouquet: Secretary-- thank you, Director Guzman. Secretary Nicholson.",
     "start": 13217.3,
-    "end": 13218.757249999999
-  },
-  {
-    "text": "Director Guzman.",
-    "start": 13219.263,
     "end": 13219.6535
   },
   {
-    "text": "Secretary Nicholson. Chris Nicholson: I just wanted to flag that this weekend is the reopening of Downtown Celebration on Saturday",
+    "text": "Chris Nicholson: I just wanted to flag that this weekend is the reopening of Downtown Celebration on Saturday and Sunday. So if you like RTD, please come take it to downtown and enjoy our lovely food and all the other cool stuff. Most of the mall is back and running and we're very excited about it, so.",
     "start": 13219.6535,
-    "end": 13225.930814814801
-  },
-  {
-    "text": "and Sunday. So if you like RTD, please come take it to downtown and enjoy our lovely food and all the other",
-    "start": 13226.268333333319,
-    "end": 13233.356222222192
-  },
-  {
-    "text": "cool stuff. Most of the mall is back and running and we're very excited about",
-    "start": 13233.69374074071,
     "end": 13238.66
   },
   {
-    "text": "it, so. Julien Bouquet: Any",
+    "text": "Julien Bouquet: Any other matters? OK. I got a quick one. It's only going to take 19 minutes. Just joking. My only other matter is please make sure that you Directors fill out that form that was due last week, extended to Monday morning. Please make sure you guys take care of that. The survey. Thank you. With that being said, do I have a motion to adjourn? Director Ruscha.",
     "start": 13238.9884,
-    "end": 13239.6452
-  },
-  {
-    "text": "other",
-    "start": 13239.973600000001,
-    "end": 13239.973600000001
-  },
-  {
-    "text": "matters? OK. I got a",
-    "start": 13240.302000000001,
-    "end": 13241.615600000003
-  },
-  {
-    "text": "quick one. It's only going to take",
-    "start": 13241.984,
-    "end": 13243.817000000003
-  },
-  {
-    "text": "19 minutes.",
-    "start": 13246.197,
-    "end": 13246.467499999999
-  },
-  {
-    "text": "Just joking. My only other matter is please make sure that you Directors fill out that form that was due last week, extended to",
-    "start": 13247.139,
-    "end": 13255.05823076922
-  },
-  {
-    "text": "Monday morning. Please make sure you guys take care",
-    "start": 13255.515,
-    "end": 13258.212692307701
-  },
-  {
-    "text": "of that.",
-    "start": 13258.482461538471,
-    "end": 13258.752230769242
-  },
-  {
-    "text": "The survey.",
-    "start": 13259.062,
-    "end": 13259.252
-  },
-  {
-    "text": "Thank you. With that being said, do I have a motion",
-    "start": 13259.743,
-    "end": 13262.443500000008
-  },
-  {
-    "text": "to adjourn?",
-    "start": 13263.59,
     "end": 13263.953571428572
   },
   {
-    "text": "Director Ruscha. Chris",
+    "text": "Chris Gutschenritter: Second.",
     "start": 13264.317142857144,
     "end": 13264.317142857144
   },
   {
-    "text": "Gutschenritter: Second. Julien Bouquet: And a second",
+    "text": "Julien Bouquet: And a second from Gutschenritter. You guys all have a lovely night. Thank you all for your patience.",
     "start": 13264.317142857144,
-    "end": 13265.771428571432
-  },
-  {
-    "text": "from Gutschenritter. You guys all have a",
-    "start": 13266.195,
-    "end": 13267.39757142857
-  },
-  {
-    "text": "lovely night. Thank you all for",
-    "start": 13267.778,
     "end": 13286.461
   }
 ]


### PR DESCRIPTION
## Summary
- keep pdf transcript lines intact when aligning
- interpolate timestamps for any line without token matches
- regenerate May Board Meeting dtw files with correct speaker labels
- validate speaker labels against pdf_transcript.txt

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`
- `python -m videocut.cli dtw-align videos/May_Board_Meeting/pdf_transcript.txt videos/May_Board_Meeting/May_Board_Meeting.srt --json-out videos/May_Board_Meeting/matched_dtw.json --txt-out videos/May_Board_Meeting/dtw-transcript.txt --band 10`


------
https://chatgpt.com/codex/tasks/task_e_684fbb033d008321a7775e16867a9168