### PR TITLE
Add whisper.cpp transcription option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,26 @@ pip install -e .[light]
    - Extracts dialogue from the PDF, aligns it to the video and writes
      `transcript.txt` with lines in the form
      `[start‑end] NAME: text`.
-   - WhisperX generates `May_Board_Meeting.json`, `May_Board_Meeting.tsv`,
-     `May_Board_Meeting.srt`, `May_Board_Meeting.vtt` and `May_Board_Meeting.txt`.
+    - WhisperX generates `May_Board_Meeting.json`, `May_Board_Meeting.tsv`,
+      `May_Board_Meeting.srt`, `May_Board_Meeting.vtt` and `May_Board_Meeting.txt`.
+
+## Transcription Options
+
+### Default (WhisperX)
+To transcribe using WhisperX (with alignment and word-level timestamps):
+```bash
+videocut transcribe input.mp4
+```
+
+### Fast Mode (whisper.cpp)
+To transcribe using whisper.cpp for much faster performance (no word-level timing):
+```bash
+videocut transcribe input.mp4 --use-whispercpp
+```
+
+Requires:
+- `main` binary from [whisper.cpp](https://github.com/ggerganov/whisper.cpp) compiled in root
+- Model at `models/ggml-base.en.bin`
 2. **Identify segments** – `videocut identify-segments May_Board_Meeting.json`
    - Creates a tab‑indented `segments.txt` containing `=START=` and `=END=`
      markers for each Nicholson segment.

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -25,7 +25,11 @@ from .core import (
     crossfade_preview,
     crossfader,
 )
-from .commands import authorize as authorize_cmd, upload as upload_cmd
+from .commands import (
+    authorize as authorize_cmd,
+    upload as upload_cmd,
+    transcribe_cpp as transcribe_cpp_cmd,
+)
 
 app = typer.Typer(help="VideoCut pipeline")
 
@@ -42,9 +46,17 @@ def transcribe(
     ),
     progress: bool = typer.Option(True, help="Show WhisperX progress output"),
     pdf: Optional[str] = typer.Option(None, help="Official PDF transcript"),
+    use_whispercpp: bool = typer.Option(
+        False, help="Use whisper.cpp instead of WhisperX"
+    ),
 ):
     """Run WhisperX transcription."""
-    transcription.transcribe(video, hf_token, diarize, speaker_db, progress, pdf)
+    if use_whispercpp:
+        transcribe_cpp_cmd.transcribe_cpp.callback(
+            input_file=video, model="models/ggml-base.en.bin", output="transcript.txt"
+        )
+    else:
+        transcription.transcribe(video, hf_token, diarize, speaker_db, progress, pdf)
 
 
 @app.command()

--- a/videocut/commands/__init__.py
+++ b/videocut/commands/__init__.py
@@ -1,0 +1,17 @@
+from .authorize import run_authorization
+from .upload import (
+    parse_segments_for_chapters,
+    seconds_to_timestamp,
+    build_description_from_segments,
+    upload_video_to_youtube,
+)
+from .transcribe_cpp import transcribe_cpp
+
+__all__ = [
+    "run_authorization",
+    "parse_segments_for_chapters",
+    "seconds_to_timestamp",
+    "build_description_from_segments",
+    "upload_video_to_youtube",
+    "transcribe_cpp",
+]

--- a/videocut/commands/transcribe_cpp.py
+++ b/videocut/commands/transcribe_cpp.py
@@ -1,0 +1,27 @@
+import subprocess
+from pathlib import Path
+import click
+from whispercpp_to_transcript import convert_whispercpp_to_transcript
+
+
+@click.command()
+@click.argument('input_file')
+@click.option('--model', default='models/ggml-base.en.bin', help='Path to whisper.cpp model')
+@click.option('--output', default='transcript.txt', help='Output transcript path')
+def transcribe_cpp(input_file, model, output):
+    """Transcribe using whisper.cpp."""
+    input_path = Path(input_file)
+    wav_path = input_path.with_suffix('.wav')
+
+    if not wav_path.exists():
+        subprocess.run(['ffmpeg', '-y', '-i', str(input_path), str(wav_path)], check=True)
+
+    subprocess.run([
+        './main',
+        '-m', model,
+        '-f', str(wav_path),
+        '-otxt'
+    ], check=True)
+
+    convert_whispercpp_to_transcript('output.txt', output)
+

--- a/whispercpp_to_transcript.py
+++ b/whispercpp_to_transcript.py
@@ -1,0 +1,13 @@
+import re
+
+def convert_whispercpp_to_transcript(input_path, output_path):
+    with open(input_path, 'r') as f:
+        lines = f.readlines()
+
+    with open(output_path, 'w') as out:
+        for line in lines:
+            match = re.match(r"\[(\d\d:\d\d:\d\d\.\d\d\d) --> (\d\d:\d\d:\d\d\.\d\d\d)\] (.*)", line)
+            if match:
+                start, end, text = match.groups()
+                out.write(f"[{start}-{end}] UNKNOWN: {text.strip()}\n")
+


### PR DESCRIPTION
## Summary
- support whisper.cpp as an alternative transcription backend
- convert whisper.cpp text output to VideoCut's transcript format
- expose the whisper.cpp path via CLI flag `--use-whispercpp`
- document the new whisper.cpp option

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_6855aac0edf0832195ed573f45f4e6ef