### PR TITLE
Update crossfade preview variations

### DIFF
--- a/videocut/core/crossfade_preview.py
+++ b/videocut/core/crossfade_preview.py
@@ -1,31 +1,30 @@
 """Generate crossfade previews between the first two clips.
 
-This helper creates a series of videos showing different fade lengths and
-brightness adjustments between the first two clips in a directory.
+This helper creates multiple videos showing different fade durations and
+brightness adjustments between ``clip_000.mp4`` and ``clip_001.mp4``.  The
+results help choose a preferred transition for the final video and are
+primarily used by the ``preview-fades`` CLI command.
 """
 from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import List
+
 
 
 def preview_crossfades(clips_dir: str = "clips", out_dir: str = "fade_previews") -> None:
     """Generate sample crossfades using FFmpeg.
 
-    Parameters
-    ----------
-    clips_dir:
-        Directory containing ``clip_000.mp4`` and ``clip_001.mp4``.
-    out_dir:
-        Directory where the preview files will be written.
+    The generated clips vary the crossfade duration and brightness of the
+    second clip. Each output file is named ``fade_XX.mp4`` in ``out_dir``.
     """
     c1 = Path(clips_dir) / "clip_000.mp4"
     c2 = Path(clips_dir) / "clip_001.mp4"
     if not c1.exists() or not c2.exists():
         raise FileNotFoundError("clip_000.mp4 or clip_001.mp4 missing")
 
-    Path(out_dir).mkdir(exist_ok=True)
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
 
     dur = float(
         subprocess.check_output(
@@ -45,18 +44,18 @@ def preview_crossfades(clips_dir: str = "clips", out_dir: str = "fade_previews")
         ).strip()
     )
 
-    brightness: List[float] = [0.5 + 0.05 * i for i in range(20)]
-    lengths: List[float] = [0.25 + 0.1 * i for i in range(20)]
+    brightness: list[float] = [0.5 + 0.05 * i for i in range(20)]
+    lengths: list[float] = [0.25 + 0.1 * i for i in range(20)]
 
     for i, (b, d) in enumerate(zip(brightness, lengths)):
         offset = max(dur - d, 0)
         vf = (
-            f"[0:v]format=yuv420p,setpts=PTS-STARTPTS[v0];"
-            f"[1:v]format=yuv420p,eq=brightness={b-1.0},setpts=PTS-STARTPTS[v1];"
+            f"[0:v]fps=30,format=yuv420p,setpts=PTS-STARTPTS[v0];"
+            f"[1:v]fps=30,format=yuv420p,eq=brightness={b-1.0},setpts=PTS-STARTPTS[v1];"
             f"[v0][v1]xfade=transition=fade:duration={d}:offset={offset}[v]"
         )
         af = f"[0:a][1:a]acrossfade=d={d}[a]"
-        out = Path(out_dir) / f"fade_{i:02d}.mp4"
+        output_file = out_path / f"fade_{i:02d}.mp4"
         subprocess.run(
             [
                 "ffmpeg",
@@ -83,11 +82,11 @@ def preview_crossfades(clips_dir: str = "clips", out_dir: str = "fade_previews")
                 "aac",
                 "-b:a",
                 "128k",
-                str(out),
+                str(output_file),
             ],
             check=True,
         )
-        print(f"✅  {out.name} duration={d:.2f}s brightness={b:.2f}")
+        print(f"✅  {output_file.name} duration={d:.2f}s brightness={b:.2f}")
 
 
 __all__ = ["preview_crossfades"]


### PR DESCRIPTION
## Summary
- restore multiple crossfade previews with brightness/duration variations
- keep fps=30 for safer ffmpeg filters

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a856de888321858b2e28cb28c8c9