### PR TITLE
Add fade preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ pip install -e .[light]
 4. **Concatenate** – `videocut concatenate`
    - Joins all clips with a fade to white between each one, creating
      `final_video.mp4`.
+5. **Preview fades** – `videocut preview-fades`
+   - Generates 20 sample crossfades between `clip_000.mp4` and `clip_001.mp4`
+     in the `fade_previews/` directory.
 
 ## Package layout
 - `videocut/cli.py` – command line interface implemented with Typer

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -22,6 +22,7 @@ from .core import (
     speaker_mapping,
     chair,
     pdf_utils,
+    crossfade_preview,
 )
 
 app = typer.Typer(help="VideoCut pipeline")
@@ -514,6 +515,12 @@ def clip_cmd(
 @app.command()
 def concatenate(clips_dir: str = "clips", out: str = "final_video.mp4"):
     video_editing.concatenate_clips(clips_dir, out)
+
+
+@app.command("preview-fades")
+def preview_fades(clips_dir: str = "clips", out_dir: str = "fade_previews") -> None:
+    """Generate crossfade preview videos between the first two clips."""
+    crossfade_preview.preview_crossfades(clips_dir, out_dir)
 
 
 @app.command()

--- a/videocut/core/__init__.py
+++ b/videocut/core/__init__.py
@@ -12,6 +12,7 @@ from . import (
     speaker_mapping,
     chair,
     pdf_utils,
+    crossfade_preview,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "speaker_mapping",
     "chair",
     "pdf_utils",
+    "crossfade_preview",
 ]

--- a/videocut/core/crossfade_preview.py
+++ b/videocut/core/crossfade_preview.py
@@ -1,0 +1,93 @@
+"""Generate crossfade previews between the first two clips.
+
+This helper creates a series of videos showing different fade lengths and
+brightness adjustments between the first two clips in a directory.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List
+
+
+def preview_crossfades(clips_dir: str = "clips", out_dir: str = "fade_previews") -> None:
+    """Generate sample crossfades using FFmpeg.
+
+    Parameters
+    ----------
+    clips_dir:
+        Directory containing ``clip_000.mp4`` and ``clip_001.mp4``.
+    out_dir:
+        Directory where the preview files will be written.
+    """
+    c1 = Path(clips_dir) / "clip_000.mp4"
+    c2 = Path(clips_dir) / "clip_001.mp4"
+    if not c1.exists() or not c2.exists():
+        raise FileNotFoundError("clip_000.mp4 or clip_001.mp4 missing")
+
+    Path(out_dir).mkdir(exist_ok=True)
+
+    dur = float(
+        subprocess.check_output(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "csv=p=0",
+                str(c1),
+            ],
+            text=True,
+        ).strip()
+    )
+
+    brightness: List[float] = [0.5 + 0.05 * i for i in range(20)]
+    lengths: List[float] = [0.25 + 0.1 * i for i in range(20)]
+
+    for i, (b, d) in enumerate(zip(brightness, lengths)):
+        offset = max(dur - d, 0)
+        vf = (
+            f"[0:v]format=yuv420p,setpts=PTS-STARTPTS[v0];"
+            f"[1:v]format=yuv420p,eq=brightness={b-1.0},setpts=PTS-STARTPTS[v1];"
+            f"[v0][v1]xfade=transition=fade:duration={d}:offset={offset}[v]"
+        )
+        af = f"[0:a][1:a]acrossfade=d={d}[a]"
+        out = Path(out_dir) / f"fade_{i:02d}.mp4"
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-v",
+                "error",
+                "-y",
+                "-i",
+                str(c1),
+                "-i",
+                str(c2),
+                "-filter_complex",
+                vf + ";" + af,
+                "-map",
+                "[v]",
+                "-map",
+                "[a]",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "veryfast",
+                "-crf",
+                "20",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                str(out),
+            ],
+            check=True,
+        )
+        print(f"✅  {out.name} duration={d:.2f}s brightness={b:.2f}")
+
+
+__all__ = ["preview_crossfades"]


### PR DESCRIPTION
## Summary
- provide `preview_crossfades` helper to generate fade previews
- expose the helper in the core package and CLI
- document the new `preview-fades` CLI command in the README

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a2aa7ae08321a8217b389759b741