### PR TITLE
Rename dtw-align command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This short guide walks through a typical workflow using the `videocut` command l
 ```bash
 videocut transcribe video.mp4
 videocut pdf-extract transcript.pdf
-videocut dtw-align pdf_transcript.txt video.srt
+videocut align pdf_transcript.txt video.srt
 videocut segment transcript.txt
 videocut clip video.mp4 segments.txt
 videocut concatenate --dip-news
@@ -40,11 +40,11 @@ Flags:
 - `--txt-out TXT` – extracted text output path (default `pdf_transcript.txt`).
 - `--json-out JSON` – JSON output path (default `pdf_transcript.json`).
 
-### dtw-align
+### align
 Align the PDF transcript to an existing SRT caption file.
 
 ```
-videocut dtw-align PDF_TXT VIDEO_SRT [--json-out JSON] [--txt-out TXT]
+videocut align PDF_TXT VIDEO_SRT [--json-out JSON] [--txt-out TXT]
                                      [--band N]
 ```
 Flags:

--- a/videocut/cli.py
+++ b/videocut/cli.py
@@ -223,7 +223,7 @@ def match_cli(
 
 # ---------------------------------------------------------------------
 # Advanced DTW alignment
-@app.command("dtw-align")
+@app.command("align")
 def dtw_align(
     pdf_txt: Path = typer.Argument(..., exists=True, readable=True),
     srt_path: Path = typer.Argument(..., exists=True, readable=True),
@@ -298,17 +298,18 @@ def make_labeled(
     typer.echo(f"✅ wrote {out_file}")
 
 
-@app.command("align")
+@app.command("legacy-align")
 def align_cmd(
     video: str,
     transcript: str,
     out_json: str = "aligned.json",
 ):
-    """Align ``transcript`` with ``video``.
+    """Align ``transcript`` with ``video`` (deprecated).
 
     When a PDF file is supplied it is converted to ``transcript.txt`` before
     alignment.
     """
+    typer.echo("⚠️  'legacy-align' is deprecated; use 'align' instead.")
     alignment.align_with_transcript(video, transcript, out_json)
 
 


### PR DESCRIPTION
## Summary
- rename `dtw-align` command to `align`
- move old video alignment command to `legacy-align`
- update README for the new command name

## Testing
- `pytest tests/test_segments_format.py tests/test_segmentation_utils.py::test_segments_txt_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d8f3f0588321aad5a429360b03e7