### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,211 +1,89 @@
-# VideoCut
+# VideoCut Quickstart
 
-VideoCut turns a recorded board meeting into a polished highlight reel. The tools align a written transcript with the video, detect remarks from Secretary Nicholson and cut the results into shareable clips.
+This short guide walks through a typical workflow using the `videocut` command line interface. Each step can be run individually or you can use the simplified `prep` and `build` commands to automate the process.
 
-## Requirements
-- Python 3.11+
-- [FFmpeg](https://ffmpeg.org/) available on your `PATH`
-- [WhisperX](https://github.com/m-bain/whisperX) and its Python dependencies
-- `HF_TOKEN` environment variable when using the diarization features
-
-## Setup
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-make install
-pytest
-```
-For a lightweight install without transcription dependencies:
+## Basic Pipeline
 
 ```bash
-pip install -e .[light]
-```
-
-## Workflow
-0. **Download Meeting Transcript & Video from Youtube & trim**
-   - Download the meeting transcript from RTD.
-   - Run:
-      - `chmod +x download-meeting.sh`
-      - `./download-meeting.sh "MEETING_YOUTUBE_VIDEO_URL"` (meeting URL in quotes)
-   - This script downloads the meeting video. Move the video and transcript into a folder.
-   - After downloading, if the meeting was delayed, trim the video to start at the beginning of the meeting so it aligns with the printed transcript.
-1. **Transcribe & align** – `videocut transcribe May_Board_Meeting.mp4 --pdf transcript.pdf`
-   - Extracts dialogue from the PDF, aligns it to the video and writes
-     `transcript.txt` with lines in the form
-     `[start‑end] NAME: text`.
-   - WhisperX generates `May_Board_Meeting.json`, `May_Board_Meeting.tsv`,
-     `May_Board_Meeting.srt`, `May_Board_Meeting.vtt` and `May_Board_Meeting.txt`.
-
-### Transcription Backends
-
-VideoCut supports multiple local transcription backends:
-
-- `whisperx` (default): Uses WhisperX via CLI subprocess.
-- `mlx`: Uses Apple's MLX-Whisper for fast on-device transcription (Apple Silicon only).
-- `whispercpp`: Runs the bundled static `whisper` binary.
-
-Example usage:
-
-```bash
-videocut transcribe myvideo.mp4 --backend mlx
-# or use whisper.cpp
-videocut transcribe myvideo.mp4 --backend whispercpp
-```
-
-Requirements:
-
-* macOS with Apple Silicon (M1/M2/M3)
-* `mlx` and `mlx-whisper` Python packages
-* `ffmpeg` must be installed and in your system path
-* for `whispercpp` download `ggml-small.en-q8.bin` into `tools/models`
-
-2. **Identify segments** – `videocut identify-segments May_Board_Meeting.json`
-   - Creates a tab‑indented `segments.txt` containing `=START=` and `=END=`
-     markers for each Nicholson segment.
-2a. *(optional)* Edit `segments.txt` to trim or reorder the segments.
-2b. You can also run `videocut segment transcript.txt` on a raw, flush‑left
-    transcript. The CLI will print "Using new segmenter 2.0 code" when this
-    code path is triggered.
-3. **Generate clips** – `videocut generate-and-align May_Board_Meeting.mp4 segments.txt`
-   - Buffers and re‑aligns each segment, trims to word boundaries and saves the
-     final clips to `clips/`. Alignment data for each clip is written as
-     `clip_###_aligned.json` with a summary in `timestamps.json`.
-   - `generate-and-align` also accepts a JSON segments file for simpler workflows.
-   - Use `videocut clip` to cut clips exactly as specified in `segments.txt` without alignment.
-4. **Concatenate** – `videocut concatenate`
-   - Joins clips with a dip-to-white transition by default, creating
-     `final_video.mp4`. Use `--dip` to customize the color and timing or
-     `--dip-news` for a preset news-style flash.
-5. **Preview fades** – `videocut preview-fades`
-   - Generates 20 sample crossfades between `clip_000.mp4` and `clip_001.mp4`
-     in the `fade_previews/` directory.
-
-## Package layout
-- `videocut/cli.py` – command line interface implemented with Typer
-- `videocut/core/` – reusable helpers
-- `videos/` – example data used by the tests
-
-### PDF transcript cleanup
-If a diarized JSON transcript already exists you can replace its text using an
-official PDF with:
-```bash
-videocut pdf-transcript existing.json transcript.pdf
-```
-
-To regenerate `transcript.txt` from a diarized JSON and an official PDF:
-```bash
-videocut json-to-transcript May_Board_Meeting.json transcript.pdf
-```
-
-### Additional transcript utilities
-Use `pdf-extract` to create both a text and JSON version of a PDF transcript:
-```bash
+videocut transcribe video.mp4
 videocut pdf-extract transcript.pdf
-```
-
-You can align those PDF lines to a diarized JSON with `pdf-match`:
-```bash
-videocut pdf-match transcript.pdf May_Board_Meeting.json
-```
-This writes `matched.json` where each line's words are paired with their
-closest timestamped match from the JSON.
-
-For raw SRT captions you can perform a band-limited DTW alignment with:
-```bash
-videocut dtw-align pdf_transcript.txt May_Board_Meeting.srt
-```
-This generates `matched_dtw.json`. Token timestamps are evenly spread across each
-caption's duration for better alignment accuracy. Use ``make-labeled`` to create
-a speaker-tagged transcript:
-```bash
-videocut make-labeled matched_dtw.json -o dtw_transcript_labeled.txt
-```
-The resulting ``dtw_transcript_labeled.txt`` is ready for ``videocut segment``.
-
-### 3 · Match (NEW)
-
-```bash
-videocut match pdf_transcript.json May_Board_Meeting.json
-```
-
-Produces `matched.json` where every PDF line now carries precise start/end
-timestamps taken from the ASR word stream. Down-stream commands
-(`identify-segments`, `generate-and-align`, `concatenate`) consume `matched.json`
-in place of `pdf_transcript.json`.
-
-Run `check-transcript` to flag segments with unusual timing:
-```bash
-videocut check-transcript May_Board_Meeting.json
-```
-This reports any segments whose words per second fall outside the normal range.
-
-### 4 · Convert to TXT (NEW)
-
-```bash
-videocut to-txt matched.json       # ⇒ transcript.txt
-```
-
-`transcript.txt` is the input expected by **`videocut segment`**.
-
-### 5 · Make Labeled Transcript (NEW)
-
-```bash
-videocut make-labeled matched.json -o labeled_transcript.txt
-```
-
-Use this when a matched JSON is missing speaker tags. The output can be fed
-directly to ``videocut segment``.
-
-The full pipeline is now:
-
-```
-transcribe  →  match/dtw-align  →  segment  →  generate-and-align  →  concatenate
-
-### 6 · Install / Run Cheat-sheet
-
-```bash
-Step #1
-(Step one should take an mp4 file and a matching pdf transcript)
-videocut transcribe May_Board_Meeting.mp4
-videocut pdf-extract transcript.pdf
-videocut dtw-align pdf_transcript.txt May_Board_Meeting.srt
+videocut dtw-align pdf_transcript.txt video.srt
 videocut segment transcript.txt
-(Step 2 should take the same mp4 file and a segmented transcript, and accept the flags for concatenate)
-Step #2
-videocut clip videocut clip May_Board_Meeting.mp4 segments.txt
+videocut clip video.mp4 segments.txt
 videocut concatenate --dip-news
 ```
 
-## 📤 Uploading to YouTube
+### transcribe
+Run WhisperX (or another backend) on `video.mp4` and create transcription files.
 
-### Step 1: Authorize access (first time only)
-
-```bash
-videocut authorize --client-secret client_secret.json --output credentials.json
+```
+videocut transcribe VIDEO [--diarize] [--hf-token TOKEN] [--speaker-db FILE]
+                    [--progress / --no-progress] [--pdf PATH]
+                    [--backend whisperx|mlx]
 ```
 
-- Get `client_secret.json` from your Google Cloud Console (OAuth credentials).
-- This saves a `credentials.json` file used for uploads.
+### pdf-extract
+Extract the meeting transcript from a PDF.
 
-### Step 2: Upload video with chapters
-
-```bash
-videocut upload final.mp4 --creds credentials.json
+```
+videocut pdf-extract FILE [--txt-out TXT] [--json-out JSON]
 ```
 
-By default, this reads `segments.txt` and generates a YouTube description with clickable chapters.
+### dtw-align
+Align the PDF transcript to an existing SRT caption file.
 
-| Flag | Description |
-|------|-------------|
-| `--title` | Title for the uploaded video |
-| `--tags` | Tags to associate with the video |
-| `--privacy` | `public`, `unlisted` (default), `private` |
-| `--segments` | Path to `segments.txt` |
-| `--fade` | Transition length in seconds (default 0.5) |
+```
+videocut dtw-align PDF_TXT VIDEO_SRT [--json-out JSON] [--txt-out TXT]
+                                     [--band N]
+```
 
+### segment
+Detect remarks from Director Nicholson in a transcript.
 
-Download the Whisper.cpp model once:
+```
+videocut segment FILE [--speaker NAME] [--out PATH] [--debug]
+```
+
+### clip
+Cut clips according to `segments.txt`.
+
+```
+videocut clip VIDEO SEGMENTS [--out-dir DIR] [--srt-file FILE]
+```
+
+### concatenate
+Join the clips with dip‑to‑white transitions (use `--dip-news` for preset timing).
+
+```
+videocut concatenate [--clips-dir DIR] [--output FILE] [--dip] [--dip-news]
+                     [--dip-color HEX] [--fade-duration SEC]
+                     [--hold-duration SEC]
+```
+
+## Streamlined Commands
+
+Two helper commands automate the above steps:
+
+### prep
+Transcribe a video, extract and align the PDF transcript, and produce `segments.txt`.
+
+```
+videocut prep [VIDEO] [PDF] [--band N]
+```
+
+### build
+Cut clips from a video using `segments.txt` and concatenate them.
+
+```
+videocut build [VIDEO] [SEGMENTS] [--out-dir DIR] [--output FILE]
+               [--dip] [--dip-news] [--dip-color HEX]
+               [--fade-duration SEC] [--hold-duration SEC]
+               [--srt-file FILE]
+```
+
+With these two commands you can run the full workflow as:
+
 ```bash
-wget -O tools/models/ggml-small.en-q8.bin \
-  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en-q8_0.bin
+videocut prep video.mp4 transcript.pdf
+videocut build video.mp4 segments.txt
 ```

--- a/README.old.md
+++ b/README.old.md
@@ -1,0 +1,211 @@
+# VideoCut
+
+VideoCut turns a recorded board meeting into a polished highlight reel. The tools align a written transcript with the video, detect remarks from Secretary Nicholson and cut the results into shareable clips.
+
+## Requirements
+- Python 3.11+
+- [FFmpeg](https://ffmpeg.org/) available on your `PATH`
+- [WhisperX](https://github.com/m-bain/whisperX) and its Python dependencies
+- `HF_TOKEN` environment variable when using the diarization features
+
+## Setup
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+make install
+pytest
+```
+For a lightweight install without transcription dependencies:
+
+```bash
+pip install -e .[light]
+```
+
+## Workflow
+0. **Download Meeting Transcript & Video from Youtube & trim**
+   - Download the meeting transcript from RTD.
+   - Run:
+      - `chmod +x download-meeting.sh`
+      - `./download-meeting.sh "MEETING_YOUTUBE_VIDEO_URL"` (meeting URL in quotes)
+   - This script downloads the meeting video. Move the video and transcript into a folder.
+   - After downloading, if the meeting was delayed, trim the video to start at the beginning of the meeting so it aligns with the printed transcript.
+1. **Transcribe & align** – `videocut transcribe May_Board_Meeting.mp4 --pdf transcript.pdf`
+   - Extracts dialogue from the PDF, aligns it to the video and writes
+     `transcript.txt` with lines in the form
+     `[start‑end] NAME: text`.
+   - WhisperX generates `May_Board_Meeting.json`, `May_Board_Meeting.tsv`,
+     `May_Board_Meeting.srt`, `May_Board_Meeting.vtt` and `May_Board_Meeting.txt`.
+
+### Transcription Backends
+
+VideoCut supports multiple local transcription backends:
+
+- `whisperx` (default): Uses WhisperX via CLI subprocess.
+- `mlx`: Uses Apple's MLX-Whisper for fast on-device transcription (Apple Silicon only).
+- `whispercpp`: Runs the bundled static `whisper` binary.
+
+Example usage:
+
+```bash
+videocut transcribe myvideo.mp4 --backend mlx
+# or use whisper.cpp
+videocut transcribe myvideo.mp4 --backend whispercpp
+```
+
+Requirements:
+
+* macOS with Apple Silicon (M1/M2/M3)
+* `mlx` and `mlx-whisper` Python packages
+* `ffmpeg` must be installed and in your system path
+* for `whispercpp` download `ggml-small.en-q8.bin` into `tools/models`
+
+2. **Identify segments** – `videocut identify-segments May_Board_Meeting.json`
+   - Creates a tab‑indented `segments.txt` containing `=START=` and `=END=`
+     markers for each Nicholson segment.
+2a. *(optional)* Edit `segments.txt` to trim or reorder the segments.
+2b. You can also run `videocut segment transcript.txt` on a raw, flush‑left
+    transcript. The CLI will print "Using new segmenter 2.0 code" when this
+    code path is triggered.
+3. **Generate clips** – `videocut generate-and-align May_Board_Meeting.mp4 segments.txt`
+   - Buffers and re‑aligns each segment, trims to word boundaries and saves the
+     final clips to `clips/`. Alignment data for each clip is written as
+     `clip_###_aligned.json` with a summary in `timestamps.json`.
+   - `generate-and-align` also accepts a JSON segments file for simpler workflows.
+   - Use `videocut clip` to cut clips exactly as specified in `segments.txt` without alignment.
+4. **Concatenate** – `videocut concatenate`
+   - Joins clips with a dip-to-white transition by default, creating
+     `final_video.mp4`. Use `--dip` to customize the color and timing or
+     `--dip-news` for a preset news-style flash.
+5. **Preview fades** – `videocut preview-fades`
+   - Generates 20 sample crossfades between `clip_000.mp4` and `clip_001.mp4`
+     in the `fade_previews/` directory.
+
+## Package layout
+- `videocut/cli.py` – command line interface implemented with Typer
+- `videocut/core/` – reusable helpers
+- `videos/` – example data used by the tests
+
+### PDF transcript cleanup
+If a diarized JSON transcript already exists you can replace its text using an
+official PDF with:
+```bash
+videocut pdf-transcript existing.json transcript.pdf
+```
+
+To regenerate `transcript.txt` from a diarized JSON and an official PDF:
+```bash
+videocut json-to-transcript May_Board_Meeting.json transcript.pdf
+```
+
+### Additional transcript utilities
+Use `pdf-extract` to create both a text and JSON version of a PDF transcript:
+```bash
+videocut pdf-extract transcript.pdf
+```
+
+You can align those PDF lines to a diarized JSON with `pdf-match`:
+```bash
+videocut pdf-match transcript.pdf May_Board_Meeting.json
+```
+This writes `matched.json` where each line's words are paired with their
+closest timestamped match from the JSON.
+
+For raw SRT captions you can perform a band-limited DTW alignment with:
+```bash
+videocut dtw-align pdf_transcript.txt May_Board_Meeting.srt
+```
+This generates `matched_dtw.json`. Token timestamps are evenly spread across each
+caption's duration for better alignment accuracy. Use ``make-labeled`` to create
+a speaker-tagged transcript:
+```bash
+videocut make-labeled matched_dtw.json -o dtw_transcript_labeled.txt
+```
+The resulting ``dtw_transcript_labeled.txt`` is ready for ``videocut segment``.
+
+### 3 · Match (NEW)
+
+```bash
+videocut match pdf_transcript.json May_Board_Meeting.json
+```
+
+Produces `matched.json` where every PDF line now carries precise start/end
+timestamps taken from the ASR word stream. Down-stream commands
+(`identify-segments`, `generate-and-align`, `concatenate`) consume `matched.json`
+in place of `pdf_transcript.json`.
+
+Run `check-transcript` to flag segments with unusual timing:
+```bash
+videocut check-transcript May_Board_Meeting.json
+```
+This reports any segments whose words per second fall outside the normal range.
+
+### 4 · Convert to TXT (NEW)
+
+```bash
+videocut to-txt matched.json       # ⇒ transcript.txt
+```
+
+`transcript.txt` is the input expected by **`videocut segment`**.
+
+### 5 · Make Labeled Transcript (NEW)
+
+```bash
+videocut make-labeled matched.json -o labeled_transcript.txt
+```
+
+Use this when a matched JSON is missing speaker tags. The output can be fed
+directly to ``videocut segment``.
+
+The full pipeline is now:
+
+```
+transcribe  →  match/dtw-align  →  segment  →  generate-and-align  →  concatenate
+
+### 6 · Install / Run Cheat-sheet
+
+```bash
+Step #1
+(Step one should take an mp4 file and a matching pdf transcript)
+videocut transcribe May_Board_Meeting.mp4
+videocut pdf-extract transcript.pdf
+videocut dtw-align pdf_transcript.txt May_Board_Meeting.srt
+videocut segment transcript.txt
+(Step 2 should take the same mp4 file and a segmented transcript, and accept the flags for concatenate)
+Step #2
+videocut clip videocut clip May_Board_Meeting.mp4 segments.txt
+videocut concatenate --dip-news
+```
+
+## 📤 Uploading to YouTube
+
+### Step 1: Authorize access (first time only)
+
+```bash
+videocut authorize --client-secret client_secret.json --output credentials.json
+```
+
+- Get `client_secret.json` from your Google Cloud Console (OAuth credentials).
+- This saves a `credentials.json` file used for uploads.
+
+### Step 2: Upload video with chapters
+
+```bash
+videocut upload final.mp4 --creds credentials.json
+```
+
+By default, this reads `segments.txt` and generates a YouTube description with clickable chapters.
+
+| Flag | Description |
+|------|-------------|
+| `--title` | Title for the uploaded video |
+| `--tags` | Tags to associate with the video |
+| `--privacy` | `public`, `unlisted` (default), `private` |
+| `--segments` | Path to `segments.txt` |
+| `--fade` | Transition length in seconds (default 0.5) |
+
+
+Download the Whisper.cpp model once:
+```bash
+wget -O tools/models/ggml-small.en-q8.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en-q8_0.bin
+```


### PR DESCRIPTION
## Summary
- archive the old README
- write a shorter quickstart README showing the basic pipeline commands
- note the `prep` and `build` helpers

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_685792d1b13c8321bf94efad7cd237b9