### PR TITLE
Improve README flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ videocut transcribe VIDEO [--diarize] [--hf-token TOKEN] [--speaker-db FILE]
                     [--progress / --no-progress] [--pdf PATH]
                     [--backend whisperx|mlx]
 ```
+Flags:
+- `--diarize` – perform speaker diarization.
+- `--hf-token TOKEN` – Hugging Face token required for diarization. The CLI also reads `HF_TOKEN` from the environment, including variables in a `.env` file.
+- `--speaker-db FILE` – speaker embedding database JSON.
+- `--progress / --no-progress` – show or hide progress output.
+- `--pdf PATH` – align an official PDF transcript.
+- `--backend whisperx|mlx` – choose transcription backend.
 
 ### pdf-extract
 Extract the meeting transcript from a PDF.
@@ -28,6 +35,9 @@ Extract the meeting transcript from a PDF.
 ```
 videocut pdf-extract FILE [--txt-out TXT] [--json-out JSON]
 ```
+Flags:
+- `--txt-out TXT` – extracted text output path (default `pdf_transcript.txt`).
+- `--json-out JSON` – JSON output path (default `pdf_transcript.json`).
 
 ### dtw-align
 Align the PDF transcript to an existing SRT caption file.
@@ -36,6 +46,10 @@ Align the PDF transcript to an existing SRT caption file.
 videocut dtw-align PDF_TXT VIDEO_SRT [--json-out JSON] [--txt-out TXT]
                                      [--band N]
 ```
+Flags:
+- `--json-out JSON` – write aligned data to this file (default `matched_dtw.json`).
+- `--txt-out TXT` – labeled transcript output path (default `dtw-transcript.txt`).
+- `--band N` – DTW radius for alignment.
 
 ### segment
 Detect remarks from Director Nicholson in a transcript.
@@ -43,6 +57,10 @@ Detect remarks from Director Nicholson in a transcript.
 ```
 videocut segment FILE [--speaker NAME] [--out PATH] [--debug]
 ```
+Flags:
+- `--speaker NAME` – name of the speaker to extract (default `Chris Nicholson`).
+- `--out PATH` – output segments file path (default `segments.txt`).
+- `--debug` – show debug information during segmentation.
 
 ### clip
 Cut clips according to `segments.txt`.
@@ -50,6 +68,9 @@ Cut clips according to `segments.txt`.
 ```
 videocut clip VIDEO SEGMENTS [--out-dir DIR] [--srt-file FILE]
 ```
+Flags:
+- `--out-dir DIR` – directory for generated clips (default `clips`).
+- `--srt-file FILE` – optional SRT captions to cut with the clips.
 
 ### concatenate
 Join the clips with dip‑to‑white transitions (use `--dip-news` for preset timing).
@@ -59,6 +80,14 @@ videocut concatenate [--clips-dir DIR] [--output FILE] [--dip] [--dip-news]
                      [--dip-color HEX] [--fade-duration SEC]
                      [--hold-duration SEC]
 ```
+Flags:
+- `--clips-dir DIR` – directory containing clip files (default `clips`).
+- `--output FILE` – path to the concatenated video (default `final_video.mp4`).
+- `--dip` – add dip‑to‑white transitions between clips.
+- `--dip-news` – use preset news‑style dip timing.
+- `--dip-color HEX` – color of the dip flash.
+- `--fade-duration SEC` – fade time in seconds.
+- `--hold-duration SEC` – hold time for the white frame.
 
 ## Streamlined Commands
 
@@ -70,6 +99,8 @@ Transcribe a video, extract and align the PDF transcript, and produce `segments.
 ```
 videocut prep [VIDEO] [PDF] [--band N]
 ```
+Flags:
+- `--band N` – DTW radius used when aligning the PDF transcript.
 
 ### build
 Cut clips from a video using `segments.txt` and concatenate them.
@@ -80,6 +111,15 @@ videocut build [VIDEO] [SEGMENTS] [--out-dir DIR] [--output FILE]
                [--fade-duration SEC] [--hold-duration SEC]
                [--srt-file FILE]
 ```
+Flags:
+- `--out-dir DIR` – directory containing clips (default `clips`).
+- `--output FILE` – final video output path (default `final_video.mp4`).
+- `--dip` – add dip‑to‑white transitions.
+- `--dip-news` – use preset news‑style timing.
+- `--dip-color HEX` – color used for the dip flash.
+- `--fade-duration SEC` – fade time in seconds.
+- `--hold-duration SEC` – hold time for the white frame.
+- `--srt-file FILE` – optional SRT to annotate clips.
 
 With these two commands you can run the full workflow as:
 


### PR DESCRIPTION
## Summary
- document CLI flag descriptions for `videocut` commands in README
- note that the Hugging Face token can be placed in a `.env` file

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_68579cd152b4832180f98c55dbfd4281