### PR TITLE
Add mlx whisper backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ pip install -e .[light]
      `[start‑end] NAME: text`.
    - WhisperX generates `May_Board_Meeting.json`, `May_Board_Meeting.tsv`,
      `May_Board_Meeting.srt`, `May_Board_Meeting.vtt` and `May_Board_Meeting.txt`.
+
+### Transcription Backends
+
+VideoCut supports multiple local transcription backends:
+
+- `whisperx` (default): Uses WhisperX via CLI subprocess.
+- `mlx`: Uses Apple's MLX-Whisper for fast on-device transcription (Apple Silicon only).
+
+Example usage:
+
+```bash
+videocut transcribe myvideo.mp4 --backend mlx
+```
+
+Requirements:
+
+* macOS with Apple Silicon (M1/M2/M3)
+* `mlx` and `mlx-whisper` Python packages
+* `ffmpeg` must be installed and in your system path
+
 2. **Identify segments** – `videocut identify-segments May_Board_Meeting.json`
    - Creates a tab‑indented `segments.txt` containing `=START=` and `=END=`
      markers for each Nicholson segment.

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -35,16 +35,17 @@ def transcribe(
     video: str = typer.Argument("input.mp4", help="Video file to transcribe"),
     diarize: bool = typer.Option(False, help="Perform speaker diarization"),
     hf_token: Optional[str] = typer.Option(
-        None, envvar="HF_TOKEN", help="Hugging Face token for diarization"
+        None, envvar="HF_TOKEN", help="Hugging Face token"
     ),
     speaker_db: Optional[str] = typer.Option(
         None, help="Speaker embedding database JSON"
     ),
     progress: bool = typer.Option(True, help="Show WhisperX progress output"),
     pdf: Optional[str] = typer.Option(None, help="Official PDF transcript"),
+    backend: str = typer.Option("whisperx", help="Transcription backend: whisperx | mlx"),
 ):
-    """Run WhisperX transcription."""
-    transcription.transcribe(video, hf_token, diarize, speaker_db, progress, pdf)
+    """Run transcription with specified backend."""
+    transcription.transcribe(video, hf_token, diarize, speaker_db, progress, pdf, backend)
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- add optional MLX-based backend for video transcription
- support new --backend flag in CLI
- document available backends in README

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_68565c56e9a88321a52d837fef9f17c1